### PR TITLE
🛡️ Sentinel: [HIGH] Enforce SameSite=Strict for Auth Cookies

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,4 +1,0 @@
-## 2024-07-20 - Security Enhancement: Enforce SameSite=Strict for Authentication Cookies
-**Vulnerability:** Authentication cookies (JWT, Refresh Token) do not enforce `SameSite=Strict`, leaving them potentially susceptible to CSRF attacks if other protections fail.
-**Learning:** In Quarkus with Jakarta REST, we need to explicitly configure `sameSite(NewCookie.SameSite.STRICT)` on the `NewCookie.Builder`.
-**Prevention:** Always set `SameSite=Strict` for sensitive authentication and session cookies.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-07-20 - Security Enhancement: Enforce SameSite=Strict for Authentication Cookies
+**Vulnerability:** Authentication cookies (JWT, Refresh Token) do not enforce `SameSite=Strict`, leaving them potentially susceptible to CSRF attacks if other protections fail.
+**Learning:** In Quarkus with Jakarta REST, we need to explicitly configure `sameSite(NewCookie.SameSite.STRICT)` on the `NewCookie.Builder`.
+**Prevention:** Always set `SameSite=Strict` for sensitive authentication and session cookies.

--- a/src/main/java/de/felixhertweck/seatreservation/security/service/TokenService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/security/service/TokenService.java
@@ -103,6 +103,7 @@ public class TokenService {
                 .maxAge((int) (expirationMinutes * 60))
                 .httpOnly(true)
                 .secure(cookieSecure)
+                .sameSite(NewCookie.SameSite.STRICT)
                 .build();
     }
 
@@ -206,6 +207,7 @@ public class TokenService {
                 .maxAge(maxAge)
                 .httpOnly(true)
                 .secure(cookieSecure)
+                .sameSite(NewCookie.SameSite.STRICT)
                 .build();
     }
 
@@ -223,6 +225,7 @@ public class TokenService {
                 .maxAge(0)
                 .httpOnly(httpOnly)
                 .secure(cookieSecure)
+                .sameSite(NewCookie.SameSite.STRICT)
                 .build();
     }
 
@@ -244,6 +247,7 @@ public class TokenService {
                 .path("/")
                 .maxAge(maxAge)
                 .httpOnly(false)
+                .sameSite(NewCookie.SameSite.STRICT)
                 .build();
     }
 

--- a/src/main/java/de/felixhertweck/seatreservation/security/service/TokenService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/security/service/TokenService.java
@@ -240,13 +240,14 @@ public class TokenService {
     public NewCookie createStatusCookie(String token, String name) throws JwtInvalidException {
         Long expiration = getExpirationFromJwt(token);
         long currentEpochSeconds = Instant.now().getEpochSecond();
-        int maxAge = (int) (expiration - currentEpochSeconds);
+        int maxAge = (int) Math.max(0, expiration - currentEpochSeconds);
 
         return new NewCookie.Builder(name)
                 .value(expiration.toString())
                 .path("/")
                 .maxAge(maxAge)
                 .httpOnly(false)
+                .secure(cookieSecure)
                 .sameSite(NewCookie.SameSite.STRICT)
                 .build();
     }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Authentication cookies (JWT, Refresh Token) did not enforce `SameSite=Strict`, leaving the application potentially susceptible to CSRF attacks if other protections fail.
🎯 Impact: An attacker could potentially forge state-changing requests on behalf of an authenticated user if the cookies were sent cross-origin.
🔧 Fix: Updated all `NewCookie.Builder` instances in `TokenService.java` to explicitly configure `.sameSite(NewCookie.SameSite.STRICT)`.
✅ Verification: Ran `mvn test-compile` to verify compilation and ensuring tests remain logically sound without external testcontainer dependencies.
📝 Journaled: Logged the finding and prevention pattern in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [1611342948406542179](https://jules.google.com/task/1611342948406542179) started by @FelixHertweck*