### PR TITLE
🔒 Fix predictable token generation in EmailSeatMapService

### DIFF
--- a/src/main/java/de/felixhertweck/seatreservation/email/service/EmailSeatMapService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/email/service/EmailSeatMapService.java
@@ -37,6 +37,7 @@ import de.felixhertweck.seatreservation.model.entity.Reservation;
 import de.felixhertweck.seatreservation.model.entity.Seat;
 import de.felixhertweck.seatreservation.model.entity.User;
 import de.felixhertweck.seatreservation.model.repository.EmailSeatMapTokenRepository;
+import de.felixhertweck.seatreservation.utils.SecurityUtils;
 import de.felixhertweck.seatreservation.utils.SvgRenderer;
 import de.felixhertweck.seatreservation.utils.SvgToPngConverter;
 import org.apache.batik.transcoder.TranscoderException;
@@ -64,8 +65,11 @@ public class EmailSeatMapService {
     @Transactional
     public String createEmailSeatMapToken(
             User user, Event event, List<Reservation> newReservations) {
-        // Generate unique token
-        String token = java.util.UUID.randomUUID().toString();
+        // Generate secure unique token
+        String token =
+                java.util.Base64.getUrlEncoder()
+                        .withoutPadding()
+                        .encodeToString(SecurityUtils.generateRandomBytes(32));
 
         // Extract seat numbers from new reservations
         Set<String> newReservedSeatNumbers =

--- a/src/main/java/de/felixhertweck/seatreservation/email/service/EmailSeatMapService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/email/service/EmailSeatMapService.java
@@ -21,6 +21,7 @@ package de.felixhertweck.seatreservation.email.service;
 
 import java.io.IOException;
 import java.time.Instant;
+import java.util.Base64;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -67,7 +68,7 @@ public class EmailSeatMapService {
             User user, Event event, List<Reservation> newReservations) {
         // Generate secure unique token
         String token =
-                java.util.Base64.getUrlEncoder()
+                Base64.getUrlEncoder()
                         .withoutPadding()
                         .encodeToString(SecurityUtils.generateRandomBytes(32));
 


### PR DESCRIPTION
🎯 **What:** Replaced the predictable `java.util.UUID.randomUUID()` with a cryptographically secure token generator in `EmailSeatMapService.java`.

⚠️ **Risk:** The previous implementation used standard UUIDs which are not cryptographically secure and could potentially allow an attacker to predict token values, leading to unauthorized access to email seat maps and partial disclosure of user reservation data.

🛡️ **Solution:** Switched to using `SecurityUtils.generateRandomBytes(32)` encoded with Base64 URL-safe (without padding), which provides 256 bits of cryptographic entropy. This aligns the seat map token generation with the secure practices already established for refresh tokens in `TokenService.java`.

---
*PR created automatically by Jules for task [11157288877272765846](https://jules.google.com/task/11157288877272765846) started by @FelixHertweck*