### PR TITLE
🔒 Security Fix: Increase check-in code length for better entropy

### DIFF
--- a/src/main/java/de/felixhertweck/seatreservation/utils/CodeGenerator.java
+++ b/src/main/java/de/felixhertweck/seatreservation/utils/CodeGenerator.java
@@ -24,7 +24,7 @@ import java.security.SecureRandom;
 public class CodeGenerator {
 
     private static final String CHARACTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
-    private static final int CODE_LENGTH = 4;
+    private static final int CODE_LENGTH = 8;
     private static final SecureRandom random = new SecureRandom();
 
     public static String generateRandomCode() {

--- a/src/test/java/de/felixhertweck/seatreservation/utils/CodeGeneratorTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/utils/CodeGeneratorTest.java
@@ -43,14 +43,14 @@ class CodeGeneratorTest {
     @Test
     void generateRandomCode_ReturnsCorrectLength() {
         String code = CodeGenerator.generateRandomCode();
-        assertEquals(4, code.length(), "Generated code should have length 4");
+        assertEquals(8, code.length(), "Generated code should have length 8");
     }
 
     @Test
     void generateRandomCode_ContainsOnlyAllowedCharacters() {
         String code = CodeGenerator.generateRandomCode();
         assertTrue(
-                code.matches("^[A-Z0-9]{4}$"),
+                code.matches("^[A-Z0-9]{8}$"),
                 "Generated code should only contain uppercase letters and digits, got: " + code);
     }
 
@@ -62,7 +62,7 @@ class CodeGeneratorTest {
             codes.add(CodeGenerator.generateRandomCode());
         }
 
-        // With 36^4 = 1,679,616 possible combinations,
+        // With 36^8 = 2,821,109,907,456 possible combinations,
         // the probability of collisions in 1000 samples is very low.
         // We expect almost all to be unique.
         assertTrue(


### PR DESCRIPTION
🎯 **What:** Increased the check-in code length from 4 to 8 in `CodeGenerator.java`.
⚠️ **Risk:** A 4-character alphanumeric code has a relatively small space of possible combinations (36^4 = ~1.6 million), which could allow an attacker to brute-force or guess valid check-in codes.
🛡️ **Solution:** Increasing the length to 8 characters significantly increases the entropy (36^8 = ~2.8 trillion combinations), making it computationally infeasible to guess check-in codes in a reasonable timeframe. Also updated relevant unit tests.

---
*PR created automatically by Jules for task [1096082692244987294](https://jules.google.com/task/1096082692244987294) started by @FelixHertweck*