### PR TITLE
🧪 Add missing IOException test for LiveViewService broadcast update

### DIFF
--- a/src/test/java/de/felixhertweck/seatreservation/supervisor/service/LiveViewServiceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/supervisor/service/LiveViewServiceTest.java
@@ -205,10 +205,21 @@ public class LiveViewServiceTest {
     @Test
     void testBroadcastUpdate_IOExceptionHandledAndConnectionRemoved() throws Exception {
         Long testEventId = 100L;
-        Reservation mockReservation = new Reservation();
-        mockReservation.id = 1L;
+        Reservation mockReservation = createTestReservation();
 
         WebSocketConnection mockConnection = Mockito.mock(WebSocketConnection.class);
+
+        // registerConnection() sends an initial reservations snapshot, so the repositories
+        // must be stubbed for testEventId or that call fails before broadcastUpdate runs.
+        Event mockEvent = new Event();
+        mockEvent.id = testEventId;
+        mockEvent.setName("Test Broadcast Event");
+        EventLocation mockLocation = new EventLocation();
+        mockLocation.id = 1L;
+        mockEvent.setEventLocation(mockLocation);
+        Mockito.when(eventRepository.findById(testEventId)).thenReturn(mockEvent);
+        Mockito.when(reservationRepository.findByEventId(testEventId))
+                .thenReturn(new java.util.ArrayList<>());
 
         // Register the mock connection for the event
         webSocketService.registerConnection(testEventId, mockConnection);

--- a/src/test/java/de/felixhertweck/seatreservation/supervisor/service/LiveViewServiceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/supervisor/service/LiveViewServiceTest.java
@@ -202,6 +202,53 @@ public class LiveViewServiceTest {
         }
     }
 
+    @Test
+    void testBroadcastUpdate_IOExceptionHandledAndConnectionRemoved() throws Exception {
+        Long testEventId = 100L;
+        Reservation mockReservation = new Reservation();
+        mockReservation.id = 1L;
+
+        WebSocketConnection mockConnection = Mockito.mock(WebSocketConnection.class);
+
+        // Register the mock connection for the event
+        webSocketService.registerConnection(testEventId, mockConnection);
+
+        // Unwrap the CDI proxy to get the real instance
+        Object realInstance = io.quarkus.arc.ClientProxy.unwrap(webSocketService);
+
+        // Save original mapper
+        java.lang.reflect.Field mapperField =
+                LiveViewService.class.getDeclaredField("objectMapper");
+        mapperField.setAccessible(true);
+        com.fasterxml.jackson.databind.ObjectMapper originalMapper =
+                (com.fasterxml.jackson.databind.ObjectMapper) mapperField.get(realInstance);
+
+        // Mock the mapper to throw a JsonProcessingException (which is a subclass of IOException)
+        com.fasterxml.jackson.databind.ObjectMapper mockMapper =
+                Mockito.mock(com.fasterxml.jackson.databind.ObjectMapper.class);
+        Mockito.when(mockMapper.writeValueAsString(Mockito.any()))
+                .thenThrow(
+                        new com.fasterxml.jackson.core.JsonProcessingException(
+                                "Simulated IOException") {});
+
+        // Inject the mock mapper
+        mapperField.set(realInstance, mockMapper);
+
+        try {
+            // Invoke the method under test
+            assertDoesNotThrow(
+                    () -> webSocketService.broadcastUpdate(testEventId, mockReservation));
+
+            // Verify that the exception was caught and the connection was removed
+            // getActiveConnectionCount should return 0 since the failed connection was removed
+            assertEquals(0, webSocketService.getActiveConnectionCount(testEventId));
+        } finally {
+            // Restore original mapper
+            mapperField.set(realInstance, originalMapper);
+            webSocketService.unregisterConnection(testEventId, mockConnection); // cleanup
+        }
+    }
+
     private Reservation createTestReservation() {
         User user = new User();
         user.id = 1L;


### PR DESCRIPTION
🎯 **What:** Added a missing error path test for `LiveViewService.broadcastUpdate` where an `IOException` (triggered via `JsonProcessingException` during `ObjectMapper` serialization) is simulated.

📊 **Coverage:** The new `testBroadcastUpdate_IOExceptionHandledAndConnectionRemoved` method in `LiveViewServiceTest.java` verifies that when message broadcasting fails, the application correctly handles the exception without crashing and removes the failed connection from the active subscription list.

✨ **Result:** Increased unit test coverage and confidence in the resilience of WebSocket management logic during runtime serialization or network errors.

---
*PR created automatically by Jules for task [10259223009734933830](https://jules.google.com/task/10259223009734933830) started by @FelixHertweck*