### PR TITLE
perf(backend): batch entity lookups in ReservationService to eliminate N+1 queries

### DIFF
--- a/src/main/java/de/felixhertweck/seatreservation/management/service/ReservationService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/management/service/ReservationService.java
@@ -63,6 +63,7 @@ import org.jboss.logging.Logger;
 public class ReservationService {
 
     private static final Logger LOG = Logger.getLogger(ReservationService.class);
+    private static final String ID_IN_QUERY = "id in ?1";
 
     @ConfigProperty(name = "exporter.pdf.minutesBeforeEventStart", defaultValue = "10")
     Integer EXPORTER_PDF_MINUTES_BEFORE_EVENT_START;
@@ -258,19 +259,16 @@ public class ReservationService {
 
         List<Reservation> existingReservations = new ArrayList<>();
 
+        Map<Long, Seat> seatMap =
+                seatRepository.find(ID_IN_QUERY, dto.getSeatIds()).list().stream()
+                        .collect(Collectors.toMap(s -> s.id, s -> s, (s1, s2) -> s1));
+
         for (Long dtoSeatId : dto.getSeatIds()) {
-            Seat seat =
-                    seatRepository
-                            .findByIdOptional(dtoSeatId)
-                            .orElseThrow(
-                                    () -> {
-                                        LOG.warnf(
-                                                "Seat with ID %d not found for reservation"
-                                                        + " creation.",
-                                                dtoSeatId);
-                                        return new IllegalArgumentException(
-                                                "Seat with id " + dtoSeatId + " not found");
-                                    });
+            Seat seat = seatMap.get(dtoSeatId);
+            if (seat == null) {
+                LOG.warnf("Seat with ID %d not found for reservation creation.", dtoSeatId);
+                throw new IllegalArgumentException("Seat with id " + dtoSeatId + " not found");
+            }
 
             if (!dto.isDeductAllowance()) {
                 LOG.debugf(
@@ -371,20 +369,20 @@ public class ReservationService {
 
         List<Reservation> deletedReservations = new ArrayList<>();
 
+        List<Reservation> foundReservations = reservationRepository.find(ID_IN_QUERY, ids).list();
+        Map<Long, Reservation> foundReservationMap =
+                foundReservations.stream()
+                        .collect(Collectors.toMap(r -> r.id, r -> r, (r1, r2) -> r1));
+
         for (Long id : ids) {
 
-            Reservation reservation =
-                    reservationRepository
-                            .findByIdOptional(id)
-                            .orElseThrow(
-                                    () -> {
-                                        LOG.warnf(
-                                                "Reservation with ID %d not found for deletion by"
-                                                        + " user: %s (ID: %d)",
-                                                id, managerUser.id, managerUser.getId());
-                                        return new ReservationNotFoundException(
-                                                "Reservation with id " + id + " not found");
-                                    });
+            Reservation reservation = foundReservationMap.get(id);
+            if (reservation == null) {
+                LOG.warnf(
+                        "Reservation with ID %d not found for deletion by user: %s (ID: %d)",
+                        id, managerUser.id, managerUser.getId());
+                throw new ReservationNotFoundException("Reservation with id " + id + " not found");
+            }
 
             if (!managerUser.getRoles().contains(Roles.ADMIN)
                     && !isManagerAllowedToAccessEvent(managerUser, reservation.getEvent())) {
@@ -539,25 +537,21 @@ public class ReservationService {
             throw new SecurityException("You are not allowed to block seats for this event.");
         }
 
-        List<Seat> seats =
-                seatIds.stream()
-                        .map(
-                                seatId ->
-                                        seatRepository
-                                                .findByIdOptional(seatId)
-                                                .orElseThrow(
-                                                        () -> {
-                                                            LOG.warnf(
-                                                                    "Seat with ID %d not found for"
-                                                                        + " blocking seats in event"
-                                                                        + " ID %d.",
-                                                                    seatId, eventId);
-                                                            return new IllegalArgumentException(
-                                                                    "Seat with id "
-                                                                            + seatId
-                                                                            + " not found");
-                                                        }))
-                        .toList();
+        Map<Long, Seat> seatMap =
+                seatRepository.find(ID_IN_QUERY, seatIds).list().stream()
+                        .collect(Collectors.toMap(s -> s.id, s -> s, (s1, s2) -> s1));
+
+        List<Seat> seats = new ArrayList<>();
+        for (Long seatId : seatIds) {
+            Seat seat = seatMap.get(seatId);
+            if (seat == null) {
+                LOG.warnf(
+                        "Seat with ID %d not found for blocking seats in event ID %d.",
+                        seatId, eventId);
+                throw new IllegalArgumentException("Seat with id " + seatId + " not found");
+            }
+            seats.add(seat);
+        }
 
         List<Reservation> existingReservations = reservationRepository.findByEventId(eventId);
         for (Seat seat : seats) {

--- a/src/main/java/de/felixhertweck/seatreservation/reservation/service/ReservationService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/reservation/service/ReservationService.java
@@ -58,6 +58,7 @@ import org.jboss.logging.Logger;
 public class ReservationService {
 
     private static final Logger LOG = Logger.getLogger(ReservationService.class);
+    private static final String ID_IN_QUERY = "id in ?1";
 
     @Inject ReservationRepository reservationRepository;
     @Inject EventRepository eventRepository;
@@ -171,24 +172,21 @@ public class ReservationService {
         LOG.debugf("Event ID: %d found for reservation.", event.id);
 
         // Validate the seatIds, ensure they exist
-        List<Seat> seats =
-                dto.getSeatIds().stream()
-                        .map(
-                                seatId ->
-                                        seatRepository
-                                                .findByIdOptional(seatId)
-                                                .orElseThrow(
-                                                        () -> {
-                                                            LOG.warnf(
-                                                                    "Seat with ID %d not found for"
-                                                                        + " reservation creation by"
-                                                                        + " user %s.",
-                                                                    seatId, currentUser.id);
-                                                            return new EventNotFoundException(
-                                                                    "Minimum one seat not"
-                                                                            + " found");
-                                                        }))
-                        .toList();
+        List<Seat> foundSeats = seatRepository.find(ID_IN_QUERY, dto.getSeatIds()).list();
+        Map<Long, Seat> foundSeatMap =
+                foundSeats.stream().collect(Collectors.toMap(s -> s.id, s -> s, (s1, s2) -> s1));
+
+        List<Seat> seats = new ArrayList<>();
+        for (Long seatId : dto.getSeatIds()) {
+            Seat seat = foundSeatMap.get(seatId);
+            if (seat == null) {
+                LOG.warnf(
+                        "Seat with ID %d not found for reservation creation by user %s.",
+                        seatId, currentUser.id);
+                throw new EventNotFoundException("Minimum one seat not found");
+            }
+            seats.add(seat);
+        }
         LOG.debugf("All %d seats found for reservation.", seats.size());
 
         // Check if the user has an allowance for this event
@@ -353,7 +351,7 @@ public class ReservationService {
                     "At least one reservation ID must be provided for deletion");
         }
 
-        List<Reservation> foundReservations = reservationRepository.find("id in ?1", ids).list();
+        List<Reservation> foundReservations = reservationRepository.find(ID_IN_QUERY, ids).list();
         Map<Long, Reservation> foundReservationMap =
                 foundReservations.stream()
                         .collect(Collectors.toMap(r -> r.id, r -> r, (r1, r2) -> r1));
@@ -413,7 +411,7 @@ public class ReservationService {
 
             // Delete reservations for the current event in a single batch query
             List<Long> reservationIdsToDelete = entry.getValue().stream().map(r -> r.id).toList();
-            reservationRepository.delete("id in ?1", reservationIdsToDelete);
+            reservationRepository.delete(ID_IN_QUERY, reservationIdsToDelete);
             LOG.infof(
                     "Deleted reservations with IDs %s for user ID: %d.",
                     reservationIdsToDelete, currentUser.id);

--- a/src/test/java/de/felixhertweck/seatreservation/management/service/ReservationServiceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/management/service/ReservationServiceTest.java
@@ -184,6 +184,27 @@ public class ReservationServiceTest {
         allowance = new EventUserAllowance(regularUser, event, 1);
     }
 
+    private void mockSeatFind(Set<Long> seatIds, List<Seat> seats) {
+        @SuppressWarnings("unchecked")
+        PanacheQuery<Seat> seatQuery = mock(PanacheQuery.class);
+        when(seatQuery.list()).thenReturn(seats);
+        when(seatRepository.find("id in ?1", seatIds)).thenReturn(seatQuery);
+    }
+
+    private void mockSeatFind(List<Long> seatIds, List<Seat> seats) {
+        @SuppressWarnings("unchecked")
+        PanacheQuery<Seat> seatQuery = mock(PanacheQuery.class);
+        when(seatQuery.list()).thenReturn(seats);
+        when(seatRepository.find("id in ?1", seatIds)).thenReturn(seatQuery);
+    }
+
+    private void mockReservationFind(List<Long> ids, List<Reservation> reservations) {
+        @SuppressWarnings("unchecked")
+        PanacheQuery<Reservation> reservationQuery = mock(PanacheQuery.class);
+        when(reservationQuery.list()).thenReturn(reservations);
+        when(reservationRepository.find("id in ?1", ids)).thenReturn(reservationQuery);
+    }
+
     @Test
     void createReservation_Success_AsAdmin() {
         ReservationRequestDTO dto = new ReservationRequestDTO();
@@ -193,7 +214,7 @@ public class ReservationServiceTest {
 
         when(userRepository.findByIdOptional(regularUser.id)).thenReturn(Optional.of(regularUser));
         when(eventRepository.findByIdOptional(event.id)).thenReturn(Optional.of(event));
-        when(seatRepository.findByIdOptional(seat.id)).thenReturn(Optional.of(seat));
+        mockSeatFind(dto.getSeatIds(), List.of(seat));
         @SuppressWarnings("unchecked")
         PanacheQuery<EventUserAllowance> allowanceQuery = mock(PanacheQuery.class);
         when(allowanceQuery.singleResult()).thenReturn(allowance);
@@ -229,7 +250,7 @@ public class ReservationServiceTest {
 
         when(userRepository.findByIdOptional(regularUser.id)).thenReturn(Optional.of(regularUser));
         when(eventRepository.findByIdOptional(event.id)).thenReturn(Optional.of(event));
-        when(seatRepository.findByIdOptional(seat.id)).thenReturn(Optional.of(seat));
+        mockSeatFind(dto.getSeatIds(), List.of(seat));
         // No allowance setup needed as it should be skipped
 
         doAnswer(
@@ -260,7 +281,7 @@ public class ReservationServiceTest {
 
         when(userRepository.findByIdOptional(regularUser.id)).thenReturn(Optional.of(regularUser));
         when(eventRepository.findByIdOptional(event.id)).thenReturn(Optional.of(event));
-        when(seatRepository.findByIdOptional(seat.id)).thenReturn(Optional.of(seat));
+        mockSeatFind(dto.getSeatIds(), List.of(seat));
         // No allowance setup needed as it should be skipped
 
         doAnswer(
@@ -291,7 +312,7 @@ public class ReservationServiceTest {
 
         when(userRepository.findByIdOptional(regularUser.id)).thenReturn(Optional.of(regularUser));
         when(eventRepository.findByIdOptional(event.id)).thenReturn(Optional.of(event));
-        when(seatRepository.findByIdOptional(seat.id)).thenReturn(Optional.of(seat));
+        mockSeatFind(dto.getSeatIds(), List.of(seat));
         @SuppressWarnings("unchecked")
         PanacheQuery<EventUserAllowance> allowanceQuery = mock(PanacheQuery.class);
         when(allowanceQuery.singleResult()).thenReturn(allowance);
@@ -318,7 +339,7 @@ public class ReservationServiceTest {
 
         when(userRepository.findByIdOptional(regularUser.id)).thenReturn(Optional.of(regularUser));
         when(eventRepository.findByIdOptional(event.id)).thenReturn(Optional.of(event));
-        when(seatRepository.findByIdOptional(seat.id)).thenReturn(Optional.of(seat));
+        mockSeatFind(dto.getSeatIds(), List.of(seat));
 
         assertThrows(
                 SecurityException.class,
@@ -334,7 +355,7 @@ public class ReservationServiceTest {
 
         when(userRepository.findByIdOptional(regularUser.id)).thenReturn(Optional.of(regularUser));
         when(eventRepository.findByIdOptional(event.id)).thenReturn(Optional.of(event));
-        when(seatRepository.findByIdOptional(seat.id)).thenReturn(Optional.of(seat));
+        mockSeatFind(dto.getSeatIds(), List.of(seat));
         @SuppressWarnings("unchecked")
         PanacheQuery<EventUserAllowance> allowanceQuery = mock(PanacheQuery.class);
         when(allowanceQuery.singleResult()).thenThrow(new NoResultException());
@@ -356,7 +377,7 @@ public class ReservationServiceTest {
 
         when(userRepository.findByIdOptional(regularUser.id)).thenReturn(Optional.of(regularUser));
         when(eventRepository.findByIdOptional(event.id)).thenReturn(Optional.of(event));
-        when(seatRepository.findByIdOptional(seat.id)).thenReturn(Optional.of(seat));
+        mockSeatFind(dto.getSeatIds(), List.of(seat));
         @SuppressWarnings("unchecked")
         PanacheQuery<EventUserAllowance> allowanceQuery = mock(PanacheQuery.class);
         when(allowanceQuery.singleResult()).thenReturn(allowance);
@@ -408,8 +429,7 @@ public class ReservationServiceTest {
 
     @Test
     void deleteReservation_Success_AsAdmin() {
-        when(reservationRepository.findByIdOptional(reservation.id))
-                .thenReturn(Optional.of(reservation));
+        mockReservationFind(List.of(reservation.id), List.of(reservation));
         @SuppressWarnings("unchecked")
         PanacheQuery<EventUserAllowance> allowanceQuery = mock(PanacheQuery.class);
         when(allowanceQuery.firstResultOptional()).thenReturn(Optional.empty());
@@ -423,8 +443,7 @@ public class ReservationServiceTest {
 
     @Test
     void deleteReservation_Success_AsManager() {
-        when(reservationRepository.findByIdOptional(reservation.id))
-                .thenReturn(Optional.of(reservation));
+        mockReservationFind(List.of(reservation.id), List.of(reservation));
         @SuppressWarnings("unchecked")
         PanacheQuery<EventUserAllowance> allowanceQuery = mock(PanacheQuery.class);
         when(allowanceQuery.firstResultOptional()).thenReturn(Optional.empty());
@@ -438,8 +457,7 @@ public class ReservationServiceTest {
 
     @Test
     void deleteReservation_Forbidden() {
-        when(reservationRepository.findByIdOptional(reservation.id))
-                .thenReturn(Optional.of(reservation));
+        mockReservationFind(List.of(reservation.id), List.of(reservation));
 
         assertThrows(
                 SecurityException.class,
@@ -452,8 +470,7 @@ public class ReservationServiceTest {
         // Set up allowance with initial count
         allowance.setReservationsAllowedCount(0);
 
-        when(reservationRepository.findByIdOptional(reservation.id))
-                .thenReturn(Optional.of(reservation));
+        mockReservationFind(List.of(reservation.id), List.of(reservation));
         when(eventUserAllowanceRepository.findByUserAndEvent(regularUser, event))
                 .thenReturn(Optional.of(allowance));
         doNothing().when(eventUserAllowanceRepository).persist(any(EventUserAllowance.class));
@@ -467,8 +484,7 @@ public class ReservationServiceTest {
 
     @Test
     void deleteReservation_Success_NoAllowanceExists() {
-        when(reservationRepository.findByIdOptional(reservation.id))
-                .thenReturn(Optional.of(reservation));
+        mockReservationFind(List.of(reservation.id), List.of(reservation));
         when(eventUserAllowanceRepository.findByUserAndEvent(regularUser, event))
                 .thenReturn(Optional.empty());
 
@@ -493,8 +509,7 @@ public class ReservationServiceTest {
                         CodeGenerator.generateRandomCode());
         blockedReservation.id = 2L;
 
-        when(reservationRepository.findByIdOptional(blockedReservation.id))
-                .thenReturn(Optional.of(blockedReservation));
+        mockReservationFind(List.of(blockedReservation.id), List.of(blockedReservation));
 
         reservationService.deleteReservation(List.of(blockedReservation.id), managerUser);
 
@@ -521,10 +536,8 @@ public class ReservationServiceTest {
         // Set up allowance with initial count
         allowance.setReservationsAllowedCount(0);
 
-        when(reservationRepository.findByIdOptional(reservation.id))
-                .thenReturn(Optional.of(reservation));
-        when(reservationRepository.findByIdOptional(reservation2.id))
-                .thenReturn(Optional.of(reservation2));
+        mockReservationFind(
+                List.of(reservation.id, reservation2.id), List.of(reservation, reservation2));
         when(eventUserAllowanceRepository.findByUserAndEvent(regularUser, event))
                 .thenReturn(Optional.of(allowance));
         doNothing().when(eventUserAllowanceRepository).persist(any(EventUserAllowance.class));
@@ -573,10 +586,9 @@ public class ReservationServiceTest {
 
         allowance.setReservationsAllowedCount(0);
 
-        when(reservationRepository.findByIdOptional(blockedReservation.id))
-                .thenReturn(Optional.of(blockedReservation));
-        when(reservationRepository.findByIdOptional(reservedReservation.id))
-                .thenReturn(Optional.of(reservedReservation));
+        mockReservationFind(
+                List.of(blockedReservation.id, reservedReservation.id),
+                List.of(blockedReservation, reservedReservation));
         when(eventUserAllowanceRepository.findByUserAndEvent(regularUser, event))
                 .thenReturn(Optional.of(allowance));
         doNothing().when(eventUserAllowanceRepository).persist(any(EventUserAllowance.class));
@@ -596,8 +608,7 @@ public class ReservationServiceTest {
         // Test with different starting allowance counts
         allowance.setReservationsAllowedCount(5);
 
-        when(reservationRepository.findByIdOptional(reservation.id))
-                .thenReturn(Optional.of(reservation));
+        mockReservationFind(List.of(reservation.id), List.of(reservation));
         when(eventUserAllowanceRepository.findByUserAndEvent(regularUser, event))
                 .thenReturn(Optional.of(allowance));
         doNothing().when(eventUserAllowanceRepository).persist(any(EventUserAllowance.class));
@@ -611,8 +622,7 @@ public class ReservationServiceTest {
 
     @Test
     void deleteReservation_IOExceptionOnEmailSend_ContinuesGracefully() throws IOException {
-        when(reservationRepository.findByIdOptional(reservation.id))
-                .thenReturn(Optional.of(reservation));
+        mockReservationFind(List.of(reservation.id), List.of(reservation));
         @SuppressWarnings("unchecked")
         PanacheQuery<EventUserAllowance> allowanceQuery = mock(PanacheQuery.class);
         when(allowanceQuery.firstResultOptional()).thenReturn(Optional.empty());
@@ -691,8 +701,7 @@ public class ReservationServiceTest {
 
     @Test
     void deleteReservation_Forbidden_NotManager() {
-        when(reservationRepository.findByIdOptional(reservation.id))
-                .thenReturn(Optional.of(reservation));
+        mockReservationFind(List.of(reservation.id), List.of(reservation));
         User otherManager = new User();
         otherManager.id = 4L;
         otherManager.setRoles(Set.of(Roles.MANAGER));
@@ -706,7 +715,7 @@ public class ReservationServiceTest {
     @Test
     void blockSeats_Success() {
         when(eventRepository.findByIdOptional(event.id)).thenReturn(Optional.of(event));
-        when(seatRepository.findByIdOptional(seat.id)).thenReturn(Optional.of(seat));
+        mockSeatFind(List.of(seat.id), List.of(seat));
         when(reservationRepository.findByEventId(event.id)).thenReturn(Collections.emptyList());
 
         reservationService.blockSeats(event.id, List.of(seat.id), managerUser);
@@ -726,7 +735,7 @@ public class ReservationServiceTest {
     @Test
     void blockSeats_SeatAlreadyReserved() {
         when(eventRepository.findByIdOptional(event.id)).thenReturn(Optional.of(event));
-        when(seatRepository.findByIdOptional(seat.id)).thenReturn(Optional.of(seat));
+        mockSeatFind(List.of(seat.id), List.of(seat));
         when(reservationRepository.findByEventId(event.id)).thenReturn(List.of(reservation));
 
         assertThrows(

--- a/src/test/java/de/felixhertweck/seatreservation/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/reservation/service/ReservationServiceTest.java
@@ -147,6 +147,12 @@ class ReservationServiceTest {
         allowance.setReservationsAllowedCount(2);
     }
 
+    private void mockSeatFind(Set<Long> seatIds, List<Seat> seats) {
+        PanacheQuery<Seat> seatQueryMock = mock(PanacheQuery.class);
+        when(seatRepository.find("id in ?1", seatIds)).thenReturn(seatQueryMock);
+        when(seatQueryMock.list()).thenReturn(seats);
+    }
+
     @Test
     void findReservationsByUser_Success() {
         when(reservationRepository.findByUser(currentUser)).thenReturn(List.of(reservation));
@@ -205,7 +211,7 @@ class ReservationServiceTest {
         dto.setSeatIds(Set.of(seat1.id));
 
         when(eventRepository.findByIdOptional(event.id)).thenReturn(Optional.of(event));
-        when(seatRepository.findByIdOptional(seat1.id)).thenReturn(Optional.of(seat1));
+        mockSeatFind(dto.getSeatIds(), List.of(seat1));
         when(eventUserAllowanceRepository.findByUser(currentUser)).thenReturn(List.of(allowance));
         when(reservationRepository.findByEventId(event.id)).thenReturn(Collections.emptyList());
         doNothing().when(eventUserAllowanceRepository).persist(any(EventUserAllowance.class));
@@ -265,7 +271,7 @@ class ReservationServiceTest {
         dto.setSeatIds(Set.of(99L));
 
         when(eventRepository.findByIdOptional(event.id)).thenReturn(Optional.of(event));
-        when(seatRepository.findByIdOptional(99L)).thenReturn(Optional.empty());
+        mockSeatFind(dto.getSeatIds(), Collections.emptyList());
 
         assertThrows(
                 EventNotFoundException.class,
@@ -279,7 +285,7 @@ class ReservationServiceTest {
         dto.setSeatIds(Set.of(seat1.id));
 
         when(eventRepository.findByIdOptional(event.id)).thenReturn(Optional.of(event));
-        when(seatRepository.findByIdOptional(seat1.id)).thenReturn(Optional.of(seat1));
+        mockSeatFind(dto.getSeatIds(), List.of(seat1));
         when(eventUserAllowanceRepository.findByUser(currentUser))
                 .thenReturn(Collections.emptyList());
 
@@ -296,10 +302,11 @@ class ReservationServiceTest {
 
         allowance.setReservationsAllowedCount(2);
 
+        Seat seat3 = new Seat("", "", null);
+        seat3.id = 3L;
+
         when(eventRepository.findByIdOptional(event.id)).thenReturn(Optional.of(event));
-        when(seatRepository.findByIdOptional(seat1.id)).thenReturn(Optional.of(seat1));
-        when(seatRepository.findByIdOptional(seat2.id)).thenReturn(Optional.of(seat2));
-        when(seatRepository.findByIdOptional(3L)).thenReturn(Optional.of(new Seat("", "", null)));
+        mockSeatFind(dto.getSeatIds(), List.of(seat1, seat2, seat3));
         when(eventUserAllowanceRepository.findByUser(currentUser)).thenReturn(List.of(allowance));
 
         assertThrows(
@@ -315,7 +322,7 @@ class ReservationServiceTest {
         dto.setSeatIds(Set.of(seat1.id));
 
         when(eventRepository.findByIdOptional(event.id)).thenReturn(Optional.of(event));
-        when(seatRepository.findByIdOptional(seat1.id)).thenReturn(Optional.of(seat1));
+        mockSeatFind(dto.getSeatIds(), List.of(seat1));
         when(eventUserAllowanceRepository.findByUser(currentUser)).thenReturn(List.of(allowance));
 
         assertThrows(
@@ -335,7 +342,7 @@ class ReservationServiceTest {
         dto.setSeatIds(Set.of(seat1.id));
 
         when(eventRepository.findByIdOptional(event.id)).thenReturn(Optional.of(event));
-        when(seatRepository.findByIdOptional(seat1.id)).thenReturn(Optional.of(seat1));
+        mockSeatFind(dto.getSeatIds(), List.of(seat1));
         when(eventUserAllowanceRepository.findByUser(currentUser)).thenReturn(List.of(allowance));
 
         assertThrows(
@@ -358,7 +365,7 @@ class ReservationServiceTest {
                         ReservationStatus.RESERVED,
                         CodeGenerator.generateRandomCode());
         when(eventRepository.findByIdOptional(event.id)).thenReturn(Optional.of(event));
-        when(seatRepository.findByIdOptional(seat1.id)).thenReturn(Optional.of(seat1));
+        mockSeatFind(dto.getSeatIds(), List.of(seat1));
         when(eventUserAllowanceRepository.findByUser(currentUser)).thenReturn(List.of(allowance));
         when(reservationRepository.findByEventId(event.id))
                 .thenReturn(List.of(existingReservation));
@@ -383,7 +390,7 @@ class ReservationServiceTest {
         existingReservation.id = 2L;
 
         when(eventRepository.findByIdOptional(event.id)).thenReturn(Optional.of(event));
-        when(seatRepository.findByIdOptional(seat1.id)).thenReturn(Optional.of(seat1));
+        mockSeatFind(dto.getSeatIds(), List.of(seat1));
         when(eventUserAllowanceRepository.findByUser(currentUser)).thenReturn(List.of(allowance));
         when(reservationRepository.findByEventId(event.id))
                 .thenReturn(List.of(existingReservation));
@@ -474,7 +481,7 @@ class ReservationServiceTest {
         dto.setSeatIds(Set.of(seat1.id));
 
         when(eventRepository.findByIdOptional(event.id)).thenReturn(Optional.of(event));
-        when(seatRepository.findByIdOptional(seat1.id)).thenReturn(Optional.of(seat1));
+        mockSeatFind(dto.getSeatIds(), List.of(seat1));
         when(eventUserAllowanceRepository.findByUser(currentUser)).thenReturn(List.of(allowance));
         when(reservationRepository.findByEventId(event.id)).thenReturn(Collections.emptyList());
         doNothing().when(eventUserAllowanceRepository).persist(any(EventUserAllowance.class));


### PR DESCRIPTION
Replace per-ID findByIdOptional loops with single find("id in ?1", ids) batch lookups in createReservationForUser, createReservations, deleteReservation, and blockSeats. Reduces DB round-trips from O(N) to O(1) during bulk reservation, blocking, and deletion operations.