### PR TITLE
🔒 [security fix] Fix Cleartext Password Logging via Missing Hash Redaction

### DIFF
--- a/src/main/java/de/felixhertweck/seatreservation/model/entity/User.java
+++ b/src/main/java/de/felixhertweck/seatreservation/model/entity/User.java
@@ -305,12 +305,6 @@ public class User extends PanacheEntity {
                 + ", lastname='"
                 + lastname
                 + '\''
-                + ", passwordHash='"
-                + passwordHash
-                + '\''
-                + ", passwordSalt='"
-                + passwordSalt
-                + '\''
                 + ", email='"
                 + email
                 + '\''

--- a/src/test/java/de/felixhertweck/seatreservation/model/entity/UserTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/model/entity/UserTest.java
@@ -227,10 +227,22 @@ class UserTest {
         user.setEmail("test@example.com");
         user.setFirstname("John");
         user.setLastname("Doe");
+        user.setPasswordHash("$2a$10$hashedPassword");
+        user.setPasswordSalt("randomSalt");
 
         String toString = user.toString();
         assertNotNull(toString);
         assertTrue(toString.contains("testuser"));
+        assertFalse(
+                toString.contains("passwordHash"),
+                "toString should not contain sensitive passwordHash");
+        assertFalse(
+                toString.contains("passwordSalt"),
+                "toString should not contain sensitive passwordSalt");
+        assertFalse(
+                toString.contains("$2a$10$hashedPassword"),
+                "toString should not contain the actual password hash");
+        assertFalse(toString.contains("randomSalt"), "toString should not contain the actual salt");
     }
 
     @Test


### PR DESCRIPTION
Fixed a security vulnerability where password hashes and salts were being logged in cleartext via the `User.toString()` method. The fix involved removing these sensitive fields from the `toString()` implementation in `User.java` and adding a corresponding verification test in `UserTest.java`.

---
*PR created automatically by Jules for task [13571284088158427942](https://jules.google.com/task/13571284088158427942) started by @FelixHertweck*