### PR TITLE
⚡ Optimize deleteUser with batch queries

### DIFF
--- a/src/main/java/de/felixhertweck/seatreservation/userManagment/service/UserService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/userManagment/service/UserService.java
@@ -25,8 +25,10 @@ import java.util.Arrays;
 import java.util.Base64;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
@@ -418,14 +420,28 @@ public class UserService {
      */
     @Transactional
     public void deleteUser(List<Long> ids) throws UserNotFoundException {
+        if (ids == null || ids.isEmpty()) {
+            return;
+        }
+
+        LOG.debugf("Attempting to batch delete users with IDs: %s.", ids);
+
+        // Fetch all users in a single query
+        List<User> users = userRepository.find("id in ?1", ids).list();
+
+        // Map users by ID for quick lookup and to preserve iterative validation behavior
+        Map<Long, User> userMap = users.stream().collect(Collectors.toMap(u -> u.id, u -> u));
+
         for (Long id : ids) {
-            LOG.debugf("Attempting to delete user with ID: %d.", id);
-            boolean deleted = userRepository.deleteById(id);
-            if (!deleted) {
+            User user = userMap.remove(id);
+            if (user == null) {
                 LOG.warnf("User with ID %d not found for deletion.", id);
                 throw new UserNotFoundException("User with id " + id + " not found.");
             }
         }
+
+        userRepository.delete("id in ?1", ids);
+
         LOG.infof("Users with IDs %s deleted successfully.", ids);
     }
 

--- a/src/test/java/de/felixhertweck/seatreservation/userManagment/service/UserServiceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/userManagment/service/UserServiceTest.java
@@ -66,6 +66,7 @@ import de.felixhertweck.seatreservation.userManagment.dto.UserProfileUpdateDTO;
 import de.felixhertweck.seatreservation.userManagment.exceptions.VerificationCodeNotFoundException;
 import de.felixhertweck.seatreservation.userManagment.exceptions.VerifyTokenExpiredException;
 import io.quarkus.elytron.security.common.BcryptUtil;
+import io.quarkus.hibernate.orm.panache.PanacheQuery;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.BeforeEach;
@@ -919,19 +920,22 @@ public class UserServiceTest {
                         Collections.singleton(Roles.USER),
                         Collections.emptySet());
         existingUser.id = 1L;
-        when(userRepository.findByIdOptional(1L)).thenReturn(Optional.of(existingUser));
-        when(userRepository.deleteById(1L)).thenReturn(true); // Mock deleteById to return true
+
+        PanacheQuery<User> mockQuery = Mockito.mock(PanacheQuery.class);
+        when(mockQuery.list()).thenReturn(List.of(existingUser));
+        when(userRepository.find("id in ?1", List.of(1L))).thenReturn(mockQuery);
+        when(userRepository.delete("id in ?1", List.of(1L))).thenReturn(1L);
 
         userService.deleteUser(List.of(1L));
 
-        verify(userRepository, times(1)).deleteById(1L);
+        verify(userRepository, times(1)).delete("id in ?1", List.of(1L));
     }
 
     @Test
     void deleteUser_UserNotFoundException() throws UserNotFoundException {
-        when(userRepository.findByIdOptional(anyLong())).thenReturn(Optional.empty());
-        when(userRepository.deleteById(anyLong()))
-                .thenReturn(false); // Mock deleteById to return false
+        PanacheQuery<User> mockQuery = Mockito.mock(PanacheQuery.class);
+        when(mockQuery.list()).thenReturn(Collections.emptyList());
+        when(userRepository.find("id in ?1", List.of(1L))).thenReturn(mockQuery);
 
         assertThrows(UserNotFoundException.class, () -> userService.deleteUser(List.of(1L)));
         verify(userRepository, never()).delete(any(User.class));


### PR DESCRIPTION
💡 **What:** Optimized the `deleteUser` method in `UserService.java` to use a batch fetch and bulk delete approach via Panache `userRepository.find("id in ?1", ids)` and `userRepository.delete("id in ?1", ids)`.
🎯 **Why:** The previous implementation contained an N+1 query issue, calling `userRepository.deleteById(id)` for every ID in a loop, which executes two database operations (Select, Delete) per user.
📊 **Measured Improvement:** Logical query reduction. A request with N user IDs drops from 2N database queries to exactly 2 queries (one Select for batch validation, one Delete for batch destruction), saving 2N-2 network round trips to the database. Functional tests were also successfully updated to cover the new Panache bulk interactions.

---
*PR created automatically by Jules for task [6031223661926567984](https://jules.google.com/task/6031223661926567984) started by @FelixHertweck*