### PR TITLE
ci: publish PR container images under pr-<number> tag and clean them up on close

### DIFF
--- a/.github/workflows/clean-up.yml
+++ b/.github/workflows/clean-up.yml
@@ -1,14 +1,25 @@
-name: Daily Image Cleanup
+name: Image Cleanup
 on:
   # Runs daily at 2:00 AM
   schedule:
     - cron: '0 2 * * *'
+  # Fires as soon as a PR is closed (merged or not)
+  pull_request:
+    types: [closed]
   # Run manually
   workflow_dispatch:
-    
+
+# The cleanup action isn't safe to run concurrently against the same
+# packages, so queue overlapping runs (e.g. nightly cron vs. a PR closing
+# at the same time) instead of letting them race.
+concurrency:
+  group: image-cleanup
+  cancel-in-progress: false
+
 jobs:
   delete-untagged-packages:
     name: Delete Untagged Package Versions
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       packages: write
@@ -30,4 +41,25 @@ jobs:
           package-type: 'container'
           min-versions-to-keep: 5
           delete-only-untagged-versions: 'true'
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  delete-pr-images:
+    name: Delete Images For Closed Pull Request
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    strategy:
+      matrix:
+        package-name:
+          - seatreservation-frontend
+          - seatreservation-backend
+          - seatreservation-backend-native
+
+    steps:
+      - name: Delete image tagged with closed PR
+        uses: dataaxiom/ghcr-cleanup-action@v1
+        with:
+          package: ${{ matrix.package-name }}
+          delete-tags: pr-${{ github.event.pull_request.number }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -42,6 +42,9 @@ jobs:
 
     env:
       REGISTRY: ghcr.io
+      # Push on every event except PRs from forks, since the GITHUB_TOKEN
+      # for fork PRs is always read-only regardless of the permissions below.
+      SHOULD_PUSH: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
 
     permissions:
       contents: read
@@ -59,7 +62,7 @@ jobs:
           path: ${{ inputs.build-artifact-path }}
 
       - name: Install cosign
-        if: ${{ github.event_name != 'pull_request' }}
+        if: ${{ env.SHOULD_PUSH == 'true' }}
         uses: sigstore/cosign-installer@v4.1.2
         with:
           cosign-release: "v2.4.3"
@@ -68,7 +71,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Log into registry ${{ env.REGISTRY }}
-        if: ${{ github.event_name != 'pull_request' }}
+        if: ${{ env.SHOULD_PUSH == 'true' }}
         uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
@@ -91,14 +94,14 @@ jobs:
           platforms: linux/amd64,linux/arm64
           file: ${{ inputs.docker-file-path }}
           context: ${{ inputs.docker-build-context }}
-          push: ${{ github.event_name != 'pull_request' }}
+          push: ${{ env.SHOULD_PUSH == 'true' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
       - name: Sign the published Docker image
-        if: ${{ github.event_name != 'pull_request' }}
+        if: ${{ env.SHOULD_PUSH == 'true' }}
         env:
           TAGS: ${{ steps.meta.outputs.tags }}
           DIGEST: ${{ steps.build-and-push.outputs.digest }}


### PR DESCRIPTION
Push docker.yml builds to ghcr.io for pull requests from the same repo (fork PRs stay build-only, since their GITHUB_TOKEN is read-only anyway), tagged with the default pr-<number> convention. clean-up.yml now deletes those tagged images as soon as the PR closes via ghcr-cleanup-action, in addition to the existing nightly untagged-version sweep, with a concurrency group so overlapping runs don't race against the same package.