### PR TITLE
⚡ Optimize N+1 query in CheckInService processCheckIn

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,3 @@
 ## 2025-02-12 - N+1 Query Optimization in CheckInService
-**Learning:** Calling `findById...` inside a loop iterating over user-provided IDs scales poorly (O(N) queries) and delays request processing unnecessarily.
-**Action:** Replace looped exact-match queries with a single batch fetch using an HQL `IN` clause. Collect the results into a `Map` for O(1) lookup during processing to maintain existing error handling and ordering semantics.
+**Learning:** Calling `findById...` inside a loop iterating over user-provided IDs scales poorly (O(N) queries) and delays request processing unnecessarily. When using HQL positional parameters with an IN clause in Panache/Hibernate, `find("id in (?1)", collection)` requires parentheses.
+**Action:** Replace looped exact-match queries with a single batch fetch using an HQL `IN (?1)` clause. Collect the results into a `Map` for O(1) lookup during processing to maintain existing error handling and ordering semantics.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,0 @@
-## 2025-02-12 - N+1 Query Optimization in CheckInService
-**Learning:** Calling `findById...` inside a loop iterating over user-provided IDs scales poorly (O(N) queries) and delays request processing unnecessarily. When using HQL positional parameters with an IN clause in Panache/Hibernate, `find("id in (?1)", collection)` requires parentheses.
-**Action:** Replace looped exact-match queries with a single batch fetch using an HQL `IN (?1)` clause. Collect the results into a `Map` for O(1) lookup during processing to maintain existing error handling and ordering semantics.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-02-12 - N+1 Query Optimization in CheckInService
+**Learning:** Calling `findById...` inside a loop iterating over user-provided IDs scales poorly (O(N) queries) and delays request processing unnecessarily.
+**Action:** Replace looped exact-match queries with a single batch fetch using an HQL `IN` clause. Collect the results into a `Map` for O(1) lookup during processing to maintain existing error handling and ordering semantics.

--- a/src/main/java/de/felixhertweck/seatreservation/model/repository/ReservationRepository.java
+++ b/src/main/java/de/felixhertweck/seatreservation/model/repository/ReservationRepository.java
@@ -139,6 +139,6 @@ public class ReservationRepository implements PanacheRepository<Reservation> {
         if (ids == null || ids.isEmpty()) {
             return java.util.Collections.emptyList();
         }
-        return find("id in ?1 and user.id = ?2 and event.id = ?3", ids, userId, eventId).list();
+        return find("id in (?1) and user.id = ?2 and event.id = ?3", ids, userId, eventId).list();
     }
 }

--- a/src/main/java/de/felixhertweck/seatreservation/model/repository/ReservationRepository.java
+++ b/src/main/java/de/felixhertweck/seatreservation/model/repository/ReservationRepository.java
@@ -114,19 +114,6 @@ public class ReservationRepository implements PanacheRepository<Reservation> {
     }
 
     /**
-     * Finds a reservation by its ID and associated user ID and event ID.
-     *
-     * @param id the reservation ID to search for
-     * @param userId the user ID to search for
-     * @param eventId the event ID to search for
-     * @return an Optional containing the reservation if found, or empty otherwise
-     */
-    public Optional<Reservation> findByIdUserIdAndEventId(Long id, Long userId, Long eventId) {
-        return find("id = ?1 and user.id = ?2 and event.id = ?3", id, userId, eventId)
-                .firstResultOptional();
-    }
-
-    /**
      * Finds multiple reservations by their IDs and associated user ID and event ID.
      *
      * @param ids the reservation IDs to search for
@@ -137,7 +124,7 @@ public class ReservationRepository implements PanacheRepository<Reservation> {
     public List<Reservation> findAllByIdUserIdAndEventId(
             List<Long> ids, Long userId, Long eventId) {
         if (ids == null || ids.isEmpty()) {
-            return java.util.Collections.emptyList();
+            return List.of();
         }
         return find("id in (?1) and user.id = ?2 and event.id = ?3", ids, userId, eventId).list();
     }

--- a/src/main/java/de/felixhertweck/seatreservation/model/repository/ReservationRepository.java
+++ b/src/main/java/de/felixhertweck/seatreservation/model/repository/ReservationRepository.java
@@ -125,4 +125,20 @@ public class ReservationRepository implements PanacheRepository<Reservation> {
         return find("id = ?1 and user.id = ?2 and event.id = ?3", id, userId, eventId)
                 .firstResultOptional();
     }
+
+    /**
+     * Finds multiple reservations by their IDs and associated user ID and event ID.
+     *
+     * @param ids the reservation IDs to search for
+     * @param userId the user ID to search for
+     * @param eventId the event ID to search for
+     * @return a list of reservations if found
+     */
+    public List<Reservation> findAllByIdUserIdAndEventId(
+            List<Long> ids, Long userId, Long eventId) {
+        if (ids == null || ids.isEmpty()) {
+            return java.util.Collections.emptyList();
+        }
+        return find("id in ?1 and user.id = ?2 and event.id = ?3", ids, userId, eventId).list();
+    }
 }

--- a/src/main/java/de/felixhertweck/seatreservation/supervisor/service/CheckInService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/supervisor/service/CheckInService.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -159,12 +160,18 @@ public class CheckInService {
                 cancelIds != null ? cancelIds.size() : 0);
 
         if (checkInIds != null && !checkInIds.isEmpty()) {
-            for (Long reservationId : checkInIds) {
-                Optional<Reservation> reservationOptional =
-                        reservationRepository.findByIdUserIdAndEventId(
-                                reservationId, userId, eventId);
+            List<Reservation> checkInReservations =
+                    reservationRepository.findAllByIdUserIdAndEventId(checkInIds, userId, eventId);
+            Map<Long, Reservation> reservationMap =
+                    checkInReservations.stream()
+                            .collect(
+                                    Collectors.toMap(
+                                            r -> r.id, Function.identity(), (r1, r2) -> r1));
 
-                if (!reservationOptional.isPresent()) {
+            for (Long reservationId : checkInIds) {
+                Reservation reservation = reservationMap.get(reservationId);
+
+                if (reservation == null) {
                     LOG.warnf(
                             "Reservation with ID %d not found or does not belong to user %d/event"
                                     + " %d for check-in.",
@@ -175,8 +182,6 @@ public class CheckInService {
                                             + " %d/event %d for check-in.",
                                     reservationId, userId, eventId));
                 }
-
-                Reservation reservation = reservationOptional.get();
 
                 LOG.debugf("Setting reservation %d to CHECK_IN status.", reservationId);
                 reservation.setLiveStatus(ReservationLiveStatus.CHECKED_IN);
@@ -189,12 +194,18 @@ public class CheckInService {
         }
 
         if (cancelIds != null && !cancelIds.isEmpty()) {
-            for (Long reservationId : cancelIds) {
-                Optional<Reservation> reservationOptional =
-                        reservationRepository.findByIdUserIdAndEventId(
-                                reservationId, userId, eventId);
+            List<Reservation> cancelReservations =
+                    reservationRepository.findAllByIdUserIdAndEventId(cancelIds, userId, eventId);
+            Map<Long, Reservation> reservationMap =
+                    cancelReservations.stream()
+                            .collect(
+                                    Collectors.toMap(
+                                            r -> r.id, Function.identity(), (r1, r2) -> r1));
 
-                if (!reservationOptional.isPresent()) {
+            for (Long reservationId : cancelIds) {
+                Reservation reservation = reservationMap.get(reservationId);
+
+                if (reservation == null) {
                     LOG.warnf(
                             "Reservation with ID %d not found or does not belong to user %d/event"
                                     + " %d for cancellation.",
@@ -205,8 +216,6 @@ public class CheckInService {
                                             + " %d/event %d for cancellation.",
                                     reservationId, userId, eventId));
                 }
-
-                Reservation reservation = reservationOptional.get();
 
                 LOG.debugf("Setting reservation %d to CANCEL status.", reservationId);
                 reservation.setLiveStatus(ReservationLiveStatus.CANCELLED);

--- a/src/main/java/de/felixhertweck/seatreservation/supervisor/service/CheckInService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/supervisor/service/CheckInService.java
@@ -23,7 +23,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;

--- a/src/test/java/de/felixhertweck/seatreservation/supervisor/service/CheckInServiceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/supervisor/service/CheckInServiceTest.java
@@ -22,7 +22,6 @@ package de.felixhertweck.seatreservation.supervisor.service;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 import jakarta.inject.Inject;

--- a/src/test/java/de/felixhertweck/seatreservation/supervisor/service/CheckInServiceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/supervisor/service/CheckInServiceTest.java
@@ -106,10 +106,9 @@ class CheckInServiceTest {
         reservation2.setEvent(event);
         reservation2.setSeat(seat);
 
-        when(reservationRepository.findByIdUserIdAndEventId(reservationId1, userId, eventId))
-                .thenReturn(Optional.of(reservation1));
-        when(reservationRepository.findByIdUserIdAndEventId(reservationId2, userId, eventId))
-                .thenReturn(Optional.of(reservation2));
+        when(reservationRepository.findAllByIdUserIdAndEventId(
+                        Arrays.asList(reservationId1, reservationId2), userId, eventId))
+                .thenReturn(Arrays.asList(reservation1, reservation2));
 
         CheckInProcessRequestDTO requestDTO =
                 new CheckInProcessRequestDTO(
@@ -151,8 +150,9 @@ class CheckInServiceTest {
         reservation1.setSeat(seat);
         reservation1.setLiveStatus(ReservationLiveStatus.CHECKED_IN);
 
-        when(reservationRepository.findByIdUserIdAndEventId(reservationId1, userId, eventId))
-                .thenReturn(Optional.of(reservation1));
+        when(reservationRepository.findAllByIdUserIdAndEventId(
+                        Collections.singletonList(reservationId1), userId, eventId))
+                .thenReturn(Collections.singletonList(reservation1));
 
         CheckInProcessRequestDTO requestDTO =
                 new CheckInProcessRequestDTO(
@@ -198,10 +198,12 @@ class CheckInServiceTest {
         cancelReservation.setEvent(event);
         cancelReservation.setSeat(seat);
 
-        when(reservationRepository.findByIdUserIdAndEventId(checkInId, userId, eventId))
-                .thenReturn(Optional.of(checkInReservation));
-        when(reservationRepository.findByIdUserIdAndEventId(cancelId, userId, eventId))
-                .thenReturn(Optional.of(cancelReservation));
+        when(reservationRepository.findAllByIdUserIdAndEventId(
+                        Collections.singletonList(checkInId), userId, eventId))
+                .thenReturn(Collections.singletonList(checkInReservation));
+        when(reservationRepository.findAllByIdUserIdAndEventId(
+                        Collections.singletonList(cancelId), userId, eventId))
+                .thenReturn(Collections.singletonList(cancelReservation));
 
         CheckInProcessRequestDTO requestDTO =
                 new CheckInProcessRequestDTO(
@@ -224,8 +226,9 @@ class CheckInServiceTest {
         long userId = 1L;
         long eventId = 10L;
 
-        when(reservationRepository.findByIdUserIdAndEventId(reservationId, userId, eventId))
-                .thenReturn(Optional.empty());
+        when(reservationRepository.findAllByIdUserIdAndEventId(
+                        Collections.singletonList(reservationId), userId, eventId))
+                .thenReturn(Collections.emptyList());
 
         CheckInProcessRequestDTO requestDTO =
                 new CheckInProcessRequestDTO(
@@ -341,8 +344,9 @@ class CheckInServiceTest {
         long userId = 1L;
         long eventId = 10L;
 
-        when(reservationRepository.findByIdUserIdAndEventId(reservationId, userId, eventId))
-                .thenReturn(Optional.of(reservation1));
+        when(reservationRepository.findAllByIdUserIdAndEventId(
+                        Collections.singletonList(reservationId), userId, eventId))
+                .thenReturn(Collections.singletonList(reservation1));
 
         CheckInProcessRequestDTO requestDTO =
                 new CheckInProcessRequestDTO(


### PR DESCRIPTION
💡 **What:** Replaced the iterative `findByIdUserIdAndEventId` queries inside loops with a single batch fetch `findAllByIdUserIdAndEventId` (using an `IN` clause) in `CheckInService#processCheckIn`.
🎯 **Why:** The previous implementation suffered from an N+1 query issue, executing a separate database query for every check-in or cancellation ID provided in the request payload. This drastically hurt performance for large bulk operations.
📊 **Measured Improvement:** Replaces O(N) database queries with O(1) queries (specifically, one query for all check-ins and one for all cancellations) per API call, significantly reducing I/O overhead and database load.

---
*PR created automatically by Jules for task [5848478108902422500](https://jules.google.com/task/5848478108902422500) started by @FelixHertweck*