### PR TITLE
⚡ Bolt: Optimize getAllEventsForSupervisor by removing N+1 queries

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,4 +1,0 @@
-
-## 2026-07-20 - N+1 query pattern in supervisor filtering
-**Learning:** Found an N+1 query bottleneck in `CheckInService.getAllEventsForSupervisor` where `isAuthorizedForEvent(User, Long)` was called per event in memory after a `findAll()`.
-**Action:** Always fetch authorized events via a targeted SQL/HQL query (e.g. `SELECT DISTINCT e FROM Event e LEFT JOIN e.supervisors s WHERE e.manager = ?1 OR s = ?1`) instead of post-filtering in memory to maintain O(1) query performance.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,4 @@
+
+## 2026-07-20 - N+1 query pattern in supervisor filtering
+**Learning:** Found an N+1 query bottleneck in `CheckInService.getAllEventsForSupervisor` where `isAuthorizedForEvent(User, Long)` was called per event in memory after a `findAll()`.
+**Action:** Always fetch authorized events via a targeted SQL/HQL query (e.g. `SELECT DISTINCT e FROM Event e LEFT JOIN e.supervisors s WHERE e.manager = ?1 OR s = ?1`) instead of post-filtering in memory to maintain O(1) query performance.

--- a/src/main/java/de/felixhertweck/seatreservation/model/repository/EventRepository.java
+++ b/src/main/java/de/felixhertweck/seatreservation/model/repository/EventRepository.java
@@ -69,4 +69,18 @@ public class EventRepository implements PanacheRepository<Event> {
                 .firstResultOptional()
                 .isPresent();
     }
+
+    /**
+     * Finds all events authorized for a specific user (manager or supervisor).
+     *
+     * @param user the user to search for
+     * @return a list of events where the user is either a manager or a supervisor
+     */
+    public List<Event> findAuthorizedEvents(User user) {
+        return find(
+                        "SELECT DISTINCT e FROM Event e LEFT JOIN e.supervisors s WHERE e.manager ="
+                                + " ?1 OR s = ?1",
+                        user)
+                .list();
+    }
 }

--- a/src/main/java/de/felixhertweck/seatreservation/supervisor/service/CheckInService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/supervisor/service/CheckInService.java
@@ -240,8 +240,15 @@ public class CheckInService {
                     .map(SupervisorEventResponseDTO::new)
                     .collect(ArrayList::new, ArrayList::add, ArrayList::addAll);
         }
-        return eventRepository.findAll().stream()
-                .filter(e -> isAuthorizedForEvent(currentUser, e.getId()))
+
+        boolean isAdmin =
+                currentUser.getRoles() != null && currentUser.getRoles().contains(Roles.ADMIN);
+        List<Event> authorizedEvents =
+                isAdmin
+                        ? eventRepository.findAll().list()
+                        : eventRepository.findAuthorizedEvents(currentUser);
+
+        return authorizedEvents.stream()
                 .map(SupervisorEventResponseDTO::new)
                 .collect(ArrayList::new, ArrayList::add, ArrayList::addAll);
     }

--- a/src/main/java/de/felixhertweck/seatreservation/supervisor/service/CheckInService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/supervisor/service/CheckInService.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Stream;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
@@ -243,12 +244,12 @@ public class CheckInService {
 
         boolean isAdmin =
                 currentUser.getRoles() != null && currentUser.getRoles().contains(Roles.ADMIN);
-        List<Event> authorizedEvents =
+        Stream<Event> authorizedEvents =
                 isAdmin
-                        ? eventRepository.findAll().list()
-                        : eventRepository.findAuthorizedEvents(currentUser);
+                        ? eventRepository.findAll().stream()
+                        : eventRepository.findAuthorizedEvents(currentUser).stream();
 
-        return authorizedEvents.stream()
+        return authorizedEvents
                 .map(SupervisorEventResponseDTO::new)
                 .collect(ArrayList::new, ArrayList::add, ArrayList::addAll);
     }

--- a/src/test/java/de/felixhertweck/seatreservation/supervisor/resource/CheckInResourceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/supervisor/resource/CheckInResourceTest.java
@@ -115,7 +115,16 @@ class CheckInResourceTest {
         // Provide a PanacheQuery for findAll containing both events
         PanacheQuery<Event> eventsQuery = (PanacheQuery<Event>) mock(PanacheQuery.class);
         when(eventsQuery.stream()).thenReturn(Stream.of(event10, event20));
+        when(eventsQuery.list()).thenReturn(List.of(event10, event20));
         when(eventRepository.findAll()).thenReturn(eventsQuery);
+
+        // Mock findAuthorizedEvents for each user
+        when(eventRepository.findAuthorizedEvents(supervisorUser)).thenReturn(List.of(event10));
+        when(eventRepository.findAuthorizedEvents(managerUser)).thenReturn(List.of(event10));
+        when(eventRepository.findAuthorizedEvents(otherSupervisor))
+                .thenReturn(Collections.emptyList());
+        when(eventRepository.findAuthorizedEvents(adminUser))
+                .thenReturn(List.of(event10, event20)); // Though admin will use findAll().list()
 
         // Mock reservations for event 10 (two usernames) and for event 20 none
         User r1 = new User();

--- a/src/test/java/de/felixhertweck/seatreservation/supervisor/service/CheckInServiceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/supervisor/service/CheckInServiceTest.java
@@ -534,9 +534,10 @@ class CheckInServiceTest {
                 (io.quarkus.hibernate.orm.panache.PanacheQuery<Event>)
                         mock(io.quarkus.hibernate.orm.panache.PanacheQuery.class);
         when(eq.stream()).thenReturn(Stream.of(e1, e2));
+        when(eq.list()).thenReturn(List.of(e1, e2));
         when(eventRepository.findAll()).thenReturn(eq);
-        when(eventRepository.isUserSupervisor(eq(10L), eq(1L))).thenReturn(true);
-        when(eventRepository.isUserSupervisor(eq(20L), eq(1L))).thenReturn(false);
+        when(eventRepository.findAuthorizedEvents(supervisor)).thenReturn(List.of(e1));
+
         List<de.felixhertweck.seatreservation.supervisor.dto.SupervisorEventResponseDTO> events =
                 checkInService.getAllEventsForSupervisor(supervisor);
         assertEquals(1, events.size());


### PR DESCRIPTION
💡 **What**: Added `findAuthorizedEvents` custom query to `EventRepository` and refactored `CheckInService.getAllEventsForSupervisor` to use it when the user is not an Admin.

🎯 **Why**: The original implementation fetched *all* events from the database via `findAll()` and then performed an O(N) in-memory filter that made multiple database calls (`eventRepository.isUserSupervisor`, `eventRepository.findById`) per event. This was a classic N+1 query problem that would scale terribly as the number of events grew.

📊 **Impact**: Reduces database queries for the supervisor event listing endpoint from O(N) to O(1). Re-renders/Memory usage on the JVM are drastically reduced since we no longer hydrate all events into memory just to filter them out.

🔬 **Measurement**: Verify by calling the supervisor event list endpoint and inspecting the hibernate query logs; you will see a single `SELECT DISTINCT` instead of one select for all events followed by multiple queries for every event.

---
*PR created automatically by Jules for task [14808774783201200769](https://jules.google.com/task/14808774783201200769) started by @FelixHertweck*