### PR TITLE
🧹 [code health] Use toast for QR code parsing errors

### DIFF
--- a/webapp/components/checkin/qr-code-scanner.tsx
+++ b/webapp/components/checkin/qr-code-scanner.tsx
@@ -130,7 +130,7 @@ export function QrCodeScanner({
       // Expected format: userId;eventId;token1,token2,...
       const parts = data.split(";");
       if (parts.length !== 3) {
-        throw new Error("Invalid format");
+        throw new Error(t("checkin.error.invalidQrFormat"));
       }
 
       const userId = parts[0];
@@ -141,7 +141,7 @@ export function QrCodeScanner({
         BigInt(userId);
         BigInt(eventId);
       } catch {
-        throw new Error("Invalid user ID or event ID");
+        throw new Error(t("checkin.error.invalidUserOrEventId"));
       }
 
       const checkInTokens = parts[2]

--- a/webapp/components/checkin/qr-code-scanner.tsx
+++ b/webapp/components/checkin/qr-code-scanner.tsx
@@ -140,8 +140,7 @@ export function QrCodeScanner({
       try {
         BigInt(userId);
         BigInt(eventId);
-      } catch (e) {
-        console.log("Error parsing QR code data:", e);
+      } catch {
         throw new Error("Invalid user ID or event ID");
       }
 
@@ -154,7 +153,13 @@ export function QrCodeScanner({
       // Stop scanning after successful scan
       stopScanning();
     } catch (error) {
-      console.log("Error parsing QR code data:", error);
+      console.error("Error parsing QR code data:", error);
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : t("checkin.error.scanningFailed"),
+        { id: "qr-scan-error" },
+      );
     }
   };
 

--- a/webapp/locales/de/translation.json
+++ b/webapp/locales/de/translation.json
@@ -1049,6 +1049,8 @@
       "default": "Bei der Verarbeitung des Check-In ist ein Fehler aufgetreten. Bitte versuchen Sie es erneut.",
       "noCheckInInfo": "Keine Check-In Informationen verfügbar.",
       "scanningFailed": "Fehler beim Scannen des QR-Codes.",
+      "invalidQrFormat": "Ungültiges QR-Code-Format.",
+      "invalidUserOrEventId": "Ungültige Benutzer-ID oder Event-ID im QR-Code.",
       "getInfoFailed": "Abrufen der Check-In Informationen fehlgeschlagen.",
       "getInfoByUsernameFailed": "Abrufen der Check-In Informationen nach Benutzername fehlgeschlagen.",
       "processFailed": "Check-In Prozess fehlgeschlagen."

--- a/webapp/locales/en/translation.json
+++ b/webapp/locales/en/translation.json
@@ -589,6 +589,8 @@
       "default": "An error occurred during check-in. Please try again.",
       "noCheckInInfo": "No check-in information available.",
       "scanningFailed": "Error scanning QR code.",
+      "invalidQrFormat": "Invalid QR code format.",
+      "invalidUserOrEventId": "Invalid user ID or event ID in QR code.",
       "getInfoFailed": "Failed to get check-in info.",
       "getInfoByUsernameFailed": "Failed to get check-in info by username.",
       "processFailed": "Check-in process failed."


### PR DESCRIPTION
🎯 **What:** Replaced the silent `console.log` in the QR code parser error handler with a `console.error` and a user-facing `toast.error` notification.
💡 **Why:** Improved maintainability by removing redundant logs in try-catch blocks and provided actionable feedback to the user on parse failures (e.g., when an invalid QR code is scanned).
✅ **Verification:** Ran `npm run lint:check`, `npm run format:check`, and `npm run build` in the `webapp/` directory to confirm safe implementation. Used the `instanceof Error` check to safely access the error's message.
✨ **Result:** Users will now be properly notified via toast when a scanned QR code cannot be processed, without disrupting scanning capability.

---
*PR created automatically by Jules for task [18216475914666282927](https://jules.google.com/task/18216475914666282927) started by @FelixHertweck*