### PR TITLE
⚡ Bolt: [performance improvement] Pull allowance query out of seat loop

### DIFF
--- a/src/main/java/de/felixhertweck/seatreservation/management/service/ReservationService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/management/service/ReservationService.java
@@ -263,6 +263,24 @@ public class ReservationService {
                 seatRepository.find(ID_IN_QUERY, dto.getSeatIds()).list().stream()
                         .collect(Collectors.toMap(s -> s.id, s -> s, (s1, s2) -> s1));
 
+        EventUserAllowance allowance = null;
+        if (dto.isDeductAllowance()) {
+            try {
+                allowance =
+                        eventUserAllowanceRepository
+                                .find("user = ?1 and event = ?2", targetUser, event)
+                                .singleResult();
+            } catch (NoResultException e) {
+                LOG.warnf(
+                        e,
+                        "User ID %d has no reservation allowance for event ID %d.",
+                        targetUser.getId(),
+                        event.getId());
+                throw new IllegalArgumentException(
+                        "User has no reservation allowance for this event.");
+            }
+        }
+
         for (Long dtoSeatId : dto.getSeatIds()) {
             Seat seat = seatMap.get(dtoSeatId);
             if (seat == null) {
@@ -275,37 +293,22 @@ public class ReservationService {
                         "Allowance check skipped for user ID: %d (ID: %d).",
                         targetUser.id, targetUser.getId());
             } else {
-                try {
-                    EventUserAllowance allowance =
-                            eventUserAllowanceRepository
-                                    .find("user = ?1 and event = ?2", targetUser, event)
-                                    .singleResult();
-                    if (allowance.getReservationsAllowedCount() <= 0) {
-                        LOG.warnf(
-                                "No more reservations allowed for user ID %d and event ID %d.",
-                                targetUser.getId(), event.getId());
-                        throw new IllegalArgumentException(
-                                "No more reservations allowed for this user and event.");
-                    }
-                    allowance.setReservationsAllowedCount(
-                            allowance.getReservationsAllowedCount() - 1);
-                    eventUserAllowanceRepository.persist(allowance);
-                    LOG.debug(
-                            String.format(
-                                    "Decremented reservation allowance for user ID %d and event ID"
-                                            + " %d. New allowance: %d",
-                                    targetUser.getId(),
-                                    event.getId(),
-                                    allowance.getReservationsAllowedCount()));
-                } catch (NoResultException e) {
+                if (allowance.getReservationsAllowedCount() <= 0) {
                     LOG.warnf(
-                            e,
-                            "User ID %d has no reservation allowance for event ID %d.",
-                            targetUser.getId(),
-                            event.getId());
+                            "No more reservations allowed for user ID %d and event ID %d.",
+                            targetUser.getId(), event.getId());
                     throw new IllegalArgumentException(
-                            "User has no reservation allowance for this event.");
+                            "No more reservations allowed for this user and event.");
                 }
+                allowance.setReservationsAllowedCount(allowance.getReservationsAllowedCount() - 1);
+                eventUserAllowanceRepository.persist(allowance);
+                LOG.debug(
+                        String.format(
+                                "Decremented reservation allowance for user ID %d and event ID"
+                                        + " %d. New allowance: %d",
+                                targetUser.getId(),
+                                event.getId(),
+                                allowance.getReservationsAllowedCount()));
             }
 
             Reservation reservation =


### PR DESCRIPTION
💡 **What:** Extracted the `eventUserAllowanceRepository.find(...)` lookup from the seat iteration loop in `ReservationService.createReservations`.
🎯 **Why:** The target user and event remain identical throughout the loop. Fetching the allowance inside the loop resulted in O(N) database queries for N requested seats, causing significant overhead for bulk reservations.
📊 **Measured Improvement:** Reduced the number of allowance database queries during reservation creation from O(N) to O(1), directly scaling efficiency for multi-seat reservations. Test syntax verification succeeds, but dynamic benchmarking and full test suite executions are limited by offline Docker/networking constraints in the sandbox. Exact functional equivalence is maintained by applying allowance verification and subtraction inside the loop itself.

---
*PR created automatically by Jules for task [10265436857614730392](https://jules.google.com/task/10265436857614730392) started by @FelixHertweck*