### PR TITLE
🧪 [testing improvement] Add missing error path test for LiveViewService IOException

### DIFF
--- a/src/test/java/de/felixhertweck/seatreservation/supervisor/service/LiveViewServiceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/supervisor/service/LiveViewServiceTest.java
@@ -151,6 +151,54 @@ public class LiveViewServiceTest {
                 () -> webSocketService.registerConnection(nullEventIdStr, mockConnection));
     }
 
+    @Test
+    void testSendInitialReservations_IOException() throws Exception {
+        // Use reflection to mock the objectMapper and force an IOException
+        // (JsonProcessingException)
+        java.lang.reflect.Field mapperField =
+                LiveViewService.class.getDeclaredField("objectMapper");
+        mapperField.setAccessible(true);
+        com.fasterxml.jackson.databind.ObjectMapper originalMapper =
+                (com.fasterxml.jackson.databind.ObjectMapper) mapperField.get(webSocketService);
+
+        com.fasterxml.jackson.databind.ObjectMapper mockMapper =
+                Mockito.mock(com.fasterxml.jackson.databind.ObjectMapper.class);
+        Mockito.when(mockMapper.writeValueAsString(Mockito.any()))
+                .thenThrow(
+                        new com.fasterxml.jackson.core.JsonProcessingException(
+                                "Test IOException") {});
+
+        mapperField.set(webSocketService, mockMapper);
+
+        try {
+            Long testEventId = 999L;
+            WebSocketConnection mockConnection = Mockito.mock(WebSocketConnection.class);
+
+            Event mockEvent = new Event();
+            mockEvent.id = testEventId;
+            mockEvent.setName("Test Exception Event");
+            EventLocation mockLocation = new EventLocation();
+            mockLocation.id = 1L;
+            mockEvent.setEventLocation(mockLocation);
+
+            Mockito.when(eventRepository.findById(testEventId)).thenReturn(mockEvent);
+            Mockito.when(reservationRepository.findByEventId(testEventId))
+                    .thenReturn(new java.util.ArrayList<>());
+
+            assertDoesNotThrow(
+                    () -> {
+                        webSocketService.registerConnection(testEventId, mockConnection);
+                    },
+                    "registerConnection should handle IOException without throwing it");
+
+            // Verify that writeValueAsString was indeed called
+            Mockito.verify(mockMapper).writeValueAsString(Mockito.any());
+        } finally {
+            // Restore original mapper
+            mapperField.set(webSocketService, originalMapper);
+        }
+    }
+
     private Reservation createTestReservation() {
         User user = new User();
         user.id = 1L;

--- a/src/test/java/de/felixhertweck/seatreservation/supervisor/service/LiveViewServiceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/supervisor/service/LiveViewServiceTest.java
@@ -153,13 +153,16 @@ public class LiveViewServiceTest {
 
     @Test
     void testSendInitialReservations_IOException() throws Exception {
-        // Use reflection to mock the objectMapper and force an IOException
-        // (JsonProcessingException)
+        // webSocketService is a CDI client proxy; its own fields are never read by the delegated
+        // business methods, so the objectMapper field must be patched on the real contextual
+        // instance behind the proxy, not on the proxy itself.
+        Object realInstance = io.quarkus.arc.ClientProxy.unwrap(webSocketService);
+
         java.lang.reflect.Field mapperField =
                 LiveViewService.class.getDeclaredField("objectMapper");
         mapperField.setAccessible(true);
         com.fasterxml.jackson.databind.ObjectMapper originalMapper =
-                (com.fasterxml.jackson.databind.ObjectMapper) mapperField.get(webSocketService);
+                (com.fasterxml.jackson.databind.ObjectMapper) mapperField.get(realInstance);
 
         com.fasterxml.jackson.databind.ObjectMapper mockMapper =
                 Mockito.mock(com.fasterxml.jackson.databind.ObjectMapper.class);
@@ -168,7 +171,7 @@ public class LiveViewServiceTest {
                         new com.fasterxml.jackson.core.JsonProcessingException(
                                 "Test IOException") {});
 
-        mapperField.set(webSocketService, mockMapper);
+        mapperField.set(realInstance, mockMapper);
 
         try {
             Long testEventId = 999L;


### PR DESCRIPTION
🎯 **What:** The missing error path test for IOException when sending initial reservations in `LiveViewService` (Supervisor) is now implemented.
📊 **Coverage:** The test `testSendInitialReservations_IOException` forces a `JsonProcessingException` during `writeValueAsString` execution by reflecting a mocked `ObjectMapper` into the service and verifying the service doesn't crash on connection registration.
✨ **Result:** Improved code coverage, specifically hitting the catch block for `IOException` in `sendInitialReservations` which previously went untested.

---
*PR created automatically by Jules for task [5741145281179422526](https://jules.google.com/task/5741145281179422526) started by @FelixHertweck*