### PR TITLE
🔒 Fix XSS vulnerability in SVG seat numbers

### DIFF
--- a/src/main/java/de/felixhertweck/seatreservation/utils/SvgRenderer.java
+++ b/src/main/java/de/felixhertweck/seatreservation/utils/SvgRenderer.java
@@ -233,7 +233,7 @@ public class SvgRenderer {
                     .append("\" font-size=\"")
                     .append(textHeight)
                     .append("\" text-anchor=\"middle\" fill=\"black\">")
-                    .append(seat.getSeatNumber())
+                    .append(escapeXml(seat.getSeatNumber()))
                     .append("</text>\n");
         }
 

--- a/src/test/java/de/felixhertweck/seatreservation/utils/SvgRendererTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/utils/SvgRendererTest.java
@@ -182,6 +182,22 @@ class SvgRendererTest {
     }
 
     @Test
+    void renderSeats_WithSpecialCharactersInSeatNumber_EscapesXml() {
+        Seat seat = new Seat();
+        seat.setSeatNumber("<script>alert(1)</script>");
+        seat.setxCoordinate(2);
+        seat.setyCoordinate(2);
+
+        String result = SvgRenderer.renderSeats(List.of(seat), Set.of(), Set.of());
+
+        assertNotNull(result);
+        assertTrue(result.contains("&lt;script&gt;alert(1)&lt;/script&gt;"));
+        assertFalse(
+                result.contains(
+                        "<script>alert(1)</script>")); // Should not contain unescaped script tags
+    }
+
+    @Test
     void renderSeats_CalculatesBoundingBoxWithMarkers() {
         Seat seat = new Seat();
         seat.setSeatNumber("A1");


### PR DESCRIPTION
🎯 What: Addressed a potential Cross-Site Scripting (XSS) / SVG injection vulnerability in `SvgRenderer` where seat numbers were concatenated directly into the SVG output without escaping. 
⚠️ Risk: If an attacker were able to create or manipulate a seat with a malicious `seatNumber` (e.g. `<script>alert(1)</script>`), the resulting SVG rendered on the client side via `dangerouslySetInnerHTML` could execute arbitrary JavaScript.
🛡️ Solution: Wrapped `seat.getSeatNumber()` with the existing `escapeXml()` utility method to safely sanitize all XML special characters before inclusion in the SVG string. Added a test in `SvgRendererTest` to assert prevention of XSS in seat numbers.

---
*PR created automatically by Jules for task [12749956757579025939](https://jules.google.com/task/12749956757579025939) started by @FelixHertweck*