### PR TITLE
perf(backend): resolve caller identity/roles from JWT claims instead of a per-request DB fetch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -160,6 +160,11 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-test-security-jwt</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-test-security-webauthn</artifactId>
       <scope>test</scope>
     </dependency>

--- a/src/main/java/de/felixhertweck/seatreservation/management/resource/AreaResource.java
+++ b/src/main/java/de/felixhertweck/seatreservation/management/resource/AreaResource.java
@@ -39,7 +39,7 @@ import de.felixhertweck.seatreservation.management.dto.AreaRequestDTO;
 import de.felixhertweck.seatreservation.management.dto.AreaResponseDTO;
 import de.felixhertweck.seatreservation.management.service.AreaService;
 import de.felixhertweck.seatreservation.model.entity.Roles;
-import de.felixhertweck.seatreservation.model.entity.User;
+import de.felixhertweck.seatreservation.utils.AuthenticatedUser;
 import de.felixhertweck.seatreservation.utils.UserSecurityContext;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
@@ -71,7 +71,7 @@ public class AreaResource {
     @APIResponse(responseCode = "404", description = "Not Found: Event location not found")
     public AreaResponseDTO createArea(@Valid AreaRequestDTO areaRequestDTO) {
         LOG.debugf("Received POST request to /api/manager/areas to create a new area.");
-        User currentUser = userSecurityContext.getCurrentUser();
+        AuthenticatedUser currentUser = userSecurityContext.getAuthenticatedUser();
         return areaService.createArea(areaRequestDTO, currentUser);
     }
 
@@ -97,7 +97,7 @@ public class AreaResource {
         if (eventLocationId == null) {
             throw new IllegalArgumentException("eventLocationId query parameter is required");
         }
-        User currentUser = userSecurityContext.getCurrentUser();
+        AuthenticatedUser currentUser = userSecurityContext.getAuthenticatedUser();
         return areaService.findAreasByLocation(eventLocationId, currentUser);
     }
 
@@ -116,7 +116,7 @@ public class AreaResource {
             description = "Not Found: Area with specified ID not found for the current manager")
     public AreaResponseDTO getManagerAreaById(@PathParam("id") Long id) {
         LOG.debugf("Received GET request to /api/manager/areas/%d.", id);
-        User currentUser = userSecurityContext.getCurrentUser();
+        AuthenticatedUser currentUser = userSecurityContext.getAuthenticatedUser();
         return areaService.findAreaByIdForManager(id, currentUser);
     }
 
@@ -136,7 +136,7 @@ public class AreaResource {
     public AreaResponseDTO updateManagerArea(
             @PathParam("id") Long id, @Valid AreaRequestDTO areaRequestDTO) {
         LOG.debugf("Received PUT request to /api/manager/areas/%d to update area.", id);
-        User currentUser = userSecurityContext.getCurrentUser();
+        AuthenticatedUser currentUser = userSecurityContext.getAuthenticatedUser();
         return areaService.updateArea(id, areaRequestDTO, currentUser);
     }
 
@@ -157,7 +157,7 @@ public class AreaResource {
         LOG.debugf(
                 "Received DELETE request to /api/manager/areas with IDs: %s",
                 ids != null ? ids : Collections.emptyList());
-        User currentUser = userSecurityContext.getCurrentUser();
+        AuthenticatedUser currentUser = userSecurityContext.getAuthenticatedUser();
         areaService.deleteAreas(ids, currentUser);
     }
 }

--- a/src/main/java/de/felixhertweck/seatreservation/management/resource/EntranceResource.java
+++ b/src/main/java/de/felixhertweck/seatreservation/management/resource/EntranceResource.java
@@ -39,7 +39,7 @@ import de.felixhertweck.seatreservation.management.dto.EntranceRequestDTO;
 import de.felixhertweck.seatreservation.management.dto.EntranceResponseDTO;
 import de.felixhertweck.seatreservation.management.service.EntranceService;
 import de.felixhertweck.seatreservation.model.entity.Roles;
-import de.felixhertweck.seatreservation.model.entity.User;
+import de.felixhertweck.seatreservation.utils.AuthenticatedUser;
 import de.felixhertweck.seatreservation.utils.UserSecurityContext;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
@@ -71,7 +71,7 @@ public class EntranceResource {
     @APIResponse(responseCode = "404", description = "Not Found: Event location not found")
     public EntranceResponseDTO createEntrance(@Valid EntranceRequestDTO entranceRequestDTO) {
         LOG.debugf("Received POST request to /api/manager/entrances to create a new entrance.");
-        User currentUser = userSecurityContext.getCurrentUser();
+        AuthenticatedUser currentUser = userSecurityContext.getAuthenticatedUser();
         return entranceService.createEntrance(entranceRequestDTO, currentUser);
     }
 
@@ -98,7 +98,7 @@ public class EntranceResource {
         if (eventLocationId == null) {
             throw new IllegalArgumentException("eventLocationId query parameter is required");
         }
-        User currentUser = userSecurityContext.getCurrentUser();
+        AuthenticatedUser currentUser = userSecurityContext.getAuthenticatedUser();
         return entranceService.findEntrancesByLocation(eventLocationId, currentUser);
     }
 
@@ -117,7 +117,7 @@ public class EntranceResource {
             description = "Not Found: Entrance with specified ID not found for the current manager")
     public EntranceResponseDTO getManagerEntranceById(@PathParam("id") Long id) {
         LOG.debugf("Received GET request to /api/manager/entrances/%d.", id);
-        User currentUser = userSecurityContext.getCurrentUser();
+        AuthenticatedUser currentUser = userSecurityContext.getAuthenticatedUser();
         return entranceService.findEntranceByIdForManager(id, currentUser);
     }
 
@@ -137,7 +137,7 @@ public class EntranceResource {
     public EntranceResponseDTO updateManagerEntrance(
             @PathParam("id") Long id, @Valid EntranceRequestDTO entranceRequestDTO) {
         LOG.debugf("Received PUT request to /api/manager/entrances/%d to update entrance.", id);
-        User currentUser = userSecurityContext.getCurrentUser();
+        AuthenticatedUser currentUser = userSecurityContext.getAuthenticatedUser();
         return entranceService.updateEntrance(id, entranceRequestDTO, currentUser);
     }
 
@@ -158,7 +158,7 @@ public class EntranceResource {
         LOG.debugf(
                 "Received DELETE request to /api/manager/entrances with IDs: %s",
                 ids != null ? ids : Collections.emptyList());
-        User currentUser = userSecurityContext.getCurrentUser();
+        AuthenticatedUser currentUser = userSecurityContext.getAuthenticatedUser();
         entranceService.deleteEntrances(ids, currentUser);
     }
 }

--- a/src/main/java/de/felixhertweck/seatreservation/management/resource/EventLocationResource.java
+++ b/src/main/java/de/felixhertweck/seatreservation/management/resource/EventLocationResource.java
@@ -40,7 +40,7 @@ import de.felixhertweck.seatreservation.management.dto.EventLocationResponseDTO;
 import de.felixhertweck.seatreservation.management.dto.EventLocationUpdateDTO;
 import de.felixhertweck.seatreservation.management.service.EventLocationService;
 import de.felixhertweck.seatreservation.model.entity.Roles;
-import de.felixhertweck.seatreservation.model.entity.User;
+import de.felixhertweck.seatreservation.utils.AuthenticatedUser;
 import de.felixhertweck.seatreservation.utils.UserSecurityContext;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
@@ -76,7 +76,7 @@ public class EventLocationResource {
             description = "Forbidden: Only MANAGER or ADMIN roles can access this resource")
     public List<EventLocationResponseDTO> getEventLocationsByCurrentManager() {
         LOG.debugf("Received GET request to /api/manager/eventlocations");
-        User currentUser = userSecurityContext.getCurrentUser();
+        AuthenticatedUser currentUser = userSecurityContext.getAuthenticatedUser();
         List<EventLocationResponseDTO> result =
                 eventLocationService.getEventLocationsByCurrentManager(currentUser);
         LOG.debugf(
@@ -101,7 +101,7 @@ public class EventLocationResource {
     public EventLocationResponseDTO createEventLocation(@Valid EventLocationRequestDTO dto) {
         LOG.debugf("Received POST request to /api/manager/eventlocations for new event location.");
         LOG.debugf("EventLocationRequestDTO received: %s", dto.toString());
-        User currentUser = userSecurityContext.getCurrentUser();
+        AuthenticatedUser currentUser = userSecurityContext.getAuthenticatedUser();
         EventLocationResponseDTO result =
                 eventLocationService.createEventLocation(dto, currentUser);
         LOG.infof("Event location '%s' created successfully.", result.name());
@@ -130,7 +130,7 @@ public class EventLocationResource {
                 "Received PUT request to /api/manager/eventlocations/%d to update event location.",
                 id);
         LOG.debugf("EventLocationRequestDTO received for ID %d: %s", id, dto.toString());
-        User currentUser = userSecurityContext.getCurrentUser();
+        AuthenticatedUser currentUser = userSecurityContext.getAuthenticatedUser();
         EventLocationResponseDTO result =
                 eventLocationService.updateEventLocation(id, dto, currentUser);
         LOG.infof("Event location with ID %d updated successfully.", id);
@@ -152,7 +152,7 @@ public class EventLocationResource {
         LOG.debugf(
                 "Received DELETE request to /api/manager/eventlocations with IDs: %s",
                 ids != null ? ids : Collections.emptyList());
-        User currentUser = userSecurityContext.getCurrentUser();
+        AuthenticatedUser currentUser = userSecurityContext.getAuthenticatedUser();
         eventLocationService.deleteEventLocation(ids, currentUser);
         LOG.debugf(
                 "Event location with IDs %s deleted successfully.",

--- a/src/main/java/de/felixhertweck/seatreservation/management/resource/EventReservationAllowanceResource.java
+++ b/src/main/java/de/felixhertweck/seatreservation/management/resource/EventReservationAllowanceResource.java
@@ -42,6 +42,7 @@ import de.felixhertweck.seatreservation.management.dto.EventUserAllowancesDto;
 import de.felixhertweck.seatreservation.management.service.EventReservationAllowanceService;
 import de.felixhertweck.seatreservation.model.entity.Roles;
 import de.felixhertweck.seatreservation.model.entity.User;
+import de.felixhertweck.seatreservation.utils.AuthenticatedUser;
 import de.felixhertweck.seatreservation.utils.UserSecurityContext;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
@@ -84,7 +85,7 @@ public class EventReservationAllowanceResource {
         LOG.debugf(
                 "Received POST request to /api/manager/reservationAllowance to set reservation"
                         + " allowance.");
-        User currentUser = userSecurityContext.getCurrentUser();
+        AuthenticatedUser currentUser = userSecurityContext.getAuthenticatedUser();
         Set<EventUserAllowancesDto> result =
                 eventReservationAllowanceService.setReservationsAllowedForUser(
                         userReservationAllowanceDTO, currentUser);
@@ -159,7 +160,7 @@ public class EventReservationAllowanceResource {
     public List<EventUserAllowancesDto> getReservationAllowances() {
         LOG.debugf(
                 "Received GET request to /api/manager/reservationAllowance to get all allowances.");
-        User currentUser = userSecurityContext.getCurrentUser();
+        AuthenticatedUser currentUser = userSecurityContext.getAuthenticatedUser();
         List<EventUserAllowancesDto> result =
                 eventReservationAllowanceService.getReservationAllowances(currentUser);
         LOG.debugf("Successfully retrieved %d reservation allowances.", result.size());

--- a/src/main/java/de/felixhertweck/seatreservation/management/resource/EventResource.java
+++ b/src/main/java/de/felixhertweck/seatreservation/management/resource/EventResource.java
@@ -40,6 +40,7 @@ import de.felixhertweck.seatreservation.management.dto.EventResponseDTO;
 import de.felixhertweck.seatreservation.management.service.EventService;
 import de.felixhertweck.seatreservation.model.entity.Roles;
 import de.felixhertweck.seatreservation.model.entity.User;
+import de.felixhertweck.seatreservation.utils.AuthenticatedUser;
 import de.felixhertweck.seatreservation.utils.UserSecurityContext;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
@@ -118,7 +119,7 @@ public class EventResource {
             description = "Forbidden: Only MANAGER or ADMIN roles can access this resource")
     public List<EventResponseDTO> getEventsByCurrentManager() {
         LOG.debugf("Received GET request to /api/manager/events to get events by current manager.");
-        User currentUser = userSecurityContext.getCurrentUser();
+        AuthenticatedUser currentUser = userSecurityContext.getAuthenticatedUser();
         List<EventResponseDTO> result = eventService.getEventsByCurrentManager(currentUser);
         LOG.debugf(
                 "Successfully responded to GET /api/manager/events with %d events.", result.size());

--- a/src/main/java/de/felixhertweck/seatreservation/management/resource/MarkerResource.java
+++ b/src/main/java/de/felixhertweck/seatreservation/management/resource/MarkerResource.java
@@ -39,7 +39,7 @@ import de.felixhertweck.seatreservation.common.dto.EventLocationMakerDTO;
 import de.felixhertweck.seatreservation.management.dto.MakerRequestDTO;
 import de.felixhertweck.seatreservation.management.service.MarkerService;
 import de.felixhertweck.seatreservation.model.entity.Roles;
-import de.felixhertweck.seatreservation.model.entity.User;
+import de.felixhertweck.seatreservation.utils.AuthenticatedUser;
 import de.felixhertweck.seatreservation.utils.UserSecurityContext;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
@@ -71,7 +71,7 @@ public class MarkerResource {
     @APIResponse(responseCode = "404", description = "Not Found: Event location not found")
     public EventLocationMakerDTO createMarker(@Valid MakerRequestDTO markerRequestDTO) {
         LOG.debugf("Received POST request to /api/manager/markers to create a new marker.");
-        User currentUser = userSecurityContext.getCurrentUser();
+        AuthenticatedUser currentUser = userSecurityContext.getAuthenticatedUser();
         return markerService.createMarker(markerRequestDTO, currentUser);
     }
 
@@ -97,7 +97,7 @@ public class MarkerResource {
         if (eventLocationId == null) {
             throw new IllegalArgumentException("eventLocationId query parameter is required");
         }
-        User currentUser = userSecurityContext.getCurrentUser();
+        AuthenticatedUser currentUser = userSecurityContext.getAuthenticatedUser();
         return markerService.findMarkersByLocation(eventLocationId, currentUser);
     }
 
@@ -116,7 +116,7 @@ public class MarkerResource {
             description = "Not Found: Marker with specified ID not found for the current manager")
     public EventLocationMakerDTO getManagerMarkerById(@PathParam("id") Long id) {
         LOG.debugf("Received GET request to /api/manager/markers/%d.", id);
-        User currentUser = userSecurityContext.getCurrentUser();
+        AuthenticatedUser currentUser = userSecurityContext.getAuthenticatedUser();
         return markerService.findMarkerByIdForManager(id, currentUser);
     }
 
@@ -136,7 +136,7 @@ public class MarkerResource {
     public EventLocationMakerDTO updateManagerMarker(
             @PathParam("id") Long id, @Valid MakerRequestDTO markerRequestDTO) {
         LOG.debugf("Received PUT request to /api/manager/markers/%d to update marker.", id);
-        User currentUser = userSecurityContext.getCurrentUser();
+        AuthenticatedUser currentUser = userSecurityContext.getAuthenticatedUser();
         return markerService.updateMarker(id, markerRequestDTO, currentUser);
     }
 
@@ -154,7 +154,7 @@ public class MarkerResource {
         LOG.debugf(
                 "Received DELETE request to /api/manager/markers with IDs: %s",
                 ids != null ? ids : Collections.emptyList());
-        User currentUser = userSecurityContext.getCurrentUser();
+        AuthenticatedUser currentUser = userSecurityContext.getAuthenticatedUser();
         markerService.deleteMarkers(ids, currentUser);
     }
 }

--- a/src/main/java/de/felixhertweck/seatreservation/management/resource/ReservationResource.java
+++ b/src/main/java/de/felixhertweck/seatreservation/management/resource/ReservationResource.java
@@ -43,6 +43,7 @@ import de.felixhertweck.seatreservation.management.dto.ReservationResponseDTO;
 import de.felixhertweck.seatreservation.management.service.ReservationService;
 import de.felixhertweck.seatreservation.model.entity.Roles;
 import de.felixhertweck.seatreservation.model.entity.User;
+import de.felixhertweck.seatreservation.utils.AuthenticatedUser;
 import de.felixhertweck.seatreservation.utils.UserSecurityContext;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
@@ -78,7 +79,7 @@ public class ReservationResource {
             description = "Forbidden: Only MANAGER or ADMIN roles can access this resource")
     public List<ReservationResponseDTO> getAllReservations() {
         LOG.debugf("Received GET request to /api/manager/reservations to get all reservations.");
-        User currentUser = userSecurityContext.getCurrentUser();
+        AuthenticatedUser currentUser = userSecurityContext.getAuthenticatedUser();
         List<ReservationResponseDTO> result = reservationService.findAllReservations(currentUser);
         LOG.debugf(
                 "Successfully responded to GET /api/manager/reservations with %d reservations.",

--- a/src/main/java/de/felixhertweck/seatreservation/management/resource/SeatResource.java
+++ b/src/main/java/de/felixhertweck/seatreservation/management/resource/SeatResource.java
@@ -39,7 +39,7 @@ import de.felixhertweck.seatreservation.common.dto.SeatDTO;
 import de.felixhertweck.seatreservation.management.dto.SeatRequestDTO;
 import de.felixhertweck.seatreservation.management.service.SeatService;
 import de.felixhertweck.seatreservation.model.entity.Roles;
-import de.felixhertweck.seatreservation.model.entity.User;
+import de.felixhertweck.seatreservation.utils.AuthenticatedUser;
 import de.felixhertweck.seatreservation.utils.UserSecurityContext;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
@@ -75,7 +75,7 @@ public class SeatResource {
                     "Conflict: Seat with this row and number already exists in this event location")
     public SeatDTO createSeat(@Valid SeatRequestDTO seatRequestDTO) {
         LOG.debugf("Received POST request to /api/manager/seats to create a new seat.");
-        User currentUser = userSecurityContext.getCurrentUser();
+        AuthenticatedUser currentUser = userSecurityContext.getAuthenticatedUser();
         SeatDTO result = seatService.createSeatManager(seatRequestDTO, currentUser);
         LOG.debugf(
                 "Seat with ID %d created successfully for event location ID %d.",
@@ -105,7 +105,7 @@ public class SeatResource {
         if (eventLocationId == null) {
             throw new IllegalArgumentException("eventLocationId query parameter is required");
         }
-        User currentUser = userSecurityContext.getCurrentUser();
+        AuthenticatedUser currentUser = userSecurityContext.getAuthenticatedUser();
         List<SeatDTO> result =
                 seatService.findSeatsForManagerByLocation(eventLocationId, currentUser);
         LOG.debugf(
@@ -128,7 +128,7 @@ public class SeatResource {
             description = "Not Found: Seat with specified ID not found for the current manager")
     public SeatDTO getManagerSeatById(@PathParam("id") Long id) {
         LOG.debugf("Received GET request to /api/manager/seats/%d.", id);
-        User currentUser = userSecurityContext.getCurrentUser();
+        AuthenticatedUser currentUser = userSecurityContext.getAuthenticatedUser();
         SeatDTO result = seatService.findSeatByIdForManager(id, currentUser);
         if (result != null) {
             LOG.debugf("Successfully retrieved seat with ID %d.", id);
@@ -158,7 +158,7 @@ public class SeatResource {
     public SeatDTO updateManagerSeat(
             @PathParam("id") Long id, @Valid SeatRequestDTO seatUpdateDTO) {
         LOG.debugf("Received PUT request to /api/manager/seats/%d to update seat.", id);
-        User currentUser = userSecurityContext.getCurrentUser();
+        AuthenticatedUser currentUser = userSecurityContext.getAuthenticatedUser();
         SeatDTO result = seatService.updateSeatForManager(id, seatUpdateDTO, currentUser);
         LOG.debugf("Seat with ID %d updated successfully.", id);
         return result;
@@ -179,7 +179,7 @@ public class SeatResource {
         LOG.debugf(
                 "Received DELETE request to /api/manager/seats with IDs: %s",
                 ids != null ? ids : Collections.emptyList());
-        User currentUser = userSecurityContext.getCurrentUser();
+        AuthenticatedUser currentUser = userSecurityContext.getAuthenticatedUser();
         seatService.deleteSeatForManager(ids, currentUser);
         LOG.debugf(
                 "Seats with IDs %s deleted successfully.",

--- a/src/main/java/de/felixhertweck/seatreservation/management/service/AreaService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/management/service/AreaService.java
@@ -33,9 +33,9 @@ import de.felixhertweck.seatreservation.management.exception.AreaInUseException;
 import de.felixhertweck.seatreservation.management.exception.AreaNotFoundException;
 import de.felixhertweck.seatreservation.model.entity.EventLocation;
 import de.felixhertweck.seatreservation.model.entity.EventLocationArea;
-import de.felixhertweck.seatreservation.model.entity.User;
 import de.felixhertweck.seatreservation.model.repository.EventLocationAreaRepository;
 import de.felixhertweck.seatreservation.model.repository.SeatRepository;
+import de.felixhertweck.seatreservation.utils.AuthenticatedUser;
 import org.jboss.logging.Logger;
 
 @ApplicationScoped
@@ -56,7 +56,8 @@ public class AreaService {
      * @param manager the manager attempting to access the areas
      * @return the areas of the event location
      */
-    public List<AreaResponseDTO> findAreasByLocation(Long eventLocationId, User manager) {
+    public List<AreaResponseDTO> findAreasByLocation(
+            Long eventLocationId, AuthenticatedUser manager) {
         EventLocation eventLocation =
                 eventLocationAccessService.findOwnedEventLocation(eventLocationId, manager);
         return areaRepository.findByEventLocation(eventLocation).stream()
@@ -71,7 +72,7 @@ public class AreaService {
      * @param manager the manager attempting to access the area
      * @return the area DTO
      */
-    public AreaResponseDTO findAreaByIdForManager(Long id, User manager) {
+    public AreaResponseDTO findAreaByIdForManager(Long id, AuthenticatedUser manager) {
         return new AreaResponseDTO(findAreaEntityById(id, manager));
     }
 
@@ -83,7 +84,7 @@ public class AreaService {
      * @return the created area DTO
      */
     @Transactional
-    public AreaResponseDTO createArea(AreaRequestDTO dto, User manager) {
+    public AreaResponseDTO createArea(AreaRequestDTO dto, AuthenticatedUser manager) {
         EventLocation eventLocation =
                 eventLocationAccessService.findOwnedEventLocation(
                         dto.getEventLocationId(), manager);
@@ -117,7 +118,7 @@ public class AreaService {
      *     still referenced by at least one seat
      */
     @Transactional
-    public AreaResponseDTO updateArea(Long id, AreaRequestDTO dto, User manager) {
+    public AreaResponseDTO updateArea(Long id, AreaRequestDTO dto, AuthenticatedUser manager) {
         EventLocationArea area = findAreaEntityById(id, manager);
         EventLocation newEventLocation =
                 eventLocationAccessService.findOwnedEventLocation(
@@ -158,7 +159,7 @@ public class AreaService {
      * @param manager the manager attempting to delete the areas
      */
     @Transactional
-    public void deleteAreas(List<Long> ids, User manager) {
+    public void deleteAreas(List<Long> ids, AuthenticatedUser manager) {
         if (ids == null || ids.isEmpty()) {
             throw new IllegalArgumentException("No area IDs provided for deletion");
         }
@@ -180,7 +181,7 @@ public class AreaService {
      * @param manager the manager attempting to access the area
      * @return the area entity
      */
-    private EventLocationArea findAreaEntityById(Long id, User manager) {
+    private EventLocationArea findAreaEntityById(Long id, AuthenticatedUser manager) {
         EventLocationArea area =
                 areaRepository
                         .findByIdWithEventLocation(id)

--- a/src/main/java/de/felixhertweck/seatreservation/management/service/EntranceService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/management/service/EntranceService.java
@@ -30,9 +30,9 @@ import de.felixhertweck.seatreservation.management.exception.EntranceInUseExcept
 import de.felixhertweck.seatreservation.management.exception.EntranceNotFoundException;
 import de.felixhertweck.seatreservation.model.entity.EventLocation;
 import de.felixhertweck.seatreservation.model.entity.EventLocationEntrance;
-import de.felixhertweck.seatreservation.model.entity.User;
 import de.felixhertweck.seatreservation.model.repository.EventLocationEntranceRepository;
 import de.felixhertweck.seatreservation.model.repository.SeatRepository;
+import de.felixhertweck.seatreservation.utils.AuthenticatedUser;
 import org.jboss.logging.Logger;
 
 @ApplicationScoped
@@ -53,7 +53,8 @@ public class EntranceService {
      * @param manager the manager attempting to access the entrances
      * @return the entrances of the event location
      */
-    public List<EntranceResponseDTO> findEntrancesByLocation(Long eventLocationId, User manager) {
+    public List<EntranceResponseDTO> findEntrancesByLocation(
+            Long eventLocationId, AuthenticatedUser manager) {
         EventLocation eventLocation =
                 eventLocationAccessService.findOwnedEventLocation(eventLocationId, manager);
         return entranceRepository.findByEventLocation(eventLocation).stream()
@@ -68,7 +69,7 @@ public class EntranceService {
      * @param manager the manager attempting to access the entrance
      * @return the entrance DTO
      */
-    public EntranceResponseDTO findEntranceByIdForManager(Long id, User manager) {
+    public EntranceResponseDTO findEntranceByIdForManager(Long id, AuthenticatedUser manager) {
         return new EntranceResponseDTO(findEntranceEntityById(id, manager));
     }
 
@@ -80,7 +81,7 @@ public class EntranceService {
      * @return the created entrance DTO
      */
     @Transactional
-    public EntranceResponseDTO createEntrance(EntranceRequestDTO dto, User manager) {
+    public EntranceResponseDTO createEntrance(EntranceRequestDTO dto, AuthenticatedUser manager) {
         EventLocation eventLocation =
                 eventLocationAccessService.findOwnedEventLocation(
                         dto.getEventLocationId(), manager);
@@ -108,7 +109,8 @@ public class EntranceService {
      *     while still referenced by at least one seat
      */
     @Transactional
-    public EntranceResponseDTO updateEntrance(Long id, EntranceRequestDTO dto, User manager) {
+    public EntranceResponseDTO updateEntrance(
+            Long id, EntranceRequestDTO dto, AuthenticatedUser manager) {
         EventLocationEntrance entrance = findEntranceEntityById(id, manager);
         EventLocation newEventLocation =
                 eventLocationAccessService.findOwnedEventLocation(
@@ -144,7 +146,7 @@ public class EntranceService {
      * @param manager the manager attempting to delete the entrances
      */
     @Transactional
-    public void deleteEntrances(List<Long> ids, User manager) {
+    public void deleteEntrances(List<Long> ids, AuthenticatedUser manager) {
         if (ids == null || ids.isEmpty()) {
             throw new IllegalArgumentException("No entrance IDs provided for deletion");
         }
@@ -166,7 +168,7 @@ public class EntranceService {
      * @param manager the manager attempting to access the entrance
      * @return the entrance entity
      */
-    private EventLocationEntrance findEntranceEntityById(Long id, User manager) {
+    private EventLocationEntrance findEntranceEntityById(Long id, AuthenticatedUser manager) {
         EventLocationEntrance entrance =
                 entranceRepository
                         .findByIdWithEventLocation(id)

--- a/src/main/java/de/felixhertweck/seatreservation/management/service/EventLocationAccessService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/management/service/EventLocationAccessService.java
@@ -24,9 +24,8 @@ import jakarta.inject.Inject;
 
 import de.felixhertweck.seatreservation.management.exception.EventLocationNotFoundException;
 import de.felixhertweck.seatreservation.model.entity.EventLocation;
-import de.felixhertweck.seatreservation.model.entity.Roles;
-import de.felixhertweck.seatreservation.model.entity.User;
 import de.felixhertweck.seatreservation.model.repository.EventLocationRepository;
+import de.felixhertweck.seatreservation.utils.AuthenticatedUser;
 
 /**
  * Central ownership check for event locations, shared by the area, entrance, marker and seat
@@ -48,7 +47,7 @@ public class EventLocationAccessService {
      * @throws EventLocationNotFoundException if no such event location exists
      * @throws SecurityException if the user neither is an ADMIN nor manages the location
      */
-    public EventLocation findOwnedEventLocation(Long eventLocationId, User user) {
+    public EventLocation findOwnedEventLocation(Long eventLocationId, AuthenticatedUser user) {
         if (eventLocationId == null) {
             throw new IllegalArgumentException("EventLocation ID must not be null");
         }
@@ -72,13 +71,13 @@ public class EventLocationAccessService {
      * @param user the user attempting to access the event location
      * @throws SecurityException if the user neither is an ADMIN nor manages the location
      */
-    public void requireAccess(EventLocation eventLocation, User user) {
-        if (user.getRoles().contains(Roles.ADMIN)) {
+    public void requireAccess(EventLocation eventLocation, AuthenticatedUser user) {
+        if (user.isAdmin()) {
             return;
         }
         // Compare by ID rather than by User#equals: the manager is a lazy association and its
         // proxy's equals() semantics are not something the authorization check should depend on.
-        if (!eventLocation.getManager().getId().equals(user.getId())) {
+        if (!eventLocation.getManager().getId().equals(user.id())) {
             throw new SecurityException("Manager does not own this EventLocation");
         }
     }

--- a/src/main/java/de/felixhertweck/seatreservation/management/service/EventLocationService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/management/service/EventLocationService.java
@@ -40,11 +40,11 @@ import de.felixhertweck.seatreservation.model.entity.EventLocation;
 import de.felixhertweck.seatreservation.model.entity.EventLocationArea;
 import de.felixhertweck.seatreservation.model.entity.EventLocationEntrance;
 import de.felixhertweck.seatreservation.model.entity.EventLocationMarker;
-import de.felixhertweck.seatreservation.model.entity.Roles;
 import de.felixhertweck.seatreservation.model.entity.Seat;
-import de.felixhertweck.seatreservation.model.entity.User;
 import de.felixhertweck.seatreservation.model.repository.EventLocationRepository;
 import de.felixhertweck.seatreservation.model.repository.SeatRepository;
+import de.felixhertweck.seatreservation.model.repository.UserRepository;
+import de.felixhertweck.seatreservation.utils.AuthenticatedUser;
 import org.jboss.logging.Logger;
 
 @ApplicationScoped
@@ -54,6 +54,7 @@ public class EventLocationService {
 
     @Inject EventLocationRepository eventLocationRepository;
     @Inject SeatRepository seatRepository;
+    @Inject UserRepository userRepository;
 
     /**
      * Validates that the user has permission to manage the given event location. Permission is
@@ -63,9 +64,8 @@ public class EventLocationService {
      * @param manager The user attempting the operation
      * @throws SecurityException If the user is not authorized
      */
-    private void validateManagerPermission(EventLocation location, User manager) {
-        if (!location.getManager().id.equals(manager.getId())
-                && !manager.getRoles().contains(Roles.ADMIN)) {
+    private void validateManagerPermission(EventLocation location, AuthenticatedUser manager) {
+        if (!location.getManager().id.equals(manager.id()) && !manager.isAdmin()) {
             throw new SecurityException("User is not the manager of this location");
         }
     }
@@ -77,22 +77,22 @@ public class EventLocationService {
      *
      * @return A list of DTOs representing the EventLocations.
      */
-    public List<EventLocationResponseDTO> getEventLocationsByCurrentManager(User manager) {
-        LOG.debugf(
-                "Attempting to retrieve event locations for manager: %s (ID: %d)",
-                manager.id, manager.getId());
+    public List<EventLocationResponseDTO> getEventLocationsByCurrentManager(
+            AuthenticatedUser manager) {
+        LOG.debugf("Attempting to retrieve event locations for manager ID: %d", manager.id());
         List<EventLocation> eventLocations;
-        if (manager.getRoles().contains(Roles.ADMIN)) {
+        if (manager.isAdmin()) {
             LOG.debug("User is ADMIN, listing all event locations.");
             eventLocations = eventLocationRepository.listAll();
         } else {
-            LOG.debugf(
-                    "User is MANAGER, listing event locations for manager ID: %d", manager.getId());
-            eventLocations = eventLocationRepository.findByManager(manager);
+            LOG.debugf("User is MANAGER, listing event locations for manager ID: %d", manager.id());
+            eventLocations =
+                    eventLocationRepository.findByManager(
+                            userRepository.getReference(manager.id()));
         }
         LOG.debugf(
-                "Retrieved %d event locations for manager: %s (ID: %d)",
-                eventLocations.size(), manager.id, manager.getId());
+                "Retrieved %d event locations for manager ID: %d",
+                eventLocations.size(), manager.id());
         return eventLocations.stream()
                 .map(EventLocationResponseDTO::new)
                 .collect(Collectors.toList());
@@ -105,26 +105,29 @@ public class EventLocationService {
      * @return A DTO representing the newly created EventLocation.
      */
     @Transactional
-    public EventLocationResponseDTO createEventLocation(EventLocationRequestDTO dto, User manager)
+    public EventLocationResponseDTO createEventLocation(
+            EventLocationRequestDTO dto, AuthenticatedUser manager)
             throws IllegalArgumentException {
         LOG.debugf(
                 "Attempting to create event location with name: %s, address: %s, capacity: %d for"
-                        + " manager: %s (ID: %d)",
-                dto.getName(), dto.getAddress(), dto.getCapacity(), manager.id, manager.getId());
+                        + " manager ID: %d",
+                dto.getName(), dto.getAddress(), dto.getCapacity(), manager.id());
         if (dto.getName() == null
                 || dto.getName().trim().isEmpty()
                 || dto.getAddress() == null
                 || dto.getAddress().trim().isEmpty()
                 || dto.getCapacity() == null
                 || dto.getCapacity() <= 0) {
-            LOG.warnf(
-                    "Invalid EventLocation data provided by manager: %s (ID: %d)",
-                    manager.id, manager.getId());
+            LOG.warnf("Invalid EventLocation data provided by manager ID: %d", manager.id());
             throw new IllegalArgumentException("Invalid EventLocation data provided.");
         }
 
         EventLocation location =
-                new EventLocation(dto.getName(), dto.getAddress(), manager, dto.getCapacity());
+                new EventLocation(
+                        dto.getName(),
+                        dto.getAddress(),
+                        userRepository.getReference(manager.id()),
+                        dto.getCapacity());
         // Set markers after location is created to avoid circular dependency
         location.setMarkers(convertToMarkerEntities(dto.getmarkers(), location));
         Map<String, EventLocationArea> areasByName = new LinkedHashMap<>();
@@ -161,8 +164,8 @@ public class EventLocationService {
         }
 
         LOG.infof(
-                "Event location '%s' (ID: %d) created successfully by manager: %s (ID: %d)",
-                location.getName(), location.getId(), manager.id, manager.getId());
+                "Event location '%s' (ID: %d) created successfully by manager ID: %d",
+                location.getName(), location.getId(), manager.id());
         return new EventLocationResponseDTO(location);
     }
 
@@ -178,11 +181,11 @@ public class EventLocationService {
      */
     @Transactional
     public EventLocationResponseDTO updateEventLocation(
-            Long id, EventLocationUpdateDTO dto, User manager)
+            Long id, EventLocationUpdateDTO dto, AuthenticatedUser manager)
             throws IllegalArgumentException, SecurityException {
         LOG.debugf(
-                "Attempting to update event location with ID: %d for manager: %s (ID: %d)",
-                id, manager.id, manager.getId());
+                "Attempting to update event location with ID: %d for manager ID: %d",
+                id, manager.id());
         EventLocation location =
                 eventLocationRepository
                         .findByIdOptional(id)
@@ -190,8 +193,8 @@ public class EventLocationService {
                                 () -> {
                                     LOG.warnf(
                                             "EventLocation with ID %d not found for update by"
-                                                    + " manager: %s (ID: %d)",
-                                            id, manager.id, manager.getId());
+                                                    + " manager ID: %d",
+                                            id, manager.id());
                                     return new EventLocationNotFoundException(
                                             "EventLocation with id " + id + " not found");
                                 });
@@ -200,8 +203,8 @@ public class EventLocationService {
             validateManagerPermission(location, manager);
         } catch (SecurityException e) {
             LOG.warnf(
-                    "user ID: %d (ID: %d) is not authorized to update event location with ID %d.",
-                    manager.id, manager.getId(), id);
+                    "manager ID: %d is not authorized to update event location with ID %d.",
+                    manager.id(), id);
             throw e;
         }
 
@@ -221,8 +224,8 @@ public class EventLocationService {
 
         eventLocationRepository.persist(location);
         LOG.infof(
-                "Event location '%s' (ID: %d) updated successfully by manager: %s (ID: %d)",
-                location.getName(), location.getId(), manager.id, manager.getId());
+                "Event location '%s' (ID: %d) updated successfully by manager ID: %d",
+                location.getName(), location.getId(), manager.id());
         return new EventLocationResponseDTO(location);
     }
 
@@ -363,18 +366,16 @@ public class EventLocationService {
      * @throws SecurityException If the user is not authorized to delete the EventLocation.
      */
     @Transactional
-    public void deleteEventLocation(List<Long> ids, User manager)
+    public void deleteEventLocation(List<Long> ids, AuthenticatedUser manager)
             throws IllegalArgumentException, SecurityException {
         if (ids == null || ids.isEmpty()) {
-            LOG.warnf(
-                    "No event locations to delete for manager: %s (ID: %d)",
-                    manager.id, manager.getId());
+            LOG.warnf("No event locations to delete for manager ID: %d", manager.id());
             throw new IllegalArgumentException("No event location IDs provided for deletion.");
         }
 
         LOG.debugf(
-                "Attempting to delete event locations with IDs: %s for manager: %s (ID: %d)",
-                ids, manager.id, manager.getId());
+                "Attempting to delete event locations with IDs: %s for manager ID: %d",
+                ids, manager.id());
 
         for (Long id : ids) {
             EventLocation location =
@@ -384,8 +385,8 @@ public class EventLocationService {
                                     () -> {
                                         LOG.warnf(
                                                 "EventLocation with ID %d not found for deletion by"
-                                                        + " manager: %s (ID: %d)",
-                                                id, manager.id, manager.getId());
+                                                        + " manager ID: %d",
+                                                id, manager.id());
                                         return new EventLocationNotFoundException(
                                                 "EventLocation with id " + id + " not found");
                                     });
@@ -394,14 +395,13 @@ public class EventLocationService {
                 validateManagerPermission(location, manager);
             } catch (SecurityException e) {
                 LOG.warnf(
-                        "user ID: %d (ID: %d) is not authorized to delete event location with ID"
-                                + " %d.",
-                        manager.id, manager.getId(), id);
+                        "manager ID: %d is not authorized to delete event location with ID %d.",
+                        manager.id(), id);
                 throw e;
             }
 
             eventLocationRepository.delete(location);
         }
-        LOG.infof("Event locations %s deleted successfully by manager: %s", ids, manager.id);
+        LOG.infof("Event locations %s deleted successfully by manager ID: %d", ids, manager.id());
     }
 }

--- a/src/main/java/de/felixhertweck/seatreservation/management/service/EventReservationAllowanceService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/management/service/EventReservationAllowanceService.java
@@ -39,6 +39,7 @@ import de.felixhertweck.seatreservation.model.entity.User;
 import de.felixhertweck.seatreservation.model.repository.EventRepository;
 import de.felixhertweck.seatreservation.model.repository.EventUserAllowanceRepository;
 import de.felixhertweck.seatreservation.model.repository.UserRepository;
+import de.felixhertweck.seatreservation.utils.AuthenticatedUser;
 import org.jboss.logging.Logger;
 
 @ApplicationScoped
@@ -63,23 +64,21 @@ public class EventReservationAllowanceService {
      */
     @Transactional
     public Set<EventUserAllowancesDto> setReservationsAllowedForUser(
-            EventUserAllowancesCreateDto dto, User manager)
+            EventUserAllowancesCreateDto dto, AuthenticatedUser manager)
             throws EventNotFoundException, UserNotFoundException {
         LOG.debugf(
-                "Attempting to set reservation allowance for user IDs: %s, event ID: %d by manager:"
-                        + " %s (ID: %d)",
+                "Attempting to set reservation allowance for user IDs: %s, event ID: %d by manager"
+                        + " ID: %d",
                 dto.getUserIds().stream().map(Object::toString).collect(Collectors.joining(", ")),
                 dto.getEventId(),
-                manager.id,
-                manager.getId());
+                manager.id());
         Event event = getEventById(dto.getEventId());
 
-        if (!event.getManager().id.equals(manager.getId())
-                && !manager.getRoles().contains(Roles.ADMIN)) {
+        if (!event.getManager().id.equals(manager.id()) && !manager.isAdmin()) {
             LOG.warnf(
-                    "user ID: %d (ID: %d) is not authorized to set reservation allowance for event"
-                            + " ID %d.",
-                    manager.id, manager.getId(), dto.getEventId());
+                    "manager ID: %d is not authorized to set reservation allowance for event ID"
+                            + " %d.",
+                    manager.id(), dto.getEventId());
             throw new SecurityException("User is not the manager of this event");
         }
 
@@ -110,13 +109,12 @@ public class EventReservationAllowanceService {
                 "Successfully set reservation allowance for user IDs %s and event ID %d",
                 dto.getUserIds(), dto.getEventId());
         LOG.debugf(
-                "Reservation allowance set to %d for user IDs %s and event ID %d by manager: %s"
-                        + " (ID: %d)",
+                "Reservation allowance set to %d for user IDs %s and event ID %d by manager ID:"
+                        + " %d",
                 dto.getReservationsAllowedCount(),
                 dto.getUserIds(),
                 dto.getEventId(),
-                manager.id,
-                manager.getId());
+                manager.id());
 
         return resultAllowances;
     }
@@ -223,25 +221,28 @@ public class EventReservationAllowanceService {
      * @throws SecurityException If the user is not authorized to view the allowances.
      * @return A list of DTOs representing the reservation allowances for the current user.
      */
-    public List<EventUserAllowancesDto> getReservationAllowances(User currentUser)
+    public List<EventUserAllowancesDto> getReservationAllowances(AuthenticatedUser currentUser)
             throws SecurityException {
         LOG.debugf(
-                "Attempting to retrieve all reservation allowances for user ID: %d (ID: %d)",
-                currentUser.id, currentUser.getId());
+                "Attempting to retrieve all reservation allowances for user ID: %d",
+                currentUser.id());
         List<EventUserAllowance> allowances;
-        if (currentUser.getRoles().contains(Roles.ADMIN)) {
+        if (currentUser.isAdmin()) {
             LOG.debug("User is ADMIN, listing all reservation allowances.");
             allowances = eventUserAllowanceRepository.listAll();
         } else {
             LOG.debugf(
                     "User is MANAGER, listing reservation allowances for events managed by user ID:"
                             + " %d",
-                    currentUser.getId());
-            allowances = eventUserAllowanceRepository.find("event.manager", currentUser).list();
+                    currentUser.id());
+            allowances =
+                    eventUserAllowanceRepository
+                            .find("event.manager", userRepository.getReference(currentUser.id()))
+                            .list();
         }
         LOG.debugf(
-                "Retrieved %d reservation allowances for user ID: %d (ID: %d)",
-                allowances.size(), currentUser.id, currentUser.getId());
+                "Retrieved %d reservation allowances for user ID: %d",
+                allowances.size(), currentUser.id());
         return allowances.stream().map(EventUserAllowancesDto::new).collect(Collectors.toList());
     }
 

--- a/src/main/java/de/felixhertweck/seatreservation/management/service/EventService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/management/service/EventService.java
@@ -41,6 +41,7 @@ import de.felixhertweck.seatreservation.model.entity.User;
 import de.felixhertweck.seatreservation.model.repository.EventLocationRepository;
 import de.felixhertweck.seatreservation.model.repository.EventRepository;
 import de.felixhertweck.seatreservation.model.repository.UserRepository;
+import de.felixhertweck.seatreservation.utils.AuthenticatedUser;
 import org.jboss.logging.Logger;
 
 @ApplicationScoped
@@ -287,19 +288,17 @@ public class EventService {
      *
      * @return A list of DTOs representing the Events.
      */
-    public List<EventResponseDTO> getEventsByCurrentManager(User manager) {
-        LOG.debugf(
-                "Attempting to retrieve events for manager: %s (ID: %d)",
-                manager.id, manager.getId());
+    public List<EventResponseDTO> getEventsByCurrentManager(AuthenticatedUser manager) {
+        LOG.debugf("Attempting to retrieve events for manager ID: %d", manager.id());
         List<Event> events;
         // Access control: If the user is an ADMIN, all Events are returned.
         // Otherwise, only Events belonging to this manager are returned.
-        if (manager.getRoles().contains(Roles.ADMIN)) {
+        if (manager.isAdmin()) {
             LOG.debug("User is ADMIN, listing all events.");
             events = eventRepository.listAll();
         } else {
-            LOG.debugf("User is MANAGER, listing events for manager ID: %d", manager.getId());
-            events = eventRepository.findByManager(manager);
+            LOG.debugf("User is MANAGER, listing events for manager ID: %d", manager.id());
+            events = eventRepository.findByManager(userRepository.getReference(manager.id()));
         }
         return events.stream().map(EventResponseDTO::new).collect(Collectors.toList());
     }

--- a/src/main/java/de/felixhertweck/seatreservation/management/service/MarkerService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/management/service/MarkerService.java
@@ -29,8 +29,8 @@ import de.felixhertweck.seatreservation.management.dto.MakerRequestDTO;
 import de.felixhertweck.seatreservation.management.exception.MarkerNotFoundException;
 import de.felixhertweck.seatreservation.model.entity.EventLocation;
 import de.felixhertweck.seatreservation.model.entity.EventLocationMarker;
-import de.felixhertweck.seatreservation.model.entity.User;
 import de.felixhertweck.seatreservation.model.repository.EventLocationMarkerRepository;
+import de.felixhertweck.seatreservation.utils.AuthenticatedUser;
 import org.jboss.logging.Logger;
 
 @ApplicationScoped
@@ -49,7 +49,8 @@ public class MarkerService {
      * @param manager the manager attempting to access the markers
      * @return the markers of the event location
      */
-    public List<EventLocationMakerDTO> findMarkersByLocation(Long eventLocationId, User manager) {
+    public List<EventLocationMakerDTO> findMarkersByLocation(
+            Long eventLocationId, AuthenticatedUser manager) {
         EventLocation eventLocation =
                 eventLocationAccessService.findOwnedEventLocation(eventLocationId, manager);
         return markerRepository.findByEventLocation(eventLocation).stream()
@@ -64,7 +65,7 @@ public class MarkerService {
      * @param manager the manager attempting to access the marker
      * @return the marker DTO
      */
-    public EventLocationMakerDTO findMarkerByIdForManager(Long id, User manager) {
+    public EventLocationMakerDTO findMarkerByIdForManager(Long id, AuthenticatedUser manager) {
         return new EventLocationMakerDTO(findMarkerEntityById(id, manager));
     }
 
@@ -76,7 +77,7 @@ public class MarkerService {
      * @return the created marker DTO
      */
     @Transactional
-    public EventLocationMakerDTO createMarker(MakerRequestDTO dto, User manager) {
+    public EventLocationMakerDTO createMarker(MakerRequestDTO dto, AuthenticatedUser manager) {
         EventLocation eventLocation =
                 eventLocationAccessService.findOwnedEventLocation(
                         dto.getEventLocationId(), manager);
@@ -106,7 +107,8 @@ public class MarkerService {
      * @return the updated marker DTO
      */
     @Transactional
-    public EventLocationMakerDTO updateMarker(Long id, MakerRequestDTO dto, User manager) {
+    public EventLocationMakerDTO updateMarker(
+            Long id, MakerRequestDTO dto, AuthenticatedUser manager) {
         EventLocationMarker marker = findMarkerEntityById(id, manager);
         EventLocation newEventLocation =
                 eventLocationAccessService.findOwnedEventLocation(
@@ -131,7 +133,7 @@ public class MarkerService {
      * @param manager the manager attempting to delete the markers
      */
     @Transactional
-    public void deleteMarkers(List<Long> ids, User manager) {
+    public void deleteMarkers(List<Long> ids, AuthenticatedUser manager) {
         if (ids == null || ids.isEmpty()) {
             throw new IllegalArgumentException("No marker IDs provided for deletion");
         }
@@ -149,7 +151,7 @@ public class MarkerService {
      * @param manager the manager attempting to access the marker
      * @return the marker entity
      */
-    private EventLocationMarker findMarkerEntityById(Long id, User manager) {
+    private EventLocationMarker findMarkerEntityById(Long id, AuthenticatedUser manager) {
         EventLocationMarker marker =
                 markerRepository
                         .findByIdWithEventLocation(id)

--- a/src/main/java/de/felixhertweck/seatreservation/management/service/ReservationService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/management/service/ReservationService.java
@@ -54,6 +54,7 @@ import de.felixhertweck.seatreservation.model.repository.EventUserAllowanceRepos
 import de.felixhertweck.seatreservation.model.repository.ReservationRepository;
 import de.felixhertweck.seatreservation.model.repository.SeatRepository;
 import de.felixhertweck.seatreservation.model.repository.UserRepository;
+import de.felixhertweck.seatreservation.utils.AuthenticatedUser;
 import de.felixhertweck.seatreservation.utils.CodeGenerator;
 import de.felixhertweck.seatreservation.utils.ReservationExporter;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
@@ -84,24 +85,23 @@ public class ReservationService {
      * @throws SecurityException If the current user does not have the necessary permissions.
      * @throws UserNotFoundException If the current user cannot be found.
      */
-    public List<ReservationResponseDTO> findAllReservations(User currentUser)
+    public List<ReservationResponseDTO> findAllReservations(AuthenticatedUser currentUser)
             throws SecurityException, UserNotFoundException {
-        LOG.debugf(
-                "Attempting to retrieve all reservations for user ID: %d (ID: %d)",
-                currentUser.id, currentUser.getId());
-        if (currentUser.getRoles().contains(Roles.ADMIN)) {
+        LOG.debugf("Attempting to retrieve all reservations for user ID: %d", currentUser.id());
+        if (currentUser.isAdmin()) {
             LOG.debug("User is ADMIN, listing all reservations.");
             return reservationRepository.listAll().stream()
                     .map(ReservationResponseDTO::new)
                     .toList();
         }
         List<ReservationResponseDTO> result =
-                reservationRepository.find("event.manager", currentUser).list().stream()
+                reservationRepository
+                        .find("event.manager", userRepository.getReference(currentUser.id()))
+                        .list()
+                        .stream()
                         .map(ReservationResponseDTO::new)
                         .toList();
-        LOG.debugf(
-                "Retrieved %d reservations for manager: %s (ID: %d)",
-                result.size(), currentUser.id, currentUser.getId());
+        LOG.debugf("Retrieved %d reservations for manager ID: %d", result.size(), currentUser.id());
         return result;
     }
 

--- a/src/main/java/de/felixhertweck/seatreservation/management/service/SeatService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/management/service/SeatService.java
@@ -30,12 +30,11 @@ import de.felixhertweck.seatreservation.management.exception.SeatNotFoundExcepti
 import de.felixhertweck.seatreservation.model.entity.EventLocation;
 import de.felixhertweck.seatreservation.model.entity.EventLocationArea;
 import de.felixhertweck.seatreservation.model.entity.EventLocationEntrance;
-import de.felixhertweck.seatreservation.model.entity.Roles;
 import de.felixhertweck.seatreservation.model.entity.Seat;
-import de.felixhertweck.seatreservation.model.entity.User;
 import de.felixhertweck.seatreservation.model.repository.EventLocationAreaRepository;
 import de.felixhertweck.seatreservation.model.repository.EventLocationEntranceRepository;
 import de.felixhertweck.seatreservation.model.repository.SeatRepository;
+import de.felixhertweck.seatreservation.utils.AuthenticatedUser;
 import org.jboss.logging.Logger;
 
 @ApplicationScoped
@@ -61,12 +60,12 @@ public class SeatService {
      * @throws SecurityException if the manager does not own the event location
      */
     @Transactional
-    public SeatDTO createSeatManager(SeatRequestDTO dto, User manager)
+    public SeatDTO createSeatManager(SeatRequestDTO dto, AuthenticatedUser manager)
             throws IllegalArgumentException, SecurityException {
         LOG.debugf(
-                "Attempting to create seat with number: %s for event location ID: %d by manager: %s"
-                        + " (ID: %d)",
-                dto.getSeatNumber(), dto.getEventLocationId(), manager.id, manager.getId());
+                "Attempting to create seat with number: %s for event location ID: %d by manager"
+                        + " ID: %d",
+                dto.getSeatNumber(), dto.getEventLocationId(), manager.id());
         EventLocation eventLocation =
                 eventLocationAccessService.findOwnedEventLocation(
                         dto.getEventLocationId(), manager);
@@ -98,9 +97,8 @@ public class SeatService {
                 "Seat ID: %d created successfully for event location ID %d",
                 seat.id, eventLocation.getId());
         LOG.debugf(
-                "Seat with ID %d created successfully for event location ID %d by manager: %s (ID:"
-                        + " %d)",
-                seat.id, eventLocation.getId(), manager.id, manager.getId());
+                "Seat with ID %d created successfully for event location ID %d by manager ID: %d",
+                seat.id, eventLocation.getId(), manager.id());
         return new SeatDTO(seat);
     }
 
@@ -112,10 +110,11 @@ public class SeatService {
      * @param manager the manager whose seats should be retrieved
      * @return a list of seat DTOs
      */
-    public List<SeatDTO> findSeatsForManagerByLocation(Long eventLocationId, User manager) {
+    public List<SeatDTO> findSeatsForManagerByLocation(
+            Long eventLocationId, AuthenticatedUser manager) {
         LOG.debugf(
-                "Attempting to retrieve seats for event location ID: %d for manager: %s (ID: %d)",
-                eventLocationId, manager.id, manager.getId());
+                "Attempting to retrieve seats for event location ID: %d for manager ID: %d",
+                eventLocationId, manager.id());
         EventLocation eventLocation =
                 eventLocationAccessService.findOwnedEventLocation(eventLocationId, manager);
         List<SeatDTO> result =
@@ -123,8 +122,8 @@ public class SeatService {
                         .map(SeatDTO::new)
                         .toList();
         LOG.debugf(
-                "Retrieved %d seats for event location ID: %d for manager: %s (ID: %d)",
-                result.size(), eventLocationId, manager.id, manager.getId());
+                "Retrieved %d seats for event location ID: %d for manager ID: %d",
+                result.size(), eventLocationId, manager.id());
         return result;
     }
 
@@ -138,15 +137,11 @@ public class SeatService {
      * @throws SeatNotFoundException if the seat is not found
      * @throws SecurityException if the manager does not have permission to access the seat
      */
-    public SeatDTO findSeatByIdForManager(Long id, User manager)
+    public SeatDTO findSeatByIdForManager(Long id, AuthenticatedUser manager)
             throws SeatNotFoundException, SecurityException {
-        LOG.debugf(
-                "Attempting to retrieve seat with ID: %d for manager: %s (ID: %d)",
-                id, manager.id, manager.getId());
+        LOG.debugf("Attempting to retrieve seat with ID: %d for manager ID: %d", id, manager.id());
         Seat seat = findSeatEntityById(id, manager); // This already checks for ownership
-        LOG.debugf(
-                "Successfully retrieved seat with ID %d for manager: %s (ID: %d)",
-                id, manager.id, manager.getId());
+        LOG.debugf("Successfully retrieved seat with ID %d for manager ID: %d", id, manager.id());
         return new SeatDTO(seat);
     }
 
@@ -162,11 +157,9 @@ public class SeatService {
      * @throws IllegalArgumentException if the event location is not found or seat data is invalid
      */
     @Transactional
-    public SeatDTO updateSeatForManager(Long id, SeatRequestDTO dto, User manager)
+    public SeatDTO updateSeatForManager(Long id, SeatRequestDTO dto, AuthenticatedUser manager)
             throws SeatNotFoundException, SecurityException, IllegalArgumentException {
-        LOG.debugf(
-                "Attempting to update seat with ID: %d for manager: %s (ID: %d)",
-                id, manager.id, manager.getId());
+        LOG.debugf("Attempting to update seat with ID: %d for manager ID: %d", id, manager.id());
         Seat seat = findSeatEntityById(id, manager);
 
         EventLocation newEventLocation =
@@ -210,9 +203,7 @@ public class SeatService {
         seatRepository.persist(seat);
 
         LOG.infof("Seat ID: %d updated successfully", seat.id);
-        LOG.debugf(
-                "Seat with ID %d updated successfully by manager: %s (ID: %d)",
-                id, manager.id, manager.getId());
+        LOG.debugf("Seat with ID %d updated successfully by manager ID: %d", id, manager.id());
         return new SeatDTO(seat);
     }
 
@@ -283,26 +274,20 @@ public class SeatService {
      * @throws IllegalArgumentException if the ids list is null or empty
      */
     @Transactional
-    public void deleteSeatForManager(List<Long> ids, User manager)
+    public void deleteSeatForManager(List<Long> ids, AuthenticatedUser manager)
             throws SecurityException, IllegalArgumentException {
         if (ids == null || ids.isEmpty()) {
-            LOG.warnf(
-                    "No seat IDs provided for deletion by manager: %s (ID: %d)",
-                    manager.id, manager.getId());
+            LOG.warnf("No seat IDs provided for deletion by manager ID: %d", manager.id());
             throw new IllegalArgumentException("No seat IDs provided for deletion");
         }
 
-        LOG.debugf(
-                "Attempting to delete seats with IDs: %s for manager: %s (ID: %d)",
-                ids, manager.id, manager.getId());
+        LOG.debugf("Attempting to delete seats with IDs: %s for manager ID: %d", ids, manager.id());
         for (Long id : ids) {
             Seat seat = findSeatEntityById(id, manager); // This already checks for ownership
             seatRepository.delete(seat);
             LOG.infof("Seat ID: %d deleted successfully", seat.id);
         }
-        LOG.debugf(
-                "Seats with IDs %s deleted successfully by manager: %s (ID: %d)",
-                ids, manager.id, manager.getId());
+        LOG.debugf("Seats with IDs %s deleted successfully by manager ID: %d", ids, manager.id());
     }
 
     /**
@@ -315,11 +300,10 @@ public class SeatService {
      * @throws SeatNotFoundException if the seat is not found
      * @throws SecurityException if the user does not have permission to access the seat
      */
-    public Seat findSeatEntityById(Long id, User currentUser)
+    public Seat findSeatEntityById(Long id, AuthenticatedUser currentUser)
             throws SeatNotFoundException, SecurityException {
         LOG.debugf(
-                "Attempting to find seat entity by ID: %d for user ID: %d (ID: %d)",
-                id, currentUser.id, currentUser.getId());
+                "Attempting to find seat entity by ID: %d for user ID: %d", id, currentUser.id());
         // Check if user has access to linked location
         Seat seat =
                 seatRepository
@@ -327,26 +311,24 @@ public class SeatService {
                         .orElseThrow(
                                 () -> {
                                     LOG.warnf(
-                                            "Seat with ID %d not found for user ID: %d (ID: %d)",
-                                            id, currentUser.id, currentUser.getId());
+                                            "Seat with ID %d not found for user ID: %d",
+                                            id, currentUser.id());
                                     return new SeatNotFoundException(
                                             "Seat with id " + id + " not found");
                                 });
 
-        if (currentUser.getRoles().contains(Roles.ADMIN)) {
+        if (currentUser.isAdmin()) {
             LOG.debugf("User is ADMIN, allowing access to seat ID %d.", id);
             return seat; // Admin can access any seat
         }
 
-        if (!seat.getLocation().getManager().getId().equals(currentUser.getId())) {
+        if (!seat.getLocation().getManager().getId().equals(currentUser.id())) {
             LOG.warnf(
-                    "user ID: %d (ID: %d) does not have permission to access seat ID %d.",
-                    currentUser.id, currentUser.getId(), id);
+                    "user ID: %d does not have permission to access seat ID %d.",
+                    currentUser.id(), id);
             throw new SecurityException("You do not have permission to access this seat");
         }
-        LOG.debugf(
-                "user ID: %d (ID: %d) has permission to access seat ID %d.",
-                currentUser.id, currentUser.getId(), id);
+        LOG.debugf("user ID: %d has permission to access seat ID %d.", currentUser.id(), id);
         return seat;
     }
 }

--- a/src/main/java/de/felixhertweck/seatreservation/model/repository/UserRepository.java
+++ b/src/main/java/de/felixhertweck/seatreservation/model/repository/UserRepository.java
@@ -95,4 +95,16 @@ public class UserRepository implements PanacheRepository<User> {
         LOG.debugf("Found %d users with specified email.", users.size());
         return users;
     }
+
+    /**
+     * Returns a lazy reference to the user with the given ID, without hitting the database. Safe to
+     * use for ID comparisons and as a foreign-key parameter in queries/relations; accessing any
+     * other field triggers a full load.
+     *
+     * @param id the user ID
+     * @return an uninitialized proxy for the user with the given ID
+     */
+    public User getReference(Long id) {
+        return getEntityManager().getReference(User.class, id);
+    }
 }

--- a/src/main/java/de/felixhertweck/seatreservation/reservation/resource/EventResource.java
+++ b/src/main/java/de/felixhertweck/seatreservation/reservation/resource/EventResource.java
@@ -28,9 +28,10 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 
 import de.felixhertweck.seatreservation.model.entity.Roles;
+import de.felixhertweck.seatreservation.model.entity.User;
 import de.felixhertweck.seatreservation.reservation.dto.UserEventResponseDTO;
 import de.felixhertweck.seatreservation.reservation.service.EventService;
-import io.quarkus.security.identity.SecurityIdentity;
+import de.felixhertweck.seatreservation.utils.UserSecurityContext;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
@@ -46,7 +47,7 @@ public class EventResource {
 
     @Inject EventService eventService;
 
-    @Inject SecurityIdentity securityIdentity;
+    @Inject UserSecurityContext userSecurityContext;
 
     @GET
     @APIResponse(
@@ -62,11 +63,10 @@ public class EventResource {
     @APIResponse(
             responseCode = "403",
             description = "Forbidden: Only authenticated users can access this resource")
-    @APIResponse(responseCode = "404", description = "Not Found: User not found")
     public List<UserEventResponseDTO> getEvents() {
-        String username = securityIdentity.getPrincipal().getName();
+        User currentUser = userSecurityContext.getCurrentUserReference();
         LOG.debug("Received GET request to /api/user/events.");
-        List<UserEventResponseDTO> events = eventService.getEventsForCurrentUser(username);
+        List<UserEventResponseDTO> events = eventService.getEventsForCurrentUser(currentUser);
         LOG.debugf("Returning %d events.", events.size());
         return events;
     }

--- a/src/main/java/de/felixhertweck/seatreservation/reservation/resource/ReservationResource.java
+++ b/src/main/java/de/felixhertweck/seatreservation/reservation/resource/ReservationResource.java
@@ -76,7 +76,7 @@ public class ReservationResource {
             responseCode = "403",
             description = "Forbidden: Only authenticated users can access this resource")
     public List<UserReservationResponseDTO> getMyReservations() {
-        User currentUser = userSecurityContext.getCurrentUser();
+        User currentUser = userSecurityContext.getCurrentUserReference();
         LOG.debugf(
                 "Received GET request to /api/user/reservations for user ID: %d", currentUser.id);
         List<UserReservationResponseDTO> reservations =

--- a/src/main/java/de/felixhertweck/seatreservation/reservation/service/EventService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/reservation/service/EventService.java
@@ -26,11 +26,9 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
 
-import de.felixhertweck.seatreservation.common.exception.UserNotFoundException;
 import de.felixhertweck.seatreservation.model.entity.User;
 import de.felixhertweck.seatreservation.model.repository.EventUserAllowanceRepository;
 import de.felixhertweck.seatreservation.model.repository.ReservationRepository;
-import de.felixhertweck.seatreservation.model.repository.UserRepository;
 import de.felixhertweck.seatreservation.reservation.dto.UserEventResponseDTO;
 import org.jboss.logging.Logger;
 
@@ -39,21 +37,17 @@ public class EventService {
 
     private static final Logger LOG = Logger.getLogger(EventService.class);
 
-    @Inject UserRepository userRepository;
     @Inject EventUserAllowanceRepository eventUserAllowanceRepository;
     @Inject ReservationRepository reservationRepository;
 
+    /**
+     * @param user a reference to the current user (id only, e.g. from {@code
+     *     UserSecurityContext#getCurrentUserReference()}); only used as a foreign-key query
+     *     parameter, never dereferenced beyond its ID
+     */
     @Transactional
-    public List<UserEventResponseDTO> getEventsForCurrentUser(String username)
-            throws UserNotFoundException {
-        LOG.debug("Attempting to retrieve events for current user.");
-        User user = userRepository.findByUsername(username);
-
-        if (user == null) {
-            LOG.warn("User not found.");
-            throw new UserNotFoundException("User not found");
-        }
-        LOG.debugf("User %s found. Retrieving event allowances.", username);
+    public List<UserEventResponseDTO> getEventsForCurrentUser(User user) {
+        LOG.debugf("Attempting to retrieve events for current user ID: %d", user.id);
 
         Map<Long, UserEventResponseDTO> eventMap = new HashMap<>();
 
@@ -77,7 +71,7 @@ public class EventService {
                                         reservation.getEvent().getId(),
                                         new UserEventResponseDTO(reservation.getEvent(), 0)));
 
-        LOG.debugf("Returning %d events for user: %s", eventMap.size(), username);
+        LOG.debugf("Returning %d events for user ID: %d", eventMap.size(), user.id);
         return List.copyOf(eventMap.values());
     }
 }

--- a/src/main/java/de/felixhertweck/seatreservation/security/resource/AuthResource.java
+++ b/src/main/java/de/felixhertweck/seatreservation/security/resource/AuthResource.java
@@ -151,7 +151,7 @@ public class AuthResource {
             description = "Forbidden: Only authenticated users can access this resource")
     public Response logout(@CookieParam("refreshToken") String refreshToken) {
         LOG.debugf("Received logout request.");
-        User currentUser = userSecurityContext.getCurrentUser();
+        User currentUser = userSecurityContext.getCurrentUserReference();
 
         // Delete the refresh token from database
         tokenService.deleteRefreshToken(refreshToken, currentUser);
@@ -186,7 +186,7 @@ public class AuthResource {
     public Response logoutAllDevices() {
         LOG.debugf("Received logout all devices request.");
 
-        User currentUser = userSecurityContext.getCurrentUser();
+        User currentUser = userSecurityContext.getCurrentUserReference();
         tokenService.logoutAllDevices(currentUser);
 
         NewCookie jwtAccessCookie = tokenService.createNewNullCookie("jwt", true);

--- a/src/main/java/de/felixhertweck/seatreservation/security/resource/WebAuthnResource.java
+++ b/src/main/java/de/felixhertweck/seatreservation/security/resource/WebAuthnResource.java
@@ -287,7 +287,7 @@ public class WebAuthnResource {
     @Authenticated
     @APIResponse(responseCode = "200", description = "Passkeys listed")
     public List<WebAuthnCredentialDTO> listCredentials() {
-        return webAuthnService.listCredentials(userSecurityContext.getCurrentUser());
+        return webAuthnService.listCredentials(userSecurityContext.getCurrentUserReference());
     }
 
     /**
@@ -327,7 +327,7 @@ public class WebAuthnResource {
     @APIResponse(responseCode = "404", description = "Passkey not found")
     public Response renameCredential(
             @PathParam("id") Long id, @Valid WebAuthnCredentialUpdateDTO update) {
-        User user = userSecurityContext.getCurrentUser();
+        User user = userSecurityContext.getCurrentUserReference();
         boolean renamed = webAuthnService.renameCredential(user, id, update.getLabel());
         if (!renamed) {
             return Response.status(Response.Status.NOT_FOUND).build();

--- a/src/main/java/de/felixhertweck/seatreservation/security/service/TokenService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/security/service/TokenService.java
@@ -82,6 +82,7 @@ public class TokenService {
                 Jwt.upn(user.getUsername())
                         .groups(user.getRoles())
                         .claim(Claims.email, user.getEmail() != null ? user.getEmail() : "")
+                        .claim("uid", user.id)
                         .issuedAt(Instant.now())
                         .expiresIn(Duration.ofMinutes(expirationMinutes))
                         .sign();

--- a/src/main/java/de/felixhertweck/seatreservation/supervisor/resource/CheckInResource.java
+++ b/src/main/java/de/felixhertweck/seatreservation/supervisor/resource/CheckInResource.java
@@ -33,12 +33,12 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
 import de.felixhertweck.seatreservation.model.entity.Roles;
-import de.felixhertweck.seatreservation.model.entity.User;
 import de.felixhertweck.seatreservation.supervisor.dto.CheckInInfoRequestDTO;
 import de.felixhertweck.seatreservation.supervisor.dto.CheckInInfoResponseDTO;
 import de.felixhertweck.seatreservation.supervisor.dto.CheckInProcessRequestDTO;
 import de.felixhertweck.seatreservation.supervisor.dto.SupervisorEventResponseDTO;
 import de.felixhertweck.seatreservation.supervisor.service.CheckInService;
+import de.felixhertweck.seatreservation.utils.AuthenticatedUser;
 import de.felixhertweck.seatreservation.utils.UserSecurityContext;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
@@ -80,7 +80,7 @@ public class CheckInResource {
                         "Received check-in info request for user %s and event %s with %d tokens.",
                         requestDTO.userId, requestDTO.eventId, tokenCount));
 
-        User currentUser = userSecurityContext.getCurrentUser();
+        AuthenticatedUser currentUser = userSecurityContext.getAuthenticatedUser();
         CheckInInfoResponseDTO responseDto =
                 checkInService.getReservationInfos(
                         currentUser,
@@ -117,7 +117,7 @@ public class CheckInResource {
                         + " cancellations.",
                 requestDTO.userId, requestDTO.eventId, checkInCount, cancelCount);
 
-        User currentUser = userSecurityContext.getCurrentUser();
+        AuthenticatedUser currentUser = userSecurityContext.getAuthenticatedUser();
         checkInService.processCheckIn(requestDTO, currentUser);
 
         LOG.infof(
@@ -147,7 +147,7 @@ public class CheckInResource {
     @APIResponse(responseCode = "401", description = "Unauthorized")
     public List<SupervisorEventResponseDTO> getAllEvents() {
         LOG.debugf("Received request for all events for supervisor view.");
-        User currentUser = userSecurityContext.getCurrentUser();
+        AuthenticatedUser currentUser = userSecurityContext.getAuthenticatedUser();
         List<SupervisorEventResponseDTO> events =
                 checkInService.getAllEventsForSupervisor(currentUser);
         LOG.debugf("Returning %d events.", events.size());
@@ -176,7 +176,7 @@ public class CheckInResource {
     @APIResponse(responseCode = "404", description = "Event not found")
     public List<String> getUsernamesWithReservations(@PathParam("eventId") Long eventId) {
         LOG.debugf("Received request for usernames with reservations for event %d.", eventId);
-        User currentUser = userSecurityContext.getCurrentUser();
+        AuthenticatedUser currentUser = userSecurityContext.getAuthenticatedUser();
         List<String> usernames = checkInService.getUsernamesWithReservations(currentUser, eventId);
         LOG.debugf(
                 "Returning %d usernames with reservations for event %d.",
@@ -201,7 +201,7 @@ public class CheckInResource {
     public CheckInInfoResponseDTO processCheckInInfoByUsername(
             @PathParam("username") String username) {
         LOG.debug("Received check-in info request.");
-        User currentUser = userSecurityContext.getCurrentUser();
+        AuthenticatedUser currentUser = userSecurityContext.getAuthenticatedUser();
         CheckInInfoResponseDTO responseDto =
                 checkInService.getReservationInfosByUsername(currentUser, username);
         LOG.debug("Check-in info request processed successfully.");

--- a/src/main/java/de/felixhertweck/seatreservation/supervisor/resource/LiveViewResource.java
+++ b/src/main/java/de/felixhertweck/seatreservation/supervisor/resource/LiveViewResource.java
@@ -23,8 +23,8 @@ import jakarta.annotation.security.RolesAllowed;
 import jakarta.inject.Inject;
 
 import de.felixhertweck.seatreservation.model.entity.Roles;
-import de.felixhertweck.seatreservation.model.entity.User;
 import de.felixhertweck.seatreservation.supervisor.service.LiveViewService;
+import de.felixhertweck.seatreservation.utils.AuthenticatedUser;
 import de.felixhertweck.seatreservation.utils.UserSecurityContext;
 import io.quarkus.websockets.next.OnClose;
 import io.quarkus.websockets.next.OnOpen;
@@ -52,13 +52,12 @@ public class LiveViewResource {
      */
     @OnOpen
     public void onOpen(WebSocketConnection connection, @PathParam("eventId") String eventIdStr) {
-        User currentUser = userSecurityContext.getCurrentUser();
+        AuthenticatedUser currentUser = userSecurityContext.getAuthenticatedUser();
         LOG.debugf(
                 "WebSocket connection opened for event %s by user ID: %d",
-                eventIdStr, currentUser.getId());
+                eventIdStr, currentUser.id());
 
-        // Register the connection with username for authorization checks
-        webSocketService.registerConnection(eventIdStr, connection, currentUser.getUsername());
+        webSocketService.registerConnection(eventIdStr, connection, currentUser);
 
         LOG.infof("WebSocket connection successfully registered for event %s", eventIdStr);
     }
@@ -71,13 +70,12 @@ public class LiveViewResource {
      */
     @OnClose
     public void onClose(WebSocketConnection connection, @PathParam("eventId") String eventIdStr) {
-        User currentUser = userSecurityContext.getCurrentUser();
+        AuthenticatedUser currentUser = userSecurityContext.getAuthenticatedUser();
         LOG.infof(
                 "WebSocket connection closed for event %s by user ID: %d",
-                eventIdStr, currentUser.getId());
+                eventIdStr, currentUser.id());
 
-        // Unregister the connection with username for authorization checks
-        webSocketService.unregisterConnection(eventIdStr, connection, currentUser.getUsername());
+        webSocketService.unregisterConnection(eventIdStr, connection, currentUser);
 
         LOG.infof("WebSocket connection unregistered for event %s", eventIdStr);
     }

--- a/src/main/java/de/felixhertweck/seatreservation/supervisor/service/CheckInService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/supervisor/service/CheckInService.java
@@ -36,7 +36,6 @@ import de.felixhertweck.seatreservation.model.entity.Event;
 import de.felixhertweck.seatreservation.model.entity.Reservation;
 import de.felixhertweck.seatreservation.model.entity.ReservationLiveStatus;
 import de.felixhertweck.seatreservation.model.entity.ReservationStatus;
-import de.felixhertweck.seatreservation.model.entity.Roles;
 import de.felixhertweck.seatreservation.model.entity.User;
 import de.felixhertweck.seatreservation.model.repository.EventRepository;
 import de.felixhertweck.seatreservation.model.repository.ReservationRepository;
@@ -49,6 +48,7 @@ import de.felixhertweck.seatreservation.supervisor.exception.CheckInException;
 import de.felixhertweck.seatreservation.supervisor.exception.CheckInTokenNotFoundException;
 import de.felixhertweck.seatreservation.supervisor.exception.EventMismatchException;
 import de.felixhertweck.seatreservation.supervisor.exception.UserMismatchException;
+import de.felixhertweck.seatreservation.utils.AuthenticatedUser;
 import org.jboss.logging.Logger;
 
 @ApplicationScoped
@@ -77,7 +77,7 @@ public class CheckInService {
      */
     @Transactional
     public CheckInInfoResponseDTO getReservationInfos(
-            User currentUser, Long userId, Long eventId, List<String> checkInTokens)
+            AuthenticatedUser currentUser, Long userId, Long eventId, List<String> checkInTokens)
             throws UserMismatchException, EventMismatchException, CheckInTokenNotFoundException {
 
         LOG.debugf(
@@ -141,7 +141,7 @@ public class CheckInService {
      *     user/event
      */
     @Transactional
-    public void processCheckIn(CheckInProcessRequestDTO requestDTO, User currentUser)
+    public void processCheckIn(CheckInProcessRequestDTO requestDTO, AuthenticatedUser currentUser)
             throws CheckInException {
         Long eventId = requestDTO.eventId;
         if (currentUser != null && !isAuthorizedForEvent(currentUser, eventId)) {
@@ -248,7 +248,8 @@ public class CheckInService {
      * @return A list of SupervisorEventResponseDTO.
      */
     @Transactional
-    public List<SupervisorEventResponseDTO> getAllEventsForSupervisor(User currentUser) {
+    public List<SupervisorEventResponseDTO> getAllEventsForSupervisor(
+            AuthenticatedUser currentUser) {
         LOG.debug("Retrieving all events for supervisor view.");
         if (currentUser == null) {
             return eventRepository.findAll().stream()
@@ -256,12 +257,12 @@ public class CheckInService {
                     .collect(ArrayList::new, ArrayList::add, ArrayList::addAll);
         }
 
-        boolean isAdmin =
-                currentUser.getRoles() != null && currentUser.getRoles().contains(Roles.ADMIN);
         Stream<Event> authorizedEvents =
-                isAdmin
+                currentUser.isAdmin()
                         ? eventRepository.findAll().stream()
-                        : eventRepository.findAuthorizedEvents(currentUser).stream();
+                        : eventRepository
+                                .findAuthorizedEvents(userRepository.getReference(currentUser.id()))
+                                .stream();
 
         return authorizedEvents
                 .map(SupervisorEventResponseDTO::new)
@@ -283,7 +284,7 @@ public class CheckInService {
      * @return A list of strings, where each string is a username.
      */
     @Transactional
-    public List<String> getUsernamesWithReservations(User currentUser, Long eventId) {
+    public List<String> getUsernamesWithReservations(AuthenticatedUser currentUser, Long eventId) {
         LOG.debugf("Retrieving usernames with reservations for event %d.", eventId);
         if (currentUser != null && !isAuthorizedForEvent(currentUser, eventId)) {
             throw new SecurityException("User is not authorized to access event " + eventId);
@@ -310,8 +311,8 @@ public class CheckInService {
      * @throws ReservationNotFoundException if no reservations are found for the user
      */
     @Transactional
-    public CheckInInfoResponseDTO getReservationInfosByUsername(User currentUser, String username)
-            throws ReservationNotFoundException {
+    public CheckInInfoResponseDTO getReservationInfosByUsername(
+            AuthenticatedUser currentUser, String username) throws ReservationNotFoundException {
         LOG.debug("Getting reservation infos for user.");
 
         User user = userRepository.findByUsername(username);
@@ -370,18 +371,18 @@ public class CheckInService {
         }
     }
 
-    private boolean isAuthorizedForEvent(User user, Long eventId) {
+    private boolean isAuthorizedForEvent(AuthenticatedUser user, Long eventId) {
         if (user == null || eventId == null) return false;
         // If user is a supervisor for the event
-        if (eventRepository.isUserSupervisor(eventId, user.id)) return true;
+        if (eventRepository.isUserSupervisor(eventId, user.id())) return true;
         // If user is manager for the event
         Event event = eventRepository.findById(eventId);
         if (event != null
                 && event.getManager() != null
-                && Objects.equals(event.getManager().id, user.id)) {
+                && Objects.equals(event.getManager().id, user.id())) {
             return true;
         }
         // If user is admin
-        return user.getRoles() != null && user.getRoles().contains(Roles.ADMIN);
+        return user.isAdmin();
     }
 }

--- a/src/main/java/de/felixhertweck/seatreservation/supervisor/service/LiveViewService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/supervisor/service/LiveViewService.java
@@ -35,15 +35,13 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import de.felixhertweck.seatreservation.model.entity.Event;
 import de.felixhertweck.seatreservation.model.entity.EventLocation;
 import de.felixhertweck.seatreservation.model.entity.Reservation;
-import de.felixhertweck.seatreservation.model.entity.Roles;
-import de.felixhertweck.seatreservation.model.entity.User;
 import de.felixhertweck.seatreservation.model.repository.EventRepository;
 import de.felixhertweck.seatreservation.model.repository.ReservationRepository;
-import de.felixhertweck.seatreservation.model.repository.UserRepository;
 import de.felixhertweck.seatreservation.supervisor.dto.SupervisorReservationResponseDTO;
 import de.felixhertweck.seatreservation.supervisor.dto.WebsocketInitialDTO;
 import de.felixhertweck.seatreservation.supervisor.dto.WebsocketUpdateDTO;
 import de.felixhertweck.seatreservation.supervisor.exception.InvalidEventIdException;
+import de.felixhertweck.seatreservation.utils.AuthenticatedUser;
 import io.quarkus.arc.Lock;
 import io.quarkus.websockets.next.WebSocketConnection;
 import org.jboss.logging.Logger;
@@ -56,7 +54,6 @@ public class LiveViewService {
     @Inject ReservationRepository reservationRepository;
 
     @Inject EventRepository eventRepository;
-    @Inject UserRepository userRepository;
 
     // Map: eventId -> List of WebSocket Connections
     private final Map<Long, List<WebSocketConnection>> eventSubscriptions =
@@ -88,19 +85,18 @@ public class LiveViewService {
     }
 
     /**
-     * Registers a websocket connection with authorization check by username.
+     * Registers a websocket connection with an authorization check for the given user.
      *
      * @param eventIdStr the event id as string
      * @param connection websocket connection
-     * @param username current user's username
+     * @param currentUser the currently authenticated user
      * @throws InvalidEventIdException if id invalid
      */
     public void registerConnection(
-            String eventIdStr, WebSocketConnection connection, String username)
+            String eventIdStr, WebSocketConnection connection, AuthenticatedUser currentUser)
             throws InvalidEventIdException {
         long eventId = parseEventId(eventIdStr);
-        User user = userRepository.findByUsername(username);
-        if (!isAuthorizedForEvent(user, eventId)) {
+        if (!isAuthorizedForEvent(currentUser, eventId)) {
             throw new SecurityException("User is not authorized to access event " + eventId);
         }
         registerConnection(eventId, connection);
@@ -121,11 +117,10 @@ public class LiveViewService {
     }
 
     public void unregisterConnection(
-            String eventIdStr, WebSocketConnection connection, String username)
+            String eventIdStr, WebSocketConnection connection, AuthenticatedUser currentUser)
             throws InvalidEventIdException {
         long eventId = parseEventId(eventIdStr);
-        User user = userRepository.findByUsername(username);
-        if (!isAuthorizedForEvent(user, eventId)) {
+        if (!isAuthorizedForEvent(currentUser, eventId)) {
             throw new SecurityException("User is not authorized to access event " + eventId);
         }
         unregisterConnection(eventId, connection);
@@ -205,14 +200,14 @@ public class LiveViewService {
         }
     }
 
-    private boolean isAuthorizedForEvent(User user, long eventId) {
+    private boolean isAuthorizedForEvent(AuthenticatedUser user, long eventId) {
         if (user == null) return false;
-        if (eventRepository.isUserSupervisor(eventId, user.id)) return true;
+        if (eventRepository.isUserSupervisor(eventId, user.id())) return true;
         Event event = eventRepository.findById(eventId);
         if (event != null
                 && event.getManager() != null
-                && Objects.equals(event.getManager().id, user.id)) return true;
-        return user.getRoles() != null && user.getRoles().contains(Roles.ADMIN);
+                && Objects.equals(event.getManager().id, user.id())) return true;
+        return user.isAdmin();
     }
 
     /**

--- a/src/main/java/de/felixhertweck/seatreservation/utils/AuthenticatedUser.java
+++ b/src/main/java/de/felixhertweck/seatreservation/utils/AuthenticatedUser.java
@@ -1,0 +1,37 @@
+/*
+ * #%L
+ * seat-reservation
+ * %%
+ * Copyright (C) 2025 Felix Hertweck
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package de.felixhertweck.seatreservation.utils;
+
+import java.util.Set;
+
+import de.felixhertweck.seatreservation.model.entity.Roles;
+
+/**
+ * Identity and roles of the authenticated caller, derived directly from the validated JWT (id and
+ * email/upn claims, groups claim) without a database round trip. Use this wherever authorization
+ * logic only needs the user's ID and/or roles; fetch the full {@code User} entity (e.g. via {@code
+ * UserSecurityContext#getCurrentUser()}) when other fields are required.
+ */
+public record AuthenticatedUser(Long id, Set<String> roles) {
+
+    public boolean isAdmin() {
+        return roles != null && roles.contains(Roles.ADMIN);
+    }
+}

--- a/src/main/java/de/felixhertweck/seatreservation/utils/UserSecurityContext.java
+++ b/src/main/java/de/felixhertweck/seatreservation/utils/UserSecurityContext.java
@@ -27,11 +27,14 @@ import de.felixhertweck.seatreservation.common.exception.UserNotFoundException;
 import de.felixhertweck.seatreservation.model.entity.User;
 import de.felixhertweck.seatreservation.model.repository.UserRepository;
 import io.quarkus.security.identity.SecurityIdentity;
+import org.eclipse.microprofile.jwt.JsonWebToken;
 
 @ApplicationScoped
 public class UserSecurityContext {
 
     @Inject SecurityIdentity securityIdentity;
+
+    @Inject JsonWebToken jsonWebToken;
 
     @Inject UserRepository userRepository;
 
@@ -48,5 +51,29 @@ public class UserSecurityContext {
             throw new UserNotFoundException("Current user not found.");
         }
         return currentUser;
+    }
+
+    /**
+     * Builds the caller's identity and roles directly from the validated JWT claims (the {@code
+     * uid} claim and the {@code groups}/roles already resolved onto {@link SecurityIdentity}) — no
+     * database access. Use this wherever only the ID and/or roles are needed instead of {@link
+     * #getCurrentUser()}.
+     *
+     * @return the authenticated user's ID and roles
+     */
+    public AuthenticatedUser getAuthenticatedUser() {
+        Long id = Long.valueOf(jsonWebToken.getClaim("uid").toString());
+        return new AuthenticatedUser(id, securityIdentity.getRoles());
+    }
+
+    /**
+     * Returns a lazy, uninitialized reference to the current user, without hitting the database.
+     * Safe to use for ID comparisons and as a foreign-key parameter in queries/relations; accessing
+     * any other field triggers a full load.
+     *
+     * @return an uninitialized proxy for the current user
+     */
+    public User getCurrentUserReference() {
+        return userRepository.getReference(getAuthenticatedUser().id());
     }
 }

--- a/src/test/java/de/felixhertweck/seatreservation/management/ressource/AreaResourceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/management/ressource/AreaResourceTest.java
@@ -40,6 +40,9 @@ import de.felixhertweck.seatreservation.model.repository.SeatRepository;
 import de.felixhertweck.seatreservation.model.repository.UserRepository;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.security.TestSecurity;
+import io.quarkus.test.security.jwt.Claim;
+import io.quarkus.test.security.jwt.ClaimType;
+import io.quarkus.test.security.jwt.JwtSecurity;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -103,6 +106,7 @@ public class AreaResourceTest {
     @TestSecurity(
             user = "manager",
             roles = {"MANAGER"})
+    @JwtSecurity(claims = @Claim(key = "uid", value = "2", type = ClaimType.LONG))
     void testGetAreasByEventLocation() {
         given().when()
                 .queryParam("eventLocationId", testLocation.id)
@@ -146,6 +150,7 @@ public class AreaResourceTest {
     @TestSecurity(
             user = "manager",
             roles = {"MANAGER"})
+    @JwtSecurity(claims = @Claim(key = "uid", value = "2", type = ClaimType.LONG))
     void testGetAreaById() {
         given().when()
                 .get("/api/manager/areas/" + testArea.id)
@@ -158,6 +163,7 @@ public class AreaResourceTest {
     @TestSecurity(
             user = "manager",
             roles = {"MANAGER"})
+    @JwtSecurity(claims = @Claim(key = "uid", value = "2", type = ClaimType.LONG))
     void testGetAreaByIdNotFound() {
         given().when().get("/api/manager/areas/999").then().statusCode(404);
     }
@@ -166,6 +172,7 @@ public class AreaResourceTest {
     @TestSecurity(
             user = "manager",
             roles = {"MANAGER"})
+    @JwtSecurity(claims = @Claim(key = "uid", value = "2", type = ClaimType.LONG))
     void testCreateArea() {
         given().contentType("application/json")
                 .body(new AreaRequestDTO(testLocation.id, "Balkon", null))
@@ -180,6 +187,7 @@ public class AreaResourceTest {
     @TestSecurity(
             user = "manager",
             roles = {"MANAGER"})
+    @JwtSecurity(claims = @Claim(key = "uid", value = "2", type = ClaimType.LONG))
     void testCreateAreaInvalidData() {
         given().contentType("application/json")
                 .body("{\"name\":\"\"}")
@@ -193,6 +201,7 @@ public class AreaResourceTest {
     @TestSecurity(
             user = "manager",
             roles = {"MANAGER"})
+    @JwtSecurity(claims = @Claim(key = "uid", value = "2", type = ClaimType.LONG))
     void testUpdateArea() {
         given().contentType("application/json")
                 .body(new AreaRequestDTO(testLocation.id, "Loge", null))
@@ -207,6 +216,7 @@ public class AreaResourceTest {
     @TestSecurity(
             user = "manager",
             roles = {"MANAGER"})
+    @JwtSecurity(claims = @Claim(key = "uid", value = "2", type = ClaimType.LONG))
     void testUpdateAreaNotFound() {
         given().contentType("application/json")
                 .body(new AreaRequestDTO(testLocation.id, "Loge", null))
@@ -220,6 +230,7 @@ public class AreaResourceTest {
     @TestSecurity(
             user = "manager",
             roles = {"MANAGER"})
+    @JwtSecurity(claims = @Claim(key = "uid", value = "2", type = ClaimType.LONG))
     void testDeleteArea() {
         given().when()
                 .queryParam("ids", testArea.id)
@@ -232,6 +243,7 @@ public class AreaResourceTest {
     @TestSecurity(
             user = "manager",
             roles = {"MANAGER"})
+    @JwtSecurity(claims = @Claim(key = "uid", value = "2", type = ClaimType.LONG))
     void testDeleteAreaNotFound() {
         given().when().queryParam("ids", 999L).delete("/api/manager/areas").then().statusCode(404);
     }
@@ -240,6 +252,7 @@ public class AreaResourceTest {
     @TestSecurity(
             user = "manager",
             roles = {"MANAGER"})
+    @JwtSecurity(claims = @Claim(key = "uid", value = "2", type = ClaimType.LONG))
     void testDeleteAreaConflictWhenReferencedBySeat() {
         Seat seat = new Seat("A1", "Row 1", testLocation);
         seat.setArea(testArea);

--- a/src/test/java/de/felixhertweck/seatreservation/management/ressource/EntranceResourceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/management/ressource/EntranceResourceTest.java
@@ -40,6 +40,9 @@ import de.felixhertweck.seatreservation.model.repository.SeatRepository;
 import de.felixhertweck.seatreservation.model.repository.UserRepository;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.security.TestSecurity;
+import io.quarkus.test.security.jwt.Claim;
+import io.quarkus.test.security.jwt.ClaimType;
+import io.quarkus.test.security.jwt.JwtSecurity;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -103,6 +106,7 @@ public class EntranceResourceTest {
     @TestSecurity(
             user = "manager",
             roles = {"MANAGER"})
+    @JwtSecurity(claims = @Claim(key = "uid", value = "2", type = ClaimType.LONG))
     void testGetEntrancesByEventLocation() {
         given().when()
                 .queryParam("eventLocationId", testLocation.id)
@@ -146,6 +150,7 @@ public class EntranceResourceTest {
     @TestSecurity(
             user = "manager",
             roles = {"MANAGER"})
+    @JwtSecurity(claims = @Claim(key = "uid", value = "2", type = ClaimType.LONG))
     void testGetEntranceById() {
         given().when()
                 .get("/api/manager/entrances/" + testEntrance.id)
@@ -158,6 +163,7 @@ public class EntranceResourceTest {
     @TestSecurity(
             user = "manager",
             roles = {"MANAGER"})
+    @JwtSecurity(claims = @Claim(key = "uid", value = "2", type = ClaimType.LONG))
     void testGetEntranceByIdNotFound() {
         given().when().get("/api/manager/entrances/999").then().statusCode(404);
     }
@@ -166,6 +172,7 @@ public class EntranceResourceTest {
     @TestSecurity(
             user = "manager",
             roles = {"MANAGER"})
+    @JwtSecurity(claims = @Claim(key = "uid", value = "2", type = ClaimType.LONG))
     void testCreateEntrance() {
         given().contentType("application/json")
                 .body(new EntranceRequestDTO(testLocation.id, "B"))
@@ -180,6 +187,7 @@ public class EntranceResourceTest {
     @TestSecurity(
             user = "manager",
             roles = {"MANAGER"})
+    @JwtSecurity(claims = @Claim(key = "uid", value = "2", type = ClaimType.LONG))
     void testCreateEntranceInvalidData() {
         given().contentType("application/json")
                 .body("{\"name\":\"\"}")
@@ -193,6 +201,7 @@ public class EntranceResourceTest {
     @TestSecurity(
             user = "manager",
             roles = {"MANAGER"})
+    @JwtSecurity(claims = @Claim(key = "uid", value = "2", type = ClaimType.LONG))
     void testUpdateEntrance() {
         given().contentType("application/json")
                 .body(new EntranceRequestDTO(testLocation.id, "C"))
@@ -207,6 +216,7 @@ public class EntranceResourceTest {
     @TestSecurity(
             user = "manager",
             roles = {"MANAGER"})
+    @JwtSecurity(claims = @Claim(key = "uid", value = "2", type = ClaimType.LONG))
     void testUpdateEntranceNotFound() {
         given().contentType("application/json")
                 .body(new EntranceRequestDTO(testLocation.id, "C"))
@@ -220,6 +230,7 @@ public class EntranceResourceTest {
     @TestSecurity(
             user = "manager",
             roles = {"MANAGER"})
+    @JwtSecurity(claims = @Claim(key = "uid", value = "2", type = ClaimType.LONG))
     void testDeleteEntrance() {
         given().when()
                 .queryParam("ids", testEntrance.id)
@@ -232,6 +243,7 @@ public class EntranceResourceTest {
     @TestSecurity(
             user = "manager",
             roles = {"MANAGER"})
+    @JwtSecurity(claims = @Claim(key = "uid", value = "2", type = ClaimType.LONG))
     void testDeleteEntranceNotFound() {
         given().when()
                 .queryParam("ids", 999L)
@@ -244,6 +256,7 @@ public class EntranceResourceTest {
     @TestSecurity(
             user = "manager",
             roles = {"MANAGER"})
+    @JwtSecurity(claims = @Claim(key = "uid", value = "2", type = ClaimType.LONG))
     void testDeleteEntranceConflictWhenReferencedBySeat() {
         Seat seat = new Seat("A1", "Row 1", testLocation);
         seat.setEntrance(testEntrance);

--- a/src/test/java/de/felixhertweck/seatreservation/management/ressource/EventLocationResourceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/management/ressource/EventLocationResourceTest.java
@@ -37,6 +37,9 @@ import de.felixhertweck.seatreservation.model.repository.SeatRepository;
 import de.felixhertweck.seatreservation.model.repository.UserRepository;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.security.TestSecurity;
+import io.quarkus.test.security.jwt.Claim;
+import io.quarkus.test.security.jwt.ClaimType;
+import io.quarkus.test.security.jwt.JwtSecurity;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -114,6 +117,7 @@ public class EventLocationResourceTest {
     @TestSecurity(
             user = "manager",
             roles = {"MANAGER"})
+    @JwtSecurity(claims = @Claim(key = "uid", value = "2", type = ClaimType.LONG))
     void testGetEventLocationsByCurrentManager() {
         given().when()
                 .get("/api/manager/eventlocations")
@@ -126,6 +130,7 @@ public class EventLocationResourceTest {
     @TestSecurity(
             user = "manager",
             roles = {"MANAGER"})
+    @JwtSecurity(claims = @Claim(key = "uid", value = "2", type = ClaimType.LONG))
     void testCreateEventLocation() {
         given().contentType("application/json")
                 .body("{\"name\":\"New Location\",\"address\":\"123 Main St\",\"capacity\":100}")
@@ -149,6 +154,7 @@ public class EventLocationResourceTest {
     @TestSecurity(
             user = "manager",
             roles = {"MANAGER"})
+    @JwtSecurity(claims = @Claim(key = "uid", value = "2", type = ClaimType.LONG))
     void testCreateEventLocationWithEmbeddedAreasAndMarkers() {
         given().contentType("application/json")
                 .body(
@@ -169,6 +175,7 @@ public class EventLocationResourceTest {
     @TestSecurity(
             user = "manager",
             roles = {"MANAGER"})
+    @JwtSecurity(claims = @Claim(key = "uid", value = "2", type = ClaimType.LONG))
     void testCreateEventLocationInvalidData() {
         given().contentType("application/json")
                 .body("{\"name\":\"\"}")
@@ -182,6 +189,7 @@ public class EventLocationResourceTest {
     @TestSecurity(
             user = "manager",
             roles = {"MANAGER"})
+    @JwtSecurity(claims = @Claim(key = "uid", value = "2", type = ClaimType.LONG))
     void testUpdateEventLocation() {
         given().contentType("application/json")
                 .body(
@@ -198,6 +206,7 @@ public class EventLocationResourceTest {
     @TestSecurity(
             user = "manager",
             roles = {"MANAGER"})
+    @JwtSecurity(claims = @Claim(key = "uid", value = "2", type = ClaimType.LONG))
     void testUpdateEventLocationInvalidData() {
         given().contentType("application/json")
                 .body("{\"name\":\"\"}")
@@ -211,6 +220,7 @@ public class EventLocationResourceTest {
     @TestSecurity(
             user = "manager",
             roles = {"MANAGER"})
+    @JwtSecurity(claims = @Claim(key = "uid", value = "2", type = ClaimType.LONG))
     void testUpdateEventLocationNotFound() {
         given().contentType("application/json")
                 .body(
@@ -226,6 +236,7 @@ public class EventLocationResourceTest {
     @TestSecurity(
             user = "manager",
             roles = {"MANAGER"})
+    @JwtSecurity(claims = @Claim(key = "uid", value = "2", type = ClaimType.LONG))
     void testDeleteEventLocation() {
         given().when()
                 .queryParam("ids", testLocation.getId())
@@ -238,6 +249,7 @@ public class EventLocationResourceTest {
     @TestSecurity(
             user = "manager",
             roles = {"MANAGER"})
+    @JwtSecurity(claims = @Claim(key = "uid", value = "2", type = ClaimType.LONG))
     void testDeleteEventLocationNotFound() {
         given().when()
                 .queryParam("ids", 999L)
@@ -250,6 +262,7 @@ public class EventLocationResourceTest {
     @TestSecurity(
             user = "manager",
             roles = {"MANAGER"})
+    @JwtSecurity(claims = @Claim(key = "uid", value = "2", type = ClaimType.LONG))
     void testDeleteMultipleEventLocations() {
         // Create additional locations for bulk delete test
         var user = userRepository.findByUsernameOptional("manager").orElseThrow();
@@ -288,6 +301,7 @@ public class EventLocationResourceTest {
     @TestSecurity(
             user = "manager",
             roles = {"MANAGER"})
+    @JwtSecurity(claims = @Claim(key = "uid", value = "2", type = ClaimType.LONG))
     void testDeleteMultipleEventLocations_PartialNotFound() {
         given().when()
                 .queryParam("ids", testLocation.getId())
@@ -328,6 +342,7 @@ public class EventLocationResourceTest {
     @TestSecurity(
             user = "manager",
             roles = {"MANAGER"})
+    @JwtSecurity(claims = @Claim(key = "uid", value = "2", type = ClaimType.LONG))
     void testCreateEventLocationWithSeats() {
         String requestBody =
                 "{\"name\":\"New Location\",\"address\":\"123 Main"

--- a/src/test/java/de/felixhertweck/seatreservation/management/ressource/EventReservationAllowanceResourceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/management/ressource/EventReservationAllowanceResourceTest.java
@@ -20,6 +20,7 @@
 package de.felixhertweck.seatreservation.management.ressource;
 
 import java.util.Collections;
+import java.util.Set;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.is;
@@ -32,6 +33,7 @@ import de.felixhertweck.seatreservation.management.dto.EventUserAllowanceUpdateD
 import de.felixhertweck.seatreservation.management.dto.EventUserAllowancesDto;
 import de.felixhertweck.seatreservation.management.service.EventReservationAllowanceService;
 import de.felixhertweck.seatreservation.model.entity.User;
+import de.felixhertweck.seatreservation.utils.AuthenticatedUser;
 import de.felixhertweck.seatreservation.utils.UserSecurityContext;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
@@ -154,8 +156,10 @@ class EventReservationAllowanceResourceTest {
             user = "testUser",
             roles = {"MANAGER"})
     void getReservationAllowances_Success() {
-        when(userSecurityContext.getCurrentUser()).thenReturn(new User());
-        when(eventReservationAllowanceService.getReservationAllowances(any(User.class)))
+        when(userSecurityContext.getAuthenticatedUser())
+                .thenReturn(new AuthenticatedUser(1L, Set.of("MANAGER")));
+        when(eventReservationAllowanceService.getReservationAllowances(
+                        any(AuthenticatedUser.class)))
                 .thenReturn(Collections.singletonList(new EventUserAllowancesDto(1L, 1L, 2L, 5)));
 
         given().when()

--- a/src/test/java/de/felixhertweck/seatreservation/management/ressource/EventResourceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/management/ressource/EventResourceTest.java
@@ -41,6 +41,9 @@ import de.felixhertweck.seatreservation.model.repository.EventUserAllowanceRepos
 import de.felixhertweck.seatreservation.model.repository.UserRepository;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.security.TestSecurity;
+import io.quarkus.test.security.jwt.Claim;
+import io.quarkus.test.security.jwt.ClaimType;
+import io.quarkus.test.security.jwt.JwtSecurity;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -127,6 +130,7 @@ public class EventResourceTest {
     @TestSecurity(
             user = "manager",
             roles = {"MANAGER"})
+    @JwtSecurity(claims = @Claim(key = "uid", value = "2", type = ClaimType.LONG))
     void testGetEventsByCurrentManager() {
         given().when().get("/api/manager/events").then().statusCode(200).body("size()", is(1));
     }
@@ -308,6 +312,7 @@ public class EventResourceTest {
     @TestSecurity(
             user = "manager",
             roles = {"MANAGER"})
+    @JwtSecurity(claims = @Claim(key = "uid", value = "2", type = ClaimType.LONG))
     void testDeleteMultipleEvents() {
         // Create additional events for bulk delete test
         var manager = userRepository.findByUsernameOptional("manager").orElseThrow();

--- a/src/test/java/de/felixhertweck/seatreservation/management/ressource/MarkerResourceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/management/ressource/MarkerResourceTest.java
@@ -41,6 +41,9 @@ import de.felixhertweck.seatreservation.model.repository.SeatRepository;
 import de.felixhertweck.seatreservation.model.repository.UserRepository;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.security.TestSecurity;
+import io.quarkus.test.security.jwt.Claim;
+import io.quarkus.test.security.jwt.ClaimType;
+import io.quarkus.test.security.jwt.JwtSecurity;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -106,6 +109,7 @@ public class MarkerResourceTest {
     @TestSecurity(
             user = "manager",
             roles = {"MANAGER"})
+    @JwtSecurity(claims = @Claim(key = "uid", value = "2", type = ClaimType.LONG))
     void testGetMarkersByEventLocation() {
         given().when()
                 .queryParam("eventLocationId", testLocation.id)
@@ -149,6 +153,7 @@ public class MarkerResourceTest {
     @TestSecurity(
             user = "manager",
             roles = {"MANAGER"})
+    @JwtSecurity(claims = @Claim(key = "uid", value = "2", type = ClaimType.LONG))
     void testGetMarkerById() {
         given().when()
                 .get("/api/manager/markers/" + testMarker.id)
@@ -161,6 +166,7 @@ public class MarkerResourceTest {
     @TestSecurity(
             user = "manager",
             roles = {"MANAGER"})
+    @JwtSecurity(claims = @Claim(key = "uid", value = "2", type = ClaimType.LONG))
     void testGetMarkerByIdNotFound() {
         given().when().get("/api/manager/markers/999").then().statusCode(404);
     }
@@ -169,6 +175,7 @@ public class MarkerResourceTest {
     @TestSecurity(
             user = "manager",
             roles = {"MANAGER"})
+    @JwtSecurity(claims = @Claim(key = "uid", value = "2", type = ClaimType.LONG))
     void testCreateMarker() {
         given().contentType("application/json")
                 .body(new MakerRequestDTO(testLocation.id, "Stage", new CoordinateDTO(5, 5)))
@@ -183,6 +190,7 @@ public class MarkerResourceTest {
     @TestSecurity(
             user = "manager",
             roles = {"MANAGER"})
+    @JwtSecurity(claims = @Claim(key = "uid", value = "2", type = ClaimType.LONG))
     void testCreateMarkerInvalidData() {
         given().contentType("application/json")
                 .body("{\"label\":\"\"}")
@@ -196,6 +204,7 @@ public class MarkerResourceTest {
     @TestSecurity(
             user = "manager",
             roles = {"MANAGER"})
+    @JwtSecurity(claims = @Claim(key = "uid", value = "2", type = ClaimType.LONG))
     void testUpdateMarker() {
         given().contentType("application/json")
                 .body(new MakerRequestDTO(testLocation.id, "Updated", new CoordinateDTO(1, 1)))
@@ -210,6 +219,7 @@ public class MarkerResourceTest {
     @TestSecurity(
             user = "manager",
             roles = {"MANAGER"})
+    @JwtSecurity(claims = @Claim(key = "uid", value = "2", type = ClaimType.LONG))
     void testUpdateMarkerNotFound() {
         given().contentType("application/json")
                 .body(new MakerRequestDTO(testLocation.id, "Updated", new CoordinateDTO(1, 1)))
@@ -223,6 +233,7 @@ public class MarkerResourceTest {
     @TestSecurity(
             user = "manager",
             roles = {"MANAGER"})
+    @JwtSecurity(claims = @Claim(key = "uid", value = "2", type = ClaimType.LONG))
     void testDeleteMarker() {
         given().when()
                 .queryParam("ids", testMarker.id)
@@ -235,6 +246,7 @@ public class MarkerResourceTest {
     @TestSecurity(
             user = "manager",
             roles = {"MANAGER"})
+    @JwtSecurity(claims = @Claim(key = "uid", value = "2", type = ClaimType.LONG))
     void testDeleteMarkerNotFound() {
         given().when()
                 .queryParam("ids", 999L)

--- a/src/test/java/de/felixhertweck/seatreservation/management/ressource/ReservationResourceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/management/ressource/ReservationResourceTest.java
@@ -44,6 +44,9 @@ import de.felixhertweck.seatreservation.model.repository.SeatRepository;
 import de.felixhertweck.seatreservation.model.repository.UserRepository;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.security.TestSecurity;
+import io.quarkus.test.security.jwt.Claim;
+import io.quarkus.test.security.jwt.ClaimType;
+import io.quarkus.test.security.jwt.JwtSecurity;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -134,6 +137,7 @@ public class ReservationResourceTest {
     @TestSecurity(
             user = "manager",
             roles = {"MANAGER"})
+    @JwtSecurity(claims = @Claim(key = "uid", value = "2", type = ClaimType.LONG))
     void testGetAllReservations() {
         given().when()
                 .get("/api/manager/reservations")
@@ -225,6 +229,7 @@ public class ReservationResourceTest {
     @TestSecurity(
             user = "manager",
             roles = {"MANAGER"})
+    @JwtSecurity(claims = @Claim(key = "uid", value = "2", type = ClaimType.LONG))
     void testDeleteMultipleReservations() {
         // Create additional reservations for bulk delete test
         var reservation2 = new Reservation();

--- a/src/test/java/de/felixhertweck/seatreservation/management/ressource/SeatResourceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/management/ressource/SeatResourceTest.java
@@ -42,6 +42,9 @@ import de.felixhertweck.seatreservation.model.repository.SeatRepository;
 import de.felixhertweck.seatreservation.model.repository.UserRepository;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.security.TestSecurity;
+import io.quarkus.test.security.jwt.Claim;
+import io.quarkus.test.security.jwt.ClaimType;
+import io.quarkus.test.security.jwt.JwtSecurity;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -151,6 +154,7 @@ public class SeatResourceTest {
     @TestSecurity(
             user = "manager",
             roles = {"MANAGER"})
+    @JwtSecurity(claims = @Claim(key = "uid", value = "2", type = ClaimType.LONG))
     void testGetAllManagerSeats() {
         given().when()
                 .queryParam("eventLocationId", testLocation.id)
@@ -172,6 +176,7 @@ public class SeatResourceTest {
     @TestSecurity(
             user = "manager",
             roles = {"MANAGER"})
+    @JwtSecurity(claims = @Claim(key = "uid", value = "2", type = ClaimType.LONG))
     void testGetManagerSeatById() {
         given().when()
                 .get("/api/manager/seats/" + testSeat.id)
@@ -184,6 +189,7 @@ public class SeatResourceTest {
     @TestSecurity(
             user = "manager",
             roles = {"MANAGER"})
+    @JwtSecurity(claims = @Claim(key = "uid", value = "2", type = ClaimType.LONG))
     void testGetManagerSeatByIdNotFound() {
         given().when().get("/api/manager/seats/999").then().statusCode(404);
     }
@@ -192,6 +198,7 @@ public class SeatResourceTest {
     @TestSecurity(
             user = "manager",
             roles = {"MANAGER"})
+    @JwtSecurity(claims = @Claim(key = "uid", value = "2", type = ClaimType.LONG))
     void testCreateSeat() {
         given().contentType("application/json")
                 .body(
@@ -209,6 +216,7 @@ public class SeatResourceTest {
     @TestSecurity(
             user = "manager",
             roles = {"MANAGER"})
+    @JwtSecurity(claims = @Claim(key = "uid", value = "2", type = ClaimType.LONG))
     void testCreateSeatInvalidData() {
         given().contentType("application/json")
                 .body("{\"seatNumber\":\"\"}")
@@ -222,6 +230,7 @@ public class SeatResourceTest {
     @TestSecurity(
             user = "manager",
             roles = {"MANAGER"})
+    @JwtSecurity(claims = @Claim(key = "uid", value = "2", type = ClaimType.LONG))
     void testUpdateManagerSeat() {
         given().contentType("application/json")
                 .body(
@@ -238,6 +247,7 @@ public class SeatResourceTest {
     @TestSecurity(
             user = "manager",
             roles = {"MANAGER"})
+    @JwtSecurity(claims = @Claim(key = "uid", value = "2", type = ClaimType.LONG))
     void testUpdateManagerSeatEntranceAndRowArePersisted() {
         given().contentType("application/json")
                 .body(
@@ -272,6 +282,7 @@ public class SeatResourceTest {
     @TestSecurity(
             user = "manager",
             roles = {"MANAGER"})
+    @JwtSecurity(claims = @Claim(key = "uid", value = "2", type = ClaimType.LONG))
     void testCreateUpdateAndRetrieveSeatLifecycle() {
         int createdSeatId =
                 given().contentType("application/json")
@@ -325,6 +336,7 @@ public class SeatResourceTest {
     @TestSecurity(
             user = "manager",
             roles = {"MANAGER"})
+    @JwtSecurity(claims = @Claim(key = "uid", value = "2", type = ClaimType.LONG))
     void testUpdateManagerSeatNotFound() {
         given().contentType("application/json")
                 .body(
@@ -340,6 +352,7 @@ public class SeatResourceTest {
     @TestSecurity(
             user = "manager",
             roles = {"MANAGER"})
+    @JwtSecurity(claims = @Claim(key = "uid", value = "2", type = ClaimType.LONG))
     void testDeleteManagerSeat() {
         given().when()
                 .queryParam("ids", testSeat.id)
@@ -352,6 +365,7 @@ public class SeatResourceTest {
     @TestSecurity(
             user = "manager",
             roles = {"MANAGER"})
+    @JwtSecurity(claims = @Claim(key = "uid", value = "2", type = ClaimType.LONG))
     void testDeleteManagerSeatNotFound() {
         given().when().queryParam("ids", 999L).delete("/api/manager/seats").then().statusCode(404);
     }
@@ -360,6 +374,7 @@ public class SeatResourceTest {
     @TestSecurity(
             user = "manager",
             roles = {"MANAGER"})
+    @JwtSecurity(claims = @Claim(key = "uid", value = "2", type = ClaimType.LONG))
     void testDeleteMultipleSeats() {
         // Create additional seats for bulk delete test
         var seat2 = new Seat("A2", "R: 1", testLocation);
@@ -390,6 +405,7 @@ public class SeatResourceTest {
     @TestSecurity(
             user = "manager",
             roles = {"MANAGER"})
+    @JwtSecurity(claims = @Claim(key = "uid", value = "2", type = ClaimType.LONG))
     void testDeleteMultipleSeats_PartialNotFound() {
         given().when()
                 .queryParam("ids", testSeat.id)

--- a/src/test/java/de/felixhertweck/seatreservation/management/service/AreaServiceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/management/service/AreaServiceTest.java
@@ -47,6 +47,7 @@ import de.felixhertweck.seatreservation.model.entity.User;
 import de.felixhertweck.seatreservation.model.repository.EventLocationAreaRepository;
 import de.felixhertweck.seatreservation.model.repository.EventLocationRepository;
 import de.felixhertweck.seatreservation.model.repository.SeatRepository;
+import de.felixhertweck.seatreservation.utils.AuthenticatedUser;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.BeforeEach;
@@ -65,6 +66,9 @@ public class AreaServiceTest {
     private User adminUser;
     private User managerUser;
     private User regularUser;
+    private AuthenticatedUser adminAuth;
+    private AuthenticatedUser managerAuth;
+    private AuthenticatedUser regularAuth;
     private EventLocation eventLocation;
     private EventLocation otherLocation;
     private EventLocation secondOwnedLocation;
@@ -114,6 +118,10 @@ public class AreaServiceTest {
                         Set.of());
         regularUser.id = 2L;
 
+        adminAuth = new AuthenticatedUser(adminUser.id, adminUser.getRoles());
+        managerAuth = new AuthenticatedUser(managerUser.id, managerUser.getRoles());
+        regularAuth = new AuthenticatedUser(regularUser.id, regularUser.getRoles());
+
         eventLocation = new EventLocation("Stadthalle", "Hauptstraße 1", managerUser, 100);
         eventLocation.id = 1L;
         otherLocation = new EventLocation("Other Hall", "Other Address", regularUser, 50);
@@ -139,7 +147,7 @@ public class AreaServiceTest {
         AreaRequestDTO dto =
                 new AreaRequestDTO(eventLocation.id, "Balkon", List.of(new CoordinateDTO(1, 1)));
 
-        AreaResponseDTO result = areaService.createArea(dto, managerUser);
+        AreaResponseDTO result = areaService.createArea(dto, managerAuth);
 
         assertNotNull(result);
         assertEquals("Balkon", result.name());
@@ -151,7 +159,7 @@ public class AreaServiceTest {
     void createArea_Success_AsAdmin() {
         AreaRequestDTO dto = new AreaRequestDTO(eventLocation.id, "Balkon", List.of());
 
-        AreaResponseDTO result = areaService.createArea(dto, adminUser);
+        AreaResponseDTO result = areaService.createArea(dto, adminAuth);
 
         assertNotNull(result);
         verify(areaRepository, times(1)).persist(any(EventLocationArea.class));
@@ -161,7 +169,7 @@ public class AreaServiceTest {
     void createArea_Forbidden_NotManagerOfLocation() {
         AreaRequestDTO dto = new AreaRequestDTO(eventLocation.id, "Balkon", List.of());
 
-        assertThrows(SecurityException.class, () -> areaService.createArea(dto, regularUser));
+        assertThrows(SecurityException.class, () -> areaService.createArea(dto, regularAuth));
         verify(areaRepository, never()).persist(any(EventLocationArea.class));
     }
 
@@ -170,7 +178,7 @@ public class AreaServiceTest {
         AreaRequestDTO dto = new AreaRequestDTO(eventLocation.id, "  ", List.of());
 
         assertThrows(
-                IllegalArgumentException.class, () -> areaService.createArea(dto, managerUser));
+                IllegalArgumentException.class, () -> areaService.createArea(dto, managerAuth));
         verify(areaRepository, never()).persist(any(EventLocationArea.class));
     }
 
@@ -181,7 +189,7 @@ public class AreaServiceTest {
 
         assertThrows(
                 EventLocationNotFoundException.class,
-                () -> areaService.createArea(dto, managerUser));
+                () -> areaService.createArea(dto, managerAuth));
     }
 
     @Test
@@ -189,7 +197,7 @@ public class AreaServiceTest {
         when(areaRepository.findByEventLocation(eventLocation)).thenReturn(List.of(existingArea));
 
         List<AreaResponseDTO> result =
-                areaService.findAreasByLocation(eventLocation.id, managerUser);
+                areaService.findAreasByLocation(eventLocation.id, managerAuth);
 
         assertEquals(1, result.size());
         assertEquals("Parkett", result.getFirst().name());
@@ -199,7 +207,7 @@ public class AreaServiceTest {
     void findAreasByLocation_Success_AsAdmin() {
         when(areaRepository.findByEventLocation(eventLocation)).thenReturn(List.of(existingArea));
 
-        List<AreaResponseDTO> result = areaService.findAreasByLocation(eventLocation.id, adminUser);
+        List<AreaResponseDTO> result = areaService.findAreasByLocation(eventLocation.id, adminAuth);
 
         assertEquals(1, result.size());
     }
@@ -208,7 +216,7 @@ public class AreaServiceTest {
     void findAreasByLocation_Forbidden_NotOwner() {
         assertThrows(
                 SecurityException.class,
-                () -> areaService.findAreasByLocation(otherLocation.id, managerUser));
+                () -> areaService.findAreasByLocation(otherLocation.id, managerAuth));
     }
 
     @Test
@@ -217,7 +225,7 @@ public class AreaServiceTest {
 
         assertThrows(
                 EventLocationNotFoundException.class,
-                () -> areaService.findAreasByLocation(999L, managerUser));
+                () -> areaService.findAreasByLocation(999L, managerAuth));
     }
 
     @Test
@@ -225,7 +233,7 @@ public class AreaServiceTest {
         when(areaRepository.findByIdWithEventLocation(existingArea.id))
                 .thenReturn(Optional.of(existingArea));
 
-        AreaResponseDTO result = areaService.findAreaByIdForManager(existingArea.id, managerUser);
+        AreaResponseDTO result = areaService.findAreaByIdForManager(existingArea.id, managerAuth);
 
         assertEquals("Parkett", result.name());
     }
@@ -236,7 +244,7 @@ public class AreaServiceTest {
 
         assertThrows(
                 AreaNotFoundException.class,
-                () -> areaService.findAreaByIdForManager(999L, managerUser));
+                () -> areaService.findAreaByIdForManager(999L, managerAuth));
     }
 
     @Test
@@ -249,7 +257,7 @@ public class AreaServiceTest {
 
         assertThrows(
                 SecurityException.class,
-                () -> areaService.findAreaByIdForManager(areaInOtherLocation.id, managerUser));
+                () -> areaService.findAreaByIdForManager(areaInOtherLocation.id, managerAuth));
     }
 
     @Test
@@ -259,7 +267,7 @@ public class AreaServiceTest {
         AreaRequestDTO dto =
                 new AreaRequestDTO(eventLocation.id, "Loge", List.of(new CoordinateDTO(2, 2)));
 
-        AreaResponseDTO result = areaService.updateArea(existingArea.id, dto, managerUser);
+        AreaResponseDTO result = areaService.updateArea(existingArea.id, dto, managerAuth);
 
         assertEquals("Loge", result.name());
         verify(areaRepository, times(1)).persist(existingArea);
@@ -271,7 +279,7 @@ public class AreaServiceTest {
         AreaRequestDTO dto = new AreaRequestDTO(eventLocation.id, "Loge", List.of());
 
         assertThrows(
-                AreaNotFoundException.class, () -> areaService.updateArea(999L, dto, managerUser));
+                AreaNotFoundException.class, () -> areaService.updateArea(999L, dto, managerAuth));
     }
 
     @Test
@@ -282,7 +290,7 @@ public class AreaServiceTest {
 
         assertThrows(
                 SecurityException.class,
-                () -> areaService.updateArea(existingArea.id, dto, managerUser));
+                () -> areaService.updateArea(existingArea.id, dto, managerAuth));
     }
 
     @Test
@@ -293,7 +301,7 @@ public class AreaServiceTest {
 
         assertThrows(
                 IllegalArgumentException.class,
-                () -> areaService.updateArea(existingArea.id, dto, managerUser));
+                () -> areaService.updateArea(existingArea.id, dto, managerAuth));
         verify(areaRepository, never()).persist(any(EventLocationArea.class));
     }
 
@@ -310,7 +318,7 @@ public class AreaServiceTest {
 
         assertThrows(
                 AreaInUseException.class,
-                () -> areaService.updateArea(existingArea.id, dto, managerUser));
+                () -> areaService.updateArea(existingArea.id, dto, managerAuth));
         verify(areaRepository, never()).persist(any(EventLocationArea.class));
         assertEquals(eventLocation.id, existingArea.getEventLocation().id);
     }
@@ -326,7 +334,7 @@ public class AreaServiceTest {
         dto.setName("Parkett");
         dto.setBoundary(List.of());
 
-        AreaResponseDTO result = areaService.updateArea(existingArea.id, dto, managerUser);
+        AreaResponseDTO result = areaService.updateArea(existingArea.id, dto, managerAuth);
 
         assertEquals(secondOwnedLocation.id, result.eventLocationId());
         verify(areaRepository, times(1)).persist(existingArea);
@@ -343,7 +351,7 @@ public class AreaServiceTest {
         dto.setName("Parkett umbenannt");
         dto.setBoundary(List.of());
 
-        AreaResponseDTO result = areaService.updateArea(existingArea.id, dto, managerUser);
+        AreaResponseDTO result = areaService.updateArea(existingArea.id, dto, managerAuth);
 
         assertEquals("Parkett umbenannt", result.name());
         verify(areaRepository, times(1)).persist(existingArea);
@@ -353,7 +361,7 @@ public class AreaServiceTest {
     void deleteAreas_InvalidInput_EmptyIds() {
         assertThrows(
                 IllegalArgumentException.class,
-                () -> areaService.deleteAreas(List.of(), managerUser));
+                () -> areaService.deleteAreas(List.of(), managerAuth));
         verify(areaRepository, never()).delete(any(EventLocationArea.class));
     }
 
@@ -363,7 +371,7 @@ public class AreaServiceTest {
                 .thenReturn(Optional.of(existingArea));
         when(seatRepository.countByArea(existingArea)).thenReturn(0L);
 
-        areaService.deleteAreas(List.of(existingArea.id), managerUser);
+        areaService.deleteAreas(List.of(existingArea.id), managerAuth);
 
         verify(areaRepository, times(1)).delete(existingArea);
     }
@@ -374,7 +382,7 @@ public class AreaServiceTest {
 
         assertThrows(
                 AreaNotFoundException.class,
-                () -> areaService.deleteAreas(List.of(999L), managerUser));
+                () -> areaService.deleteAreas(List.of(999L), managerAuth));
     }
 
     @Test
@@ -387,7 +395,7 @@ public class AreaServiceTest {
 
         assertThrows(
                 SecurityException.class,
-                () -> areaService.deleteAreas(List.of(areaInOtherLocation.id), managerUser));
+                () -> areaService.deleteAreas(List.of(areaInOtherLocation.id), managerAuth));
     }
 
     @Test
@@ -398,7 +406,7 @@ public class AreaServiceTest {
 
         assertThrows(
                 AreaInUseException.class,
-                () -> areaService.deleteAreas(List.of(existingArea.id), managerUser));
+                () -> areaService.deleteAreas(List.of(existingArea.id), managerAuth));
         verify(areaRepository, never()).delete(any(EventLocationArea.class));
     }
 }

--- a/src/test/java/de/felixhertweck/seatreservation/management/service/EntranceServiceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/management/service/EntranceServiceTest.java
@@ -46,6 +46,7 @@ import de.felixhertweck.seatreservation.model.entity.User;
 import de.felixhertweck.seatreservation.model.repository.EventLocationEntranceRepository;
 import de.felixhertweck.seatreservation.model.repository.EventLocationRepository;
 import de.felixhertweck.seatreservation.model.repository.SeatRepository;
+import de.felixhertweck.seatreservation.utils.AuthenticatedUser;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.BeforeEach;
@@ -64,6 +65,9 @@ public class EntranceServiceTest {
     private User adminUser;
     private User managerUser;
     private User regularUser;
+    private AuthenticatedUser adminAuth;
+    private AuthenticatedUser managerAuth;
+    private AuthenticatedUser regularAuth;
     private EventLocation eventLocation;
     private EventLocation otherLocation;
     private EventLocation secondOwnedLocation;
@@ -113,6 +117,10 @@ public class EntranceServiceTest {
                         Set.of());
         regularUser.id = 2L;
 
+        adminAuth = new AuthenticatedUser(adminUser.id, adminUser.getRoles());
+        managerAuth = new AuthenticatedUser(managerUser.id, managerUser.getRoles());
+        regularAuth = new AuthenticatedUser(regularUser.id, regularUser.getRoles());
+
         eventLocation = new EventLocation("Stadthalle", "Hauptstraße 1", managerUser, 100);
         eventLocation.id = 1L;
         otherLocation = new EventLocation("Other Hall", "Other Address", regularUser, 50);
@@ -137,7 +145,7 @@ public class EntranceServiceTest {
     void createEntrance_Success_AsManager() {
         EntranceRequestDTO dto = new EntranceRequestDTO(eventLocation.id, "B");
 
-        EntranceResponseDTO result = entranceService.createEntrance(dto, managerUser);
+        EntranceResponseDTO result = entranceService.createEntrance(dto, managerAuth);
 
         assertNotNull(result);
         assertEquals("B", result.name());
@@ -149,7 +157,7 @@ public class EntranceServiceTest {
     void createEntrance_Success_AsAdmin() {
         EntranceRequestDTO dto = new EntranceRequestDTO(eventLocation.id, "B");
 
-        EntranceResponseDTO result = entranceService.createEntrance(dto, adminUser);
+        EntranceResponseDTO result = entranceService.createEntrance(dto, adminAuth);
 
         assertNotNull(result);
         verify(entranceRepository, times(1)).persist(any(EventLocationEntrance.class));
@@ -160,7 +168,7 @@ public class EntranceServiceTest {
         EntranceRequestDTO dto = new EntranceRequestDTO(eventLocation.id, "B");
 
         assertThrows(
-                SecurityException.class, () -> entranceService.createEntrance(dto, regularUser));
+                SecurityException.class, () -> entranceService.createEntrance(dto, regularAuth));
         verify(entranceRepository, never()).persist(any(EventLocationEntrance.class));
     }
 
@@ -170,7 +178,7 @@ public class EntranceServiceTest {
 
         assertThrows(
                 IllegalArgumentException.class,
-                () -> entranceService.createEntrance(dto, managerUser));
+                () -> entranceService.createEntrance(dto, managerAuth));
         verify(entranceRepository, never()).persist(any(EventLocationEntrance.class));
     }
 
@@ -181,7 +189,7 @@ public class EntranceServiceTest {
 
         assertThrows(
                 EventLocationNotFoundException.class,
-                () -> entranceService.createEntrance(dto, managerUser));
+                () -> entranceService.createEntrance(dto, managerAuth));
     }
 
     @Test
@@ -190,7 +198,7 @@ public class EntranceServiceTest {
                 .thenReturn(List.of(existingEntrance));
 
         List<EntranceResponseDTO> result =
-                entranceService.findEntrancesByLocation(eventLocation.id, managerUser);
+                entranceService.findEntrancesByLocation(eventLocation.id, managerAuth);
 
         assertEquals(1, result.size());
         assertEquals("A", result.getFirst().name());
@@ -200,7 +208,7 @@ public class EntranceServiceTest {
     void findEntrancesByLocation_Forbidden_NotOwner() {
         assertThrows(
                 SecurityException.class,
-                () -> entranceService.findEntrancesByLocation(otherLocation.id, managerUser));
+                () -> entranceService.findEntrancesByLocation(otherLocation.id, managerAuth));
     }
 
     @Test
@@ -209,7 +217,7 @@ public class EntranceServiceTest {
 
         assertThrows(
                 EventLocationNotFoundException.class,
-                () -> entranceService.findEntrancesByLocation(999L, managerUser));
+                () -> entranceService.findEntrancesByLocation(999L, managerAuth));
     }
 
     @Test
@@ -218,7 +226,7 @@ public class EntranceServiceTest {
                 .thenReturn(Optional.of(existingEntrance));
 
         EntranceResponseDTO result =
-                entranceService.findEntranceByIdForManager(existingEntrance.id, managerUser);
+                entranceService.findEntranceByIdForManager(existingEntrance.id, managerAuth);
 
         assertEquals("A", result.name());
     }
@@ -229,7 +237,7 @@ public class EntranceServiceTest {
 
         assertThrows(
                 EntranceNotFoundException.class,
-                () -> entranceService.findEntranceByIdForManager(999L, managerUser));
+                () -> entranceService.findEntranceByIdForManager(999L, managerAuth));
     }
 
     @Test
@@ -244,7 +252,7 @@ public class EntranceServiceTest {
                 SecurityException.class,
                 () ->
                         entranceService.findEntranceByIdForManager(
-                                entranceInOtherLocation.id, managerUser));
+                                entranceInOtherLocation.id, managerAuth));
     }
 
     @Test
@@ -254,7 +262,7 @@ public class EntranceServiceTest {
         EntranceRequestDTO dto = new EntranceRequestDTO(eventLocation.id, "C");
 
         EntranceResponseDTO result =
-                entranceService.updateEntrance(existingEntrance.id, dto, managerUser);
+                entranceService.updateEntrance(existingEntrance.id, dto, managerAuth);
 
         assertEquals("C", result.name());
         verify(entranceRepository, times(1)).persist(existingEntrance);
@@ -267,7 +275,7 @@ public class EntranceServiceTest {
 
         assertThrows(
                 EntranceNotFoundException.class,
-                () -> entranceService.updateEntrance(999L, dto, managerUser));
+                () -> entranceService.updateEntrance(999L, dto, managerAuth));
     }
 
     @Test
@@ -278,7 +286,7 @@ public class EntranceServiceTest {
 
         assertThrows(
                 SecurityException.class,
-                () -> entranceService.updateEntrance(existingEntrance.id, dto, managerUser));
+                () -> entranceService.updateEntrance(existingEntrance.id, dto, managerAuth));
     }
 
     @Test
@@ -289,7 +297,7 @@ public class EntranceServiceTest {
 
         assertThrows(
                 IllegalArgumentException.class,
-                () -> entranceService.updateEntrance(existingEntrance.id, dto, managerUser));
+                () -> entranceService.updateEntrance(existingEntrance.id, dto, managerAuth));
         verify(entranceRepository, never()).persist(any(EventLocationEntrance.class));
     }
 
@@ -305,7 +313,7 @@ public class EntranceServiceTest {
 
         assertThrows(
                 EntranceInUseException.class,
-                () -> entranceService.updateEntrance(existingEntrance.id, dto, managerUser));
+                () -> entranceService.updateEntrance(existingEntrance.id, dto, managerAuth));
         verify(entranceRepository, never()).persist(any(EventLocationEntrance.class));
         assertEquals(eventLocation.id, existingEntrance.getEventLocation().id);
     }
@@ -321,7 +329,7 @@ public class EntranceServiceTest {
         dto.setName("A");
 
         EntranceResponseDTO result =
-                entranceService.updateEntrance(existingEntrance.id, dto, managerUser);
+                entranceService.updateEntrance(existingEntrance.id, dto, managerAuth);
 
         assertEquals(secondOwnedLocation.id, result.eventLocationId());
         verify(entranceRepository, times(1)).persist(existingEntrance);
@@ -338,7 +346,7 @@ public class EntranceServiceTest {
         dto.setName("A umbenannt");
 
         EntranceResponseDTO result =
-                entranceService.updateEntrance(existingEntrance.id, dto, managerUser);
+                entranceService.updateEntrance(existingEntrance.id, dto, managerAuth);
 
         assertEquals("A umbenannt", result.name());
         verify(entranceRepository, times(1)).persist(existingEntrance);
@@ -348,7 +356,7 @@ public class EntranceServiceTest {
     void deleteEntrances_InvalidInput_EmptyIds() {
         assertThrows(
                 IllegalArgumentException.class,
-                () -> entranceService.deleteEntrances(List.of(), managerUser));
+                () -> entranceService.deleteEntrances(List.of(), managerAuth));
         verify(entranceRepository, never()).delete(any(EventLocationEntrance.class));
     }
 
@@ -358,7 +366,7 @@ public class EntranceServiceTest {
                 .thenReturn(Optional.of(existingEntrance));
         when(seatRepository.countByEntrance(existingEntrance)).thenReturn(0L);
 
-        entranceService.deleteEntrances(List.of(existingEntrance.id), managerUser);
+        entranceService.deleteEntrances(List.of(existingEntrance.id), managerAuth);
 
         verify(entranceRepository, times(1)).delete(existingEntrance);
     }
@@ -369,7 +377,7 @@ public class EntranceServiceTest {
 
         assertThrows(
                 EntranceNotFoundException.class,
-                () -> entranceService.deleteEntrances(List.of(999L), managerUser));
+                () -> entranceService.deleteEntrances(List.of(999L), managerAuth));
     }
 
     @Test
@@ -380,7 +388,7 @@ public class EntranceServiceTest {
 
         assertThrows(
                 EntranceInUseException.class,
-                () -> entranceService.deleteEntrances(List.of(existingEntrance.id), managerUser));
+                () -> entranceService.deleteEntrances(List.of(existingEntrance.id), managerAuth));
         verify(entranceRepository, never()).delete(any(EventLocationEntrance.class));
     }
 }

--- a/src/test/java/de/felixhertweck/seatreservation/management/service/EventLocationServiceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/management/service/EventLocationServiceTest.java
@@ -54,6 +54,7 @@ import de.felixhertweck.seatreservation.model.entity.User;
 import de.felixhertweck.seatreservation.model.repository.EventLocationRepository;
 import de.felixhertweck.seatreservation.model.repository.SeatRepository;
 import de.felixhertweck.seatreservation.model.repository.UserRepository;
+import de.felixhertweck.seatreservation.utils.AuthenticatedUser;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.BeforeEach;
@@ -73,6 +74,9 @@ public class EventLocationServiceTest {
     private User adminUser;
     private User managerUser;
     private User regularUser;
+    private AuthenticatedUser adminAuth;
+    private AuthenticatedUser managerAuth;
+    private AuthenticatedUser regularAuth;
     private EventLocation existingLocation;
 
     @BeforeEach
@@ -120,6 +124,13 @@ public class EventLocationServiceTest {
                         Set.of());
         regularUser.id = 2L;
 
+        adminAuth = new AuthenticatedUser(adminUser.id, adminUser.getRoles());
+        managerAuth = new AuthenticatedUser(managerUser.id, managerUser.getRoles());
+        regularAuth = new AuthenticatedUser(regularUser.id, regularUser.getRoles());
+
+        when(userRepository.getReference(managerUser.id)).thenReturn(managerUser);
+        when(userRepository.getReference(regularUser.id)).thenReturn(regularUser);
+
         existingLocation = new EventLocation("Stadthalle", "Hauptstraße 1", managerUser, 100);
         existingLocation.id = 1L;
     }
@@ -133,7 +144,7 @@ public class EventLocationServiceTest {
         when(eventLocationRepository.listAll()).thenReturn(allLocations);
 
         List<EventLocationResponseDTO> result =
-                eventLocationService.getEventLocationsByCurrentManager(adminUser);
+                eventLocationService.getEventLocationsByCurrentManager(adminAuth);
 
         assertNotNull(result);
         assertEquals(2, result.size());
@@ -147,7 +158,7 @@ public class EventLocationServiceTest {
         when(eventLocationRepository.findByManager(managerUser)).thenReturn(managerLocations);
 
         List<EventLocationResponseDTO> result =
-                eventLocationService.getEventLocationsByCurrentManager(managerUser);
+                eventLocationService.getEventLocationsByCurrentManager(managerAuth);
 
         assertNotNull(result);
         assertEquals(1, result.size());
@@ -162,7 +173,7 @@ public class EventLocationServiceTest {
                 .thenReturn(Collections.emptyList());
 
         List<EventLocationResponseDTO> result =
-                eventLocationService.getEventLocationsByCurrentManager(managerUser);
+                eventLocationService.getEventLocationsByCurrentManager(managerAuth);
 
         assertNotNull(result);
         assertTrue(result.isEmpty());
@@ -189,7 +200,7 @@ public class EventLocationServiceTest {
                 .persist(any(EventLocation.class));
 
         EventLocationResponseDTO createdLocation =
-                eventLocationService.createEventLocation(dto, managerUser);
+                eventLocationService.createEventLocation(dto, managerAuth);
 
         assertNotNull(createdLocation);
         assertEquals("New Hall", createdLocation.name());
@@ -208,7 +219,7 @@ public class EventLocationServiceTest {
 
         assertThrows(
                 IllegalArgumentException.class,
-                () -> eventLocationService.createEventLocation(dto, managerUser));
+                () -> eventLocationService.createEventLocation(dto, managerAuth));
         verify(eventLocationRepository, never()).persist(any(EventLocation.class));
     }
 
@@ -221,7 +232,7 @@ public class EventLocationServiceTest {
 
         assertThrows(
                 IllegalArgumentException.class,
-                () -> eventLocationService.createEventLocation(dto, managerUser));
+                () -> eventLocationService.createEventLocation(dto, managerAuth));
         verify(eventLocationRepository, never()).persist(any(EventLocation.class));
     }
 
@@ -236,7 +247,7 @@ public class EventLocationServiceTest {
                 .thenReturn(Optional.of(existingLocation));
 
         EventLocationResponseDTO updatedLocation =
-                eventLocationService.updateEventLocation(1L, dto, managerUser);
+                eventLocationService.updateEventLocation(1L, dto, managerAuth);
 
         assertNotNull(updatedLocation);
         assertEquals("Updated Hall", updatedLocation.name());
@@ -256,7 +267,7 @@ public class EventLocationServiceTest {
 
         assertThrows(
                 EventLocationNotFoundException.class,
-                () -> eventLocationService.updateEventLocation(99L, dto, managerUser));
+                () -> eventLocationService.updateEventLocation(99L, dto, managerAuth));
         verify(eventLocationRepository, never()).persist(any(EventLocation.class));
     }
 
@@ -271,7 +282,7 @@ public class EventLocationServiceTest {
                 .thenReturn(Optional.of(existingLocation));
 
         EventLocationResponseDTO updatedLocation =
-                eventLocationService.updateEventLocation(1L, dto, adminUser);
+                eventLocationService.updateEventLocation(1L, dto, adminAuth);
 
         assertNotNull(updatedLocation);
         assertEquals("Updated Hall by Admin", updatedLocation.name());
@@ -292,7 +303,7 @@ public class EventLocationServiceTest {
 
         assertThrows(
                 SecurityException.class,
-                () -> eventLocationService.updateEventLocation(1L, dto, regularUser));
+                () -> eventLocationService.updateEventLocation(1L, dto, regularAuth));
         verify(eventLocationRepository, never()).persist(any(EventLocation.class));
     }
 
@@ -302,7 +313,7 @@ public class EventLocationServiceTest {
                 .thenReturn(Optional.of(existingLocation));
         doNothing().when(eventLocationRepository).delete(any(EventLocation.class));
 
-        eventLocationService.deleteEventLocation(List.of(1L), managerUser);
+        eventLocationService.deleteEventLocation(List.of(1L), managerAuth);
 
         verify(eventLocationRepository, times(1)).delete(existingLocation);
     }
@@ -313,7 +324,7 @@ public class EventLocationServiceTest {
 
         assertThrows(
                 EventLocationNotFoundException.class,
-                () -> eventLocationService.deleteEventLocation(List.of(99L), managerUser));
+                () -> eventLocationService.deleteEventLocation(List.of(99L), managerAuth));
         verify(eventLocationRepository, never()).delete(any(EventLocation.class));
     }
 
@@ -323,7 +334,7 @@ public class EventLocationServiceTest {
                 .thenReturn(Optional.of(existingLocation));
         doNothing().when(eventLocationRepository).delete(any(EventLocation.class));
 
-        eventLocationService.deleteEventLocation(List.of(1L), adminUser);
+        eventLocationService.deleteEventLocation(List.of(1L), adminAuth);
 
         verify(eventLocationRepository, times(1)).delete(existingLocation);
     }
@@ -335,7 +346,7 @@ public class EventLocationServiceTest {
 
         assertThrows(
                 SecurityException.class,
-                () -> eventLocationService.deleteEventLocation(List.of(1L), regularUser));
+                () -> eventLocationService.deleteEventLocation(List.of(1L), regularAuth));
         verify(eventLocationRepository, never()).delete(any(EventLocation.class));
     }
 
@@ -375,7 +386,7 @@ public class EventLocationServiceTest {
 
         // Act
         EventLocationResponseDTO result =
-                eventLocationService.createEventLocation(dto, managerUser);
+                eventLocationService.createEventLocation(dto, managerAuth);
 
         // Assert
         assertNotNull(result);
@@ -428,7 +439,7 @@ public class EventLocationServiceTest {
                 .persist(any(EventLocation.class));
 
         EventLocationResponseDTO result =
-                eventLocationService.createEventLocation(dto, managerUser);
+                eventLocationService.createEventLocation(dto, managerAuth);
 
         assertNotNull(result);
         assertEquals("Concert Hall", result.name());
@@ -467,7 +478,7 @@ public class EventLocationServiceTest {
                 .persist(any(EventLocation.class));
 
         EventLocationResponseDTO result =
-                eventLocationService.createEventLocation(dto, managerUser);
+                eventLocationService.createEventLocation(dto, managerAuth);
 
         assertNotNull(result);
         assertEquals("Simple Hall", result.name());
@@ -498,7 +509,7 @@ public class EventLocationServiceTest {
                 .persist(any(EventLocation.class));
 
         EventLocationResponseDTO result =
-                eventLocationService.createEventLocation(dto, managerUser);
+                eventLocationService.createEventLocation(dto, managerAuth);
 
         assertNotNull(result);
         assertEquals("Empty Markers Hall", result.name());
@@ -531,7 +542,7 @@ public class EventLocationServiceTest {
                 .persist(any(EventLocation.class));
 
         EventLocationResponseDTO result =
-                eventLocationService.createEventLocation(dto, managerUser);
+                eventLocationService.createEventLocation(dto, managerAuth);
 
         assertNotNull(result);
         assertEquals(3, result.markers().size());
@@ -574,7 +585,7 @@ public class EventLocationServiceTest {
                 .when(eventLocationRepository)
                 .persist(any(EventLocation.class));
 
-        eventLocationService.createEventLocation(dto, managerUser);
+        eventLocationService.createEventLocation(dto, managerAuth);
 
         ArgumentCaptor<EventLocation> locationCaptor = ArgumentCaptor.forClass(EventLocation.class);
         verify(eventLocationRepository, times(1)).persist(locationCaptor.capture());
@@ -616,7 +627,7 @@ public class EventLocationServiceTest {
                 .when(eventLocationRepository)
                 .persist(any(EventLocation.class));
 
-        eventLocationService.createEventLocation(dto, managerUser);
+        eventLocationService.createEventLocation(dto, managerAuth);
 
         ArgumentCaptor<EventLocation> locationCaptor = ArgumentCaptor.forClass(EventLocation.class);
         verify(eventLocationRepository, times(1)).persist(locationCaptor.capture());

--- a/src/test/java/de/felixhertweck/seatreservation/management/service/EventServiceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/management/service/EventServiceTest.java
@@ -58,6 +58,7 @@ import de.felixhertweck.seatreservation.model.repository.EventLocationRepository
 import de.felixhertweck.seatreservation.model.repository.EventRepository;
 import de.felixhertweck.seatreservation.model.repository.EventUserAllowanceRepository;
 import de.felixhertweck.seatreservation.model.repository.UserRepository;
+import de.felixhertweck.seatreservation.utils.AuthenticatedUser;
 import io.quarkus.hibernate.orm.panache.PanacheQuery;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
@@ -82,6 +83,9 @@ public class EventServiceTest {
     private User managerUser;
     private User supervisorUser;
     private User regularUser;
+    private AuthenticatedUser adminAuth;
+    private AuthenticatedUser managerAuth;
+    private AuthenticatedUser regularAuth;
     private EventLocation eventLocation;
     private Event existingEvent;
 
@@ -146,6 +150,11 @@ public class EventServiceTest {
                         Set.of(Roles.USER),
                         Set.of());
         regularUser.id = 2L;
+
+        adminAuth = new AuthenticatedUser(adminUser.id, adminUser.getRoles());
+        managerAuth = new AuthenticatedUser(managerUser.id, managerUser.getRoles());
+        regularAuth = new AuthenticatedUser(regularUser.id, regularUser.getRoles());
+        when(userRepository.getReference(managerUser.id)).thenReturn(managerUser);
 
         eventLocation = new EventLocation("Stadthalle", "Hauptstraße 1", managerUser, 100);
         eventLocation.id = 1L;
@@ -405,7 +414,7 @@ public class EventServiceTest {
                                 Set.of(supervisorUser)));
         when(eventRepository.listAll()).thenReturn(allEvents);
 
-        List<EventResponseDTO> result = eventService.getEventsByCurrentManager(adminUser);
+        List<EventResponseDTO> result = eventService.getEventsByCurrentManager(adminAuth);
 
         assertNotNull(result);
         assertEquals(2, result.size());
@@ -418,7 +427,7 @@ public class EventServiceTest {
         List<Event> managerEvents = List.of(existingEvent);
         when(eventRepository.findByManager(managerUser)).thenReturn(managerEvents);
 
-        List<EventResponseDTO> result = eventService.getEventsByCurrentManager(managerUser);
+        List<EventResponseDTO> result = eventService.getEventsByCurrentManager(managerAuth);
 
         assertNotNull(result);
         assertEquals(1, result.size());
@@ -431,7 +440,7 @@ public class EventServiceTest {
     void getEventsByCurrentManager_Success_NoEventsForManager() {
         when(eventRepository.findByManager(managerUser)).thenReturn(Collections.emptyList());
 
-        List<EventResponseDTO> result = eventService.getEventsByCurrentManager(managerUser);
+        List<EventResponseDTO> result = eventService.getEventsByCurrentManager(managerAuth);
 
         assertNotNull(result);
         assertTrue(result.isEmpty());
@@ -464,7 +473,7 @@ public class EventServiceTest {
                 .when(eventUserAllowanceRepository)
                 .persist(any(EventUserAllowance.class));
 
-        eventReservationAllowanceService.setReservationsAllowedForUser(dto, managerUser);
+        eventReservationAllowanceService.setReservationsAllowedForUser(dto, managerAuth);
 
         verify(eventUserAllowanceRepository, times(1)).persist(any(EventUserAllowance.class));
     }
@@ -489,7 +498,7 @@ public class EventServiceTest {
         when(mockQuery.firstResultOptional()).thenReturn(Optional.of(existingAllowance));
         doNothing().when(eventUserAllowanceRepository).persist(any(EventUserAllowance.class));
 
-        eventReservationAllowanceService.setReservationsAllowedForUser(dto, managerUser);
+        eventReservationAllowanceService.setReservationsAllowedForUser(dto, managerAuth);
 
         assertEquals(10, existingAllowance.getReservationsAllowedCount());
         verify(eventUserAllowanceRepository, times(1)).persist(existingAllowance);
@@ -515,7 +524,7 @@ public class EventServiceTest {
         when(mockQuery.firstResultOptional()).thenReturn(Optional.empty());
 
         // Act
-        eventReservationAllowanceService.setReservationsAllowedForUser(dto, adminUser);
+        eventReservationAllowanceService.setReservationsAllowedForUser(dto, adminAuth);
 
         // Assert
         verify(eventUserAllowanceRepository).persist(allowanceCaptor.capture());
@@ -538,7 +547,7 @@ public class EventServiceTest {
                 EventNotFoundException.class,
                 () ->
                         eventReservationAllowanceService.setReservationsAllowedForUser(
-                                dto, managerUser));
+                                dto, managerAuth));
         verify(eventUserAllowanceRepository, never()).persist(any(EventUserAllowance.class));
     }
 
@@ -555,7 +564,7 @@ public class EventServiceTest {
                 UserNotFoundException.class,
                 () ->
                         eventReservationAllowanceService.setReservationsAllowedForUser(
-                                dto, managerUser));
+                                dto, managerAuth));
         verify(eventUserAllowanceRepository, never()).persist(any(EventUserAllowance.class));
     }
 
@@ -572,7 +581,7 @@ public class EventServiceTest {
                 SecurityException.class,
                 () ->
                         eventReservationAllowanceService.setReservationsAllowedForUser(
-                                dto, regularUser));
+                                dto, regularAuth));
         verify(eventUserAllowanceRepository, never()).persist(any(EventUserAllowance.class));
     }
 

--- a/src/test/java/de/felixhertweck/seatreservation/management/service/MarkerServiceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/management/service/MarkerServiceTest.java
@@ -45,6 +45,7 @@ import de.felixhertweck.seatreservation.model.entity.Roles;
 import de.felixhertweck.seatreservation.model.entity.User;
 import de.felixhertweck.seatreservation.model.repository.EventLocationMarkerRepository;
 import de.felixhertweck.seatreservation.model.repository.EventLocationRepository;
+import de.felixhertweck.seatreservation.utils.AuthenticatedUser;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.BeforeEach;
@@ -62,6 +63,9 @@ public class MarkerServiceTest {
     private User adminUser;
     private User managerUser;
     private User regularUser;
+    private AuthenticatedUser adminAuth;
+    private AuthenticatedUser managerAuth;
+    private AuthenticatedUser regularAuth;
     private EventLocation eventLocation;
     private EventLocation otherLocation;
     private EventLocationMarker existingMarker;
@@ -110,6 +114,10 @@ public class MarkerServiceTest {
                         Set.of());
         regularUser.id = 2L;
 
+        adminAuth = new AuthenticatedUser(adminUser.id, adminUser.getRoles());
+        managerAuth = new AuthenticatedUser(managerUser.id, managerUser.getRoles());
+        regularAuth = new AuthenticatedUser(regularUser.id, regularUser.getRoles());
+
         eventLocation = new EventLocation("Stadthalle", "Hauptstraße 1", managerUser, 100);
         eventLocation.id = 1L;
         otherLocation = new EventLocation("Other Hall", "Other Address", regularUser, 50);
@@ -130,7 +138,7 @@ public class MarkerServiceTest {
         MakerRequestDTO dto =
                 new MakerRequestDTO(eventLocation.id, "Stage", new CoordinateDTO(5, 5));
 
-        EventLocationMakerDTO result = markerService.createMarker(dto, managerUser);
+        EventLocationMakerDTO result = markerService.createMarker(dto, managerAuth);
 
         assertNotNull(result);
         assertEquals("Stage", result.label());
@@ -143,7 +151,7 @@ public class MarkerServiceTest {
         MakerRequestDTO dto =
                 new MakerRequestDTO(eventLocation.id, "Stage", new CoordinateDTO(5, 5));
 
-        assertThrows(SecurityException.class, () -> markerService.createMarker(dto, regularUser));
+        assertThrows(SecurityException.class, () -> markerService.createMarker(dto, regularAuth));
         verify(markerRepository, never()).persist(any(EventLocationMarker.class));
     }
 
@@ -152,7 +160,7 @@ public class MarkerServiceTest {
         MakerRequestDTO dto = new MakerRequestDTO(eventLocation.id, "  ", new CoordinateDTO(5, 5));
 
         assertThrows(
-                IllegalArgumentException.class, () -> markerService.createMarker(dto, managerUser));
+                IllegalArgumentException.class, () -> markerService.createMarker(dto, managerAuth));
         verify(markerRepository, never()).persist(any(EventLocationMarker.class));
     }
 
@@ -163,7 +171,7 @@ public class MarkerServiceTest {
 
         assertThrows(
                 EventLocationNotFoundException.class,
-                () -> markerService.createMarker(dto, managerUser));
+                () -> markerService.createMarker(dto, managerAuth));
     }
 
     @Test
@@ -172,7 +180,7 @@ public class MarkerServiceTest {
                 .thenReturn(List.of(existingMarker));
 
         List<EventLocationMakerDTO> result =
-                markerService.findMarkersByLocation(eventLocation.id, managerUser);
+                markerService.findMarkersByLocation(eventLocation.id, managerAuth);
 
         assertEquals(1, result.size());
         assertEquals("Main Entrance", result.getFirst().label());
@@ -182,7 +190,7 @@ public class MarkerServiceTest {
     void findMarkersByLocation_Forbidden_NotOwner() {
         assertThrows(
                 SecurityException.class,
-                () -> markerService.findMarkersByLocation(otherLocation.id, managerUser));
+                () -> markerService.findMarkersByLocation(otherLocation.id, managerAuth));
     }
 
     @Test
@@ -191,7 +199,7 @@ public class MarkerServiceTest {
 
         assertThrows(
                 EventLocationNotFoundException.class,
-                () -> markerService.findMarkersByLocation(999L, managerUser));
+                () -> markerService.findMarkersByLocation(999L, managerAuth));
     }
 
     @Test
@@ -200,7 +208,7 @@ public class MarkerServiceTest {
                 .thenReturn(Optional.of(existingMarker));
 
         EventLocationMakerDTO result =
-                markerService.findMarkerByIdForManager(existingMarker.id, managerUser);
+                markerService.findMarkerByIdForManager(existingMarker.id, managerAuth);
 
         assertEquals("Main Entrance", result.label());
     }
@@ -211,7 +219,7 @@ public class MarkerServiceTest {
 
         assertThrows(
                 MarkerNotFoundException.class,
-                () -> markerService.findMarkerByIdForManager(999L, managerUser));
+                () -> markerService.findMarkerByIdForManager(999L, managerAuth));
     }
 
     @Test
@@ -222,7 +230,7 @@ public class MarkerServiceTest {
                 new MakerRequestDTO(eventLocation.id, "Updated", new CoordinateDTO(1, 1));
 
         EventLocationMakerDTO result =
-                markerService.updateMarker(existingMarker.id, dto, managerUser);
+                markerService.updateMarker(existingMarker.id, dto, managerAuth);
 
         assertEquals("Updated", result.label());
         verify(markerRepository, times(1)).persist(existingMarker);
@@ -236,7 +244,7 @@ public class MarkerServiceTest {
 
         assertThrows(
                 MarkerNotFoundException.class,
-                () -> markerService.updateMarker(999L, dto, managerUser));
+                () -> markerService.updateMarker(999L, dto, managerAuth));
     }
 
     @Test
@@ -248,7 +256,7 @@ public class MarkerServiceTest {
 
         assertThrows(
                 SecurityException.class,
-                () -> markerService.updateMarker(existingMarker.id, dto, managerUser));
+                () -> markerService.updateMarker(existingMarker.id, dto, managerAuth));
     }
 
     @Test
@@ -259,7 +267,7 @@ public class MarkerServiceTest {
 
         assertThrows(
                 IllegalArgumentException.class,
-                () -> markerService.updateMarker(existingMarker.id, dto, managerUser));
+                () -> markerService.updateMarker(existingMarker.id, dto, managerAuth));
         verify(markerRepository, never()).persist(any(EventLocationMarker.class));
     }
 
@@ -267,7 +275,7 @@ public class MarkerServiceTest {
     void deleteMarkers_InvalidInput_EmptyIds() {
         assertThrows(
                 IllegalArgumentException.class,
-                () -> markerService.deleteMarkers(List.of(), managerUser));
+                () -> markerService.deleteMarkers(List.of(), managerAuth));
         verify(markerRepository, never()).delete(any(EventLocationMarker.class));
     }
 
@@ -276,7 +284,7 @@ public class MarkerServiceTest {
         when(markerRepository.findByIdWithEventLocation(existingMarker.id))
                 .thenReturn(Optional.of(existingMarker));
 
-        markerService.deleteMarkers(List.of(existingMarker.id), managerUser);
+        markerService.deleteMarkers(List.of(existingMarker.id), managerAuth);
 
         verify(markerRepository, times(1)).delete(existingMarker);
     }
@@ -287,7 +295,7 @@ public class MarkerServiceTest {
 
         assertThrows(
                 MarkerNotFoundException.class,
-                () -> markerService.deleteMarkers(List.of(999L), managerUser));
+                () -> markerService.deleteMarkers(List.of(999L), managerAuth));
     }
 
     @Test
@@ -300,6 +308,6 @@ public class MarkerServiceTest {
 
         assertThrows(
                 SecurityException.class,
-                () -> markerService.deleteMarkers(List.of(markerInOtherLocation.id), managerUser));
+                () -> markerService.deleteMarkers(List.of(markerInOtherLocation.id), managerAuth));
     }
 }

--- a/src/test/java/de/felixhertweck/seatreservation/management/service/ReservationServiceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/management/service/ReservationServiceTest.java
@@ -63,6 +63,7 @@ import de.felixhertweck.seatreservation.model.repository.EventUserAllowanceRepos
 import de.felixhertweck.seatreservation.model.repository.ReservationRepository;
 import de.felixhertweck.seatreservation.model.repository.SeatRepository;
 import de.felixhertweck.seatreservation.model.repository.UserRepository;
+import de.felixhertweck.seatreservation.utils.AuthenticatedUser;
 import de.felixhertweck.seatreservation.utils.CodeGenerator;
 import io.quarkus.hibernate.orm.panache.PanacheQuery;
 import io.quarkus.test.InjectMock;
@@ -86,6 +87,9 @@ public class ReservationServiceTest {
     private User adminUser;
     private User regularUser;
     private User managerUser;
+    private AuthenticatedUser adminAuth;
+    private AuthenticatedUser managerAuth;
+    private AuthenticatedUser regularAuth;
     private Event event;
     private Seat seat;
     private Reservation reservation;
@@ -143,6 +147,12 @@ public class ReservationServiceTest {
                         Set.of(Roles.MANAGER),
                         Set.of());
         managerUser.id = 3L;
+
+        adminAuth = new AuthenticatedUser(adminUser.id, adminUser.getRoles());
+        managerAuth = new AuthenticatedUser(managerUser.id, managerUser.getRoles());
+        regularAuth = new AuthenticatedUser(regularUser.id, regularUser.getRoles());
+        when(userRepository.getReference(managerUser.id)).thenReturn(managerUser);
+        when(userRepository.getReference(regularUser.id)).thenReturn(regularUser);
 
         EventLocation eventLocation =
                 new EventLocation("Stadthalle", "Hauptstraße 1", managerUser, 100);
@@ -644,7 +654,7 @@ public class ReservationServiceTest {
     void findAllReservations_Success_AsAdmin() {
         when(reservationRepository.listAll()).thenReturn(List.of(reservation));
 
-        var result = reservationService.findAllReservations(adminUser);
+        var result = reservationService.findAllReservations(adminAuth);
 
         assertNotNull(result);
         assertFalse(result.isEmpty());
@@ -659,7 +669,7 @@ public class ReservationServiceTest {
         when(reservationQuery.list()).thenReturn(List.of(reservation));
         when(reservationRepository.find("event.manager", managerUser)).thenReturn(reservationQuery);
 
-        var result = reservationService.findAllReservations(managerUser);
+        var result = reservationService.findAllReservations(managerAuth);
 
         assertNotNull(result);
         assertFalse(result.isEmpty());
@@ -673,7 +683,7 @@ public class ReservationServiceTest {
         when(reservationQuery.list()).thenReturn(Collections.emptyList());
         when(reservationRepository.find("event.manager", managerUser)).thenReturn(reservationQuery);
 
-        var result = reservationService.findAllReservations(managerUser);
+        var result = reservationService.findAllReservations(managerAuth);
 
         assertNotNull(result);
         assertTrue(result.isEmpty());
@@ -686,7 +696,7 @@ public class ReservationServiceTest {
         when(reservationQuery.list()).thenReturn(Collections.emptyList());
         when(reservationRepository.find("event.manager", regularUser)).thenReturn(reservationQuery);
 
-        var result = reservationService.findAllReservations(regularUser);
+        var result = reservationService.findAllReservations(regularAuth);
         assertTrue(result.isEmpty());
     }
 

--- a/src/test/java/de/felixhertweck/seatreservation/management/service/SeatServiceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/management/service/SeatServiceTest.java
@@ -56,6 +56,7 @@ import de.felixhertweck.seatreservation.model.repository.EventLocationEntranceRe
 import de.felixhertweck.seatreservation.model.repository.EventLocationRepository;
 import de.felixhertweck.seatreservation.model.repository.SeatRepository;
 import de.felixhertweck.seatreservation.model.repository.UserRepository;
+import de.felixhertweck.seatreservation.utils.AuthenticatedUser;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.BeforeEach;
@@ -77,6 +78,9 @@ public class SeatServiceTest {
     private User adminUser;
     private User managerUser;
     private User regularUser;
+    private AuthenticatedUser adminAuth;
+    private AuthenticatedUser managerAuth;
+    private AuthenticatedUser regularAuth;
     private EventLocation eventLocation;
     private Seat existingSeat;
     private EventLocationArea areaParkett;
@@ -130,6 +134,10 @@ public class SeatServiceTest {
                         Set.of(Roles.USER),
                         Set.of());
         regularUser.id = 2L;
+
+        adminAuth = new AuthenticatedUser(adminUser.id, adminUser.getRoles());
+        managerAuth = new AuthenticatedUser(managerUser.id, managerUser.getRoles());
+        regularAuth = new AuthenticatedUser(regularUser.id, regularUser.getRoles());
 
         eventLocation = new EventLocation("Stadthalle", "Hauptstraße 1", managerUser, 100);
         eventLocation.id = 1L;
@@ -201,7 +209,7 @@ public class SeatServiceTest {
                 .when(seatRepository)
                 .persist(any(Seat.class));
 
-        SeatDTO createdSeat = seatService.createSeatManager(dto, managerUser);
+        SeatDTO createdSeat = seatService.createSeatManager(dto, managerAuth);
 
         assertNotNull(createdSeat);
         assertEquals("B2", createdSeat.seatNumber());
@@ -231,7 +239,7 @@ public class SeatServiceTest {
                 .when(seatRepository)
                 .persist(any(Seat.class));
 
-        SeatDTO createdSeat = seatService.createSeatManager(dto, adminUser);
+        SeatDTO createdSeat = seatService.createSeatManager(dto, adminAuth);
 
         assertNotNull(createdSeat);
         assertEquals("C3", createdSeat.seatNumber());
@@ -255,7 +263,7 @@ public class SeatServiceTest {
                 .thenReturn(Optional.of(eventLocation));
 
         assertThrows(
-                SecurityException.class, () -> seatService.createSeatManager(dto, regularUser));
+                SecurityException.class, () -> seatService.createSeatManager(dto, regularAuth));
         verify(seatRepository, never()).persist(any(Seat.class));
     }
 
@@ -270,14 +278,14 @@ public class SeatServiceTest {
                 .thenReturn(Optional.of(eventLocation));
         assertThrows(
                 IllegalArgumentException.class,
-                () -> seatService.createSeatManager(dto, managerUser));
+                () -> seatService.createSeatManager(dto, managerAuth));
         verify(seatRepository, never()).persist(any(Seat.class));
 
         dto.setSeatNumber("C3");
         dto.setCoordinate(new CoordinateDTO(1, -1)); // Negative coordinate
         assertThrows(
                 IllegalArgumentException.class,
-                () -> seatService.createSeatManager(dto, managerUser));
+                () -> seatService.createSeatManager(dto, managerAuth));
         verify(seatRepository, never()).persist(any(Seat.class));
     }
 
@@ -291,7 +299,7 @@ public class SeatServiceTest {
 
         assertThrows(
                 IllegalArgumentException.class,
-                () -> seatService.createSeatManager(dto, managerUser));
+                () -> seatService.createSeatManager(dto, managerAuth));
         verify(seatRepository, never()).persist(any(Seat.class));
     }
 
@@ -306,7 +314,7 @@ public class SeatServiceTest {
 
         assertThrows(
                 IllegalArgumentException.class,
-                () -> seatService.createSeatManager(dto, managerUser));
+                () -> seatService.createSeatManager(dto, managerAuth));
         verify(seatRepository, never()).persist(any(Seat.class));
     }
 
@@ -320,7 +328,7 @@ public class SeatServiceTest {
 
         assertThrows(
                 IllegalArgumentException.class,
-                () -> seatService.createSeatManager(dto, managerUser));
+                () -> seatService.createSeatManager(dto, managerAuth));
         verify(seatRepository, never()).persist(any(Seat.class));
     }
 
@@ -335,7 +343,7 @@ public class SeatServiceTest {
 
         assertThrows(
                 IllegalArgumentException.class,
-                () -> seatService.createSeatManager(dto, managerUser));
+                () -> seatService.createSeatManager(dto, managerAuth));
         verify(seatRepository, never()).persist(any(Seat.class));
     }
 
@@ -346,7 +354,7 @@ public class SeatServiceTest {
         when(seatRepository.findByEventLocation(eventLocation)).thenReturn(List.of(existingSeat));
 
         List<SeatDTO> result =
-                seatService.findSeatsForManagerByLocation(eventLocation.id, adminUser);
+                seatService.findSeatsForManagerByLocation(eventLocation.id, adminAuth);
 
         assertNotNull(result);
         assertEquals(1, result.size());
@@ -360,7 +368,7 @@ public class SeatServiceTest {
         when(seatRepository.findByEventLocation(eventLocation)).thenReturn(List.of(existingSeat));
 
         List<SeatDTO> result =
-                seatService.findSeatsForManagerByLocation(eventLocation.id, managerUser);
+                seatService.findSeatsForManagerByLocation(eventLocation.id, managerAuth);
 
         assertNotNull(result);
         assertEquals(1, result.size());
@@ -384,7 +392,7 @@ public class SeatServiceTest {
 
         assertThrows(
                 SecurityException.class,
-                () -> seatService.findSeatsForManagerByLocation(otherLocation.id, managerUser));
+                () -> seatService.findSeatsForManagerByLocation(otherLocation.id, managerAuth));
     }
 
     @Test
@@ -393,14 +401,14 @@ public class SeatServiceTest {
 
         assertThrows(
                 EventLocationNotFoundException.class,
-                () -> seatService.findSeatsForManagerByLocation(999L, managerUser));
+                () -> seatService.findSeatsForManagerByLocation(999L, managerAuth));
     }
 
     @Test
     void findSeatByIdForManager_Success_AsAdmin() {
         when(seatRepository.findByIdOptional(existingSeat.id))
                 .thenReturn(Optional.of(existingSeat));
-        SeatDTO foundSeat = seatService.findSeatByIdForManager(existingSeat.id, adminUser);
+        SeatDTO foundSeat = seatService.findSeatByIdForManager(existingSeat.id, adminAuth);
 
         assertNotNull(foundSeat);
         assertEquals(existingSeat.getSeatNumber(), foundSeat.seatNumber());
@@ -414,7 +422,7 @@ public class SeatServiceTest {
     void findSeatByIdForManager_Success_AsManager() {
         when(seatRepository.findByIdOptional(existingSeat.id))
                 .thenReturn(Optional.of(existingSeat));
-        SeatDTO foundSeat = seatService.findSeatByIdForManager(existingSeat.id, managerUser);
+        SeatDTO foundSeat = seatService.findSeatByIdForManager(existingSeat.id, managerAuth);
 
         assertNotNull(foundSeat);
         assertEquals(existingSeat.getSeatNumber(), foundSeat.seatNumber());
@@ -430,7 +438,7 @@ public class SeatServiceTest {
 
         assertThrows(
                 SeatNotFoundException.class,
-                () -> seatService.findSeatByIdForManager(99L, managerUser));
+                () -> seatService.findSeatByIdForManager(99L, managerAuth));
     }
 
     @Test
@@ -445,7 +453,7 @@ public class SeatServiceTest {
                 .thenReturn(Optional.of(seatInOtherLocation));
         assertThrows(
                 SecurityException.class,
-                () -> seatService.findSeatByIdForManager(seatInOtherLocation.id, managerUser));
+                () -> seatService.findSeatByIdForManager(seatInOtherLocation.id, managerAuth));
     }
 
     @Test
@@ -463,7 +471,7 @@ public class SeatServiceTest {
         when(eventLocationRepository.findByIdOptional(eventLocation.id))
                 .thenReturn(Optional.of(eventLocation));
 
-        SeatDTO updatedSeat = seatService.updateSeatForManager(existingSeat.id, dto, managerUser);
+        SeatDTO updatedSeat = seatService.updateSeatForManager(existingSeat.id, dto, managerAuth);
 
         assertNotNull(updatedSeat);
         assertEquals("Updated A1", updatedSeat.seatNumber());
@@ -493,7 +501,7 @@ public class SeatServiceTest {
         when(eventLocationRepository.findByIdOptional(eventLocation.id))
                 .thenReturn(Optional.of(eventLocation));
 
-        SeatDTO updatedSeat = seatService.updateSeatForManager(existingSeat.id, dto, managerUser);
+        SeatDTO updatedSeat = seatService.updateSeatForManager(existingSeat.id, dto, managerAuth);
 
         assertNotNull(updatedSeat);
         assertEquals("A1", updatedSeat.seatNumber());
@@ -518,7 +526,7 @@ public class SeatServiceTest {
 
         assertThrows(
                 IllegalArgumentException.class,
-                () -> seatService.updateSeatForManager(existingSeat.id, dto, managerUser));
+                () -> seatService.updateSeatForManager(existingSeat.id, dto, managerAuth));
         verify(seatRepository, never()).persist(any(Seat.class));
     }
 
@@ -538,7 +546,7 @@ public class SeatServiceTest {
 
         assertThrows(
                 IllegalArgumentException.class,
-                () -> seatService.updateSeatForManager(existingSeat.id, dto, managerUser));
+                () -> seatService.updateSeatForManager(existingSeat.id, dto, managerAuth));
         verify(seatRepository, never()).persist(any(Seat.class));
     }
 
@@ -556,7 +564,7 @@ public class SeatServiceTest {
         when(eventLocationRepository.findByIdOptional(eventLocation.id))
                 .thenReturn(Optional.of(eventLocation));
 
-        SeatDTO updatedSeat = seatService.updateSeatForManager(existingSeat.id, dto, adminUser);
+        SeatDTO updatedSeat = seatService.updateSeatForManager(existingSeat.id, dto, adminAuth);
 
         assertNotNull(updatedSeat);
         assertEquals("Updated A1 by Admin", updatedSeat.seatNumber());
@@ -578,7 +586,7 @@ public class SeatServiceTest {
 
         assertThrows(
                 SeatNotFoundException.class,
-                () -> seatService.updateSeatForManager(99L, dto, managerUser));
+                () -> seatService.updateSeatForManager(99L, dto, managerAuth));
         verify(seatRepository, never()).persist(any(Seat.class));
     }
 
@@ -596,21 +604,21 @@ public class SeatServiceTest {
 
         assertThrows(
                 IllegalArgumentException.class,
-                () -> seatService.updateSeatForManager(existingSeat.id, dto, managerUser));
+                () -> seatService.updateSeatForManager(existingSeat.id, dto, managerAuth));
         verify(seatRepository, never()).persist(any(Seat.class));
 
         dto.setSeatNumber("A1");
         dto.setCoordinate(new CoordinateDTO(1, -1)); // Invalid coordinate
         assertThrows(
                 IllegalArgumentException.class,
-                () -> seatService.updateSeatForManager(existingSeat.id, dto, managerUser));
+                () -> seatService.updateSeatForManager(existingSeat.id, dto, managerAuth));
         verify(seatRepository, never()).persist(any(Seat.class));
 
         dto.setCoordinate(new CoordinateDTO(1, 1));
         dto.setSeatRow(""); // Invalid seat row
         assertThrows(
                 IllegalArgumentException.class,
-                () -> seatService.updateSeatForManager(existingSeat.id, dto, managerUser));
+                () -> seatService.updateSeatForManager(existingSeat.id, dto, managerAuth));
         verify(seatRepository, never()).persist(any(Seat.class));
     }
 
@@ -626,7 +634,7 @@ public class SeatServiceTest {
 
         assertThrows(
                 EventLocationNotFoundException.class,
-                () -> seatService.createSeatManager(dto, managerUser));
+                () -> seatService.createSeatManager(dto, managerAuth));
         verify(seatRepository, never()).persist(any(Seat.class));
     }
 
@@ -644,7 +652,7 @@ public class SeatServiceTest {
 
         assertThrows(
                 EventLocationNotFoundException.class,
-                () -> seatService.updateSeatForManager(existingSeat.id, dto, managerUser));
+                () -> seatService.updateSeatForManager(existingSeat.id, dto, managerAuth));
         verify(seatRepository, never()).persist(any(Seat.class));
     }
 
@@ -652,7 +660,7 @@ public class SeatServiceTest {
     void deleteSeat_InvalidInput_EmptyIds() {
         assertThrows(
                 IllegalArgumentException.class,
-                () -> seatService.deleteSeatForManager(List.of(), managerUser));
+                () -> seatService.deleteSeatForManager(List.of(), managerAuth));
         verify(seatRepository, never()).delete(any(Seat.class));
     }
 
@@ -676,7 +684,7 @@ public class SeatServiceTest {
 
         assertThrows(
                 SecurityException.class,
-                () -> seatService.updateSeatForManager(seatInOtherLocation.id, dto, managerUser));
+                () -> seatService.updateSeatForManager(seatInOtherLocation.id, dto, managerAuth));
         verify(seatRepository, never()).persist(any(Seat.class));
     }
 
@@ -698,7 +706,7 @@ public class SeatServiceTest {
 
         assertThrows(
                 SecurityException.class,
-                () -> seatService.updateSeatForManager(existingSeat.id, dto, managerUser));
+                () -> seatService.updateSeatForManager(existingSeat.id, dto, managerAuth));
         verify(seatRepository, never()).persist(any(Seat.class));
     }
 
@@ -708,7 +716,7 @@ public class SeatServiceTest {
                 .thenReturn(Optional.of(existingSeat));
         doNothing().when(seatRepository).delete(any(Seat.class));
 
-        seatService.deleteSeatForManager(List.of(existingSeat.id), managerUser);
+        seatService.deleteSeatForManager(List.of(existingSeat.id), managerAuth);
 
         verify(seatRepository, times(1)).delete(existingSeat);
     }
@@ -719,7 +727,7 @@ public class SeatServiceTest {
                 .thenReturn(Optional.of(existingSeat));
         doNothing().when(seatRepository).delete(any(Seat.class));
 
-        seatService.deleteSeatForManager(List.of(existingSeat.id), adminUser);
+        seatService.deleteSeatForManager(List.of(existingSeat.id), adminAuth);
 
         verify(seatRepository, times(1)).delete(existingSeat);
     }
@@ -730,7 +738,7 @@ public class SeatServiceTest {
 
         assertThrows(
                 SeatNotFoundException.class,
-                () -> seatService.deleteSeatForManager(List.of(99L), managerUser));
+                () -> seatService.deleteSeatForManager(List.of(99L), managerAuth));
         verify(seatRepository, never()).delete(any(Seat.class));
     }
 
@@ -749,7 +757,7 @@ public class SeatServiceTest {
                 SecurityException.class,
                 () ->
                         seatService.deleteSeatForManager(
-                                List.of(seatInOtherLocation.id), managerUser));
+                                List.of(seatInOtherLocation.id), managerAuth));
         verify(seatRepository, never()).delete(any(Seat.class));
     }
 
@@ -757,7 +765,7 @@ public class SeatServiceTest {
     void findSeatEntityById_Success() {
         when(seatRepository.findByIdOptional(existingSeat.id))
                 .thenReturn(Optional.of(existingSeat));
-        Seat foundSeat = seatService.findSeatEntityById(existingSeat.id, adminUser);
+        Seat foundSeat = seatService.findSeatEntityById(existingSeat.id, adminAuth);
 
         assertNotNull(foundSeat);
         assertEquals(existingSeat.getSeatNumber(), foundSeat.getSeatNumber());
@@ -770,6 +778,6 @@ public class SeatServiceTest {
 
         assertThrows(
                 SecurityException.class,
-                () -> seatService.findSeatEntityById(existingSeat.id, regularUser));
+                () -> seatService.findSeatEntityById(existingSeat.id, regularAuth));
     }
 }

--- a/src/test/java/de/felixhertweck/seatreservation/reservation/resource/EventResourceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/reservation/resource/EventResourceTest.java
@@ -31,6 +31,9 @@ import de.felixhertweck.seatreservation.model.entity.EventUserAllowance;
 import de.felixhertweck.seatreservation.model.repository.*;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.security.TestSecurity;
+import io.quarkus.test.security.jwt.Claim;
+import io.quarkus.test.security.jwt.ClaimType;
+import io.quarkus.test.security.jwt.JwtSecurity;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -99,6 +102,7 @@ public class EventResourceTest {
     @TestSecurity(
             user = "user",
             roles = {"USER"})
+    @JwtSecurity(claims = @Claim(key = "uid", value = "3", type = ClaimType.LONG))
     void testGetEventsForCurrentUser_Success() {
         given().when()
                 .get("/api/user/events")
@@ -113,6 +117,7 @@ public class EventResourceTest {
     @TestSecurity(
             user = "admin",
             roles = {"USER"})
+    @JwtSecurity(claims = @Claim(key = "uid", value = "1", type = ClaimType.LONG))
     void testGetEventsForCurrentUser_NoAllowances() {
         given().when().get("/api/user/events").then().statusCode(200).body("size()", is(0));
     }

--- a/src/test/java/de/felixhertweck/seatreservation/reservation/resource/ReservationResourceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/reservation/resource/ReservationResourceTest.java
@@ -48,6 +48,9 @@ import de.felixhertweck.seatreservation.reservation.dto.UserReservationsRequestD
 import de.felixhertweck.seatreservation.utils.CodeGenerator;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.security.TestSecurity;
+import io.quarkus.test.security.jwt.Claim;
+import io.quarkus.test.security.jwt.ClaimType;
+import io.quarkus.test.security.jwt.JwtSecurity;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -147,6 +150,7 @@ public class ReservationResourceTest {
     @TestSecurity(
             user = "user",
             roles = {"USER"})
+    @JwtSecurity(claims = @Claim(key = "uid", value = "3", type = ClaimType.LONG))
     void testGetMyReservations_Success() {
         given().when()
                 .get("/api/user/reservations")
@@ -160,6 +164,7 @@ public class ReservationResourceTest {
     @TestSecurity(
             user = "admin",
             roles = {"USER"})
+    @JwtSecurity(claims = @Claim(key = "uid", value = "1", type = ClaimType.LONG))
     void testGetMyReservations_EmptyList() {
         given().when().get("/api/user/reservations").then().statusCode(200).body("$", hasSize(0));
     }
@@ -348,6 +353,7 @@ public class ReservationResourceTest {
     @TestSecurity(
             user = "user",
             roles = {"USER"})
+    @JwtSecurity(claims = @Claim(key = "uid", value = "3", type = ClaimType.LONG))
     void testDeleteMultipleReservations_Success() {
         // Create additional reservations for bulk delete test
         var testUser = userRepository.findByUsernameOptional("user").orElseThrow();

--- a/src/test/java/de/felixhertweck/seatreservation/reservation/service/EventServiceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/reservation/service/EventServiceTest.java
@@ -26,7 +26,6 @@ import jakarta.inject.Inject;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
 
-import de.felixhertweck.seatreservation.common.exception.UserNotFoundException;
 import de.felixhertweck.seatreservation.model.entity.Event;
 import de.felixhertweck.seatreservation.model.entity.EventLocation;
 import de.felixhertweck.seatreservation.model.entity.EventUserAllowance;
@@ -34,7 +33,6 @@ import de.felixhertweck.seatreservation.model.entity.Reservation;
 import de.felixhertweck.seatreservation.model.entity.User;
 import de.felixhertweck.seatreservation.model.repository.EventUserAllowanceRepository;
 import de.felixhertweck.seatreservation.model.repository.ReservationRepository;
-import de.felixhertweck.seatreservation.model.repository.UserRepository;
 import de.felixhertweck.seatreservation.reservation.dto.UserEventResponseDTO;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
@@ -46,7 +44,6 @@ class EventServiceTest {
 
     @Inject EventService eventService;
 
-    @InjectMock UserRepository userRepository;
     @InjectMock EventUserAllowanceRepository eventUserAllowanceRepository;
     @InjectMock ReservationRepository reservationRepository;
 
@@ -92,11 +89,10 @@ class EventServiceTest {
 
     @Test
     void getEventsForCurrentUser_Success_OnlyAllowances() {
-        when(userRepository.findByUsername("testuser")).thenReturn(user);
         when(eventUserAllowanceRepository.findByUser(user)).thenReturn(List.of(allowance1));
         when(reservationRepository.findByUser(user)).thenReturn(Collections.emptyList());
 
-        List<UserEventResponseDTO> result = eventService.getEventsForCurrentUser("testuser");
+        List<UserEventResponseDTO> result = eventService.getEventsForCurrentUser(user);
 
         assertFalse(result.isEmpty());
         assertEquals(1, result.size());
@@ -106,11 +102,10 @@ class EventServiceTest {
 
     @Test
     void getEventsForCurrentUser_Success_OnlyReservations() {
-        when(userRepository.findByUsername("testuser")).thenReturn(user);
         when(eventUserAllowanceRepository.findByUser(user)).thenReturn(Collections.emptyList());
         when(reservationRepository.findByUser(user)).thenReturn(List.of(reservation2));
 
-        List<UserEventResponseDTO> result = eventService.getEventsForCurrentUser("testuser");
+        List<UserEventResponseDTO> result = eventService.getEventsForCurrentUser(user);
 
         assertFalse(result.isEmpty());
         assertEquals(1, result.size());
@@ -121,11 +116,10 @@ class EventServiceTest {
 
     @Test
     void getEventsForCurrentUser_Success_AllowancesAndDifferentReservations() {
-        when(userRepository.findByUsername("testuser")).thenReturn(user);
         when(eventUserAllowanceRepository.findByUser(user)).thenReturn(List.of(allowance1));
         when(reservationRepository.findByUser(user)).thenReturn(List.of(reservation2));
 
-        List<UserEventResponseDTO> result = eventService.getEventsForCurrentUser("testuser");
+        List<UserEventResponseDTO> result = eventService.getEventsForCurrentUser(user);
 
         assertFalse(result.isEmpty());
         assertEquals(2, result.size());
@@ -148,12 +142,11 @@ class EventServiceTest {
 
     @Test
     void getEventsForCurrentUser_Success_AllowancesAndSameEventReservations() {
-        when(userRepository.findByUsername("testuser")).thenReturn(user);
         when(eventUserAllowanceRepository.findByUser(user)).thenReturn(List.of(allowance1));
         when(reservationRepository.findByUser(user))
                 .thenReturn(List.of(reservation1)); // reservation for event1
 
-        List<UserEventResponseDTO> result = eventService.getEventsForCurrentUser("testuser");
+        List<UserEventResponseDTO> result = eventService.getEventsForCurrentUser(user);
 
         assertFalse(result.isEmpty());
         assertEquals(1, result.size());
@@ -163,21 +156,11 @@ class EventServiceTest {
     }
 
     @Test
-    void getEventsForCurrentUser_UserNotFoundException() {
-        when(userRepository.findByUsername("unknownuser")).thenReturn(null);
-
-        assertThrows(
-                UserNotFoundException.class,
-                () -> eventService.getEventsForCurrentUser("unknownuser"));
-    }
-
-    @Test
     void getEventsForCurrentUser_Success_NoEvents() {
-        when(userRepository.findByUsername("testuser")).thenReturn(user);
         when(eventUserAllowanceRepository.findByUser(user)).thenReturn(Collections.emptyList());
         when(reservationRepository.findByUser(user)).thenReturn(Collections.emptyList());
 
-        List<UserEventResponseDTO> result = eventService.getEventsForCurrentUser("testuser");
+        List<UserEventResponseDTO> result = eventService.getEventsForCurrentUser(user);
 
         assertTrue(result.isEmpty());
     }

--- a/src/test/java/de/felixhertweck/seatreservation/security/resource/AuthResourceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/security/resource/AuthResourceTest.java
@@ -405,6 +405,7 @@ public class AuthResourceTest {
     void testLogoutAllDevices_Success() throws Exception {
         // Mock the security context to return the test user when getCurrentUser is called
         Mockito.when(userSecurityContext.getCurrentUser()).thenReturn(testUser);
+        Mockito.when(userSecurityContext.getCurrentUserReference()).thenReturn(testUser);
         Mockito.doNothing().when(tokenService).logoutAllDevices(testUser);
 
         // Mock cookie clearing
@@ -466,6 +467,7 @@ public class AuthResourceTest {
             roles = {"USER"})
     void testLogout_Success() {
         Mockito.when(userSecurityContext.getCurrentUser()).thenReturn(testUser);
+        Mockito.when(userSecurityContext.getCurrentUserReference()).thenReturn(testUser);
 
         // Mock deleteRefreshToken to do nothing (success case)
         Mockito.doNothing().when(tokenService).deleteRefreshToken("someRefreshToken", testUser);
@@ -527,6 +529,7 @@ public class AuthResourceTest {
             roles = {"USER"})
     void testLogout_NoRefreshTokenCookie() {
         Mockito.when(userSecurityContext.getCurrentUser()).thenReturn(testUser);
+        Mockito.when(userSecurityContext.getCurrentUserReference()).thenReturn(testUser);
 
         // Mock deleteRefreshToken to handle null/empty token gracefully
         Mockito.doNothing().when(tokenService).deleteRefreshToken(null, testUser);
@@ -570,6 +573,7 @@ public class AuthResourceTest {
             roles = {"USER"})
     void testLogout_WithDifferentUser() {
         Mockito.when(userSecurityContext.getCurrentUser()).thenReturn(testUser);
+        Mockito.when(userSecurityContext.getCurrentUserReference()).thenReturn(testUser);
 
         // Mock deleteRefreshToken to do nothing
         Mockito.doNothing().when(tokenService).deleteRefreshToken("someRefreshToken", testUser);

--- a/src/test/java/de/felixhertweck/seatreservation/security/service/TokenServiceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/security/service/TokenServiceTest.java
@@ -104,6 +104,7 @@ public class TokenServiceTest {
     @Test
     void generateToken_ValidTokenContent() {
         User user = new User();
+        user.id = 1L;
         user.setUsername("testuser");
         user.setEmail("test@example.com");
         user.setRoles(new HashSet<>(Arrays.asList("USER", "ADMIN")));
@@ -114,6 +115,7 @@ public class TokenServiceTest {
             mockedJwt.when(() -> Jwt.upn(user.getUsername())).thenReturn(claimsBuilder);
             when(claimsBuilder.groups(user.getRoles())).thenReturn(claimsBuilder);
             when(claimsBuilder.claim(Claims.email, user.getEmail())).thenReturn(claimsBuilder);
+            when(claimsBuilder.claim("uid", user.id)).thenReturn(claimsBuilder);
             when(claimsBuilder.issuedAt(any())).thenReturn(claimsBuilder);
             when(claimsBuilder.expiresIn(any(Duration.class))).thenReturn(claimsBuilder);
             when(claimsBuilder.sign()).thenReturn("mockedToken");
@@ -129,6 +131,7 @@ public class TokenServiceTest {
     @Test
     void generateToken_NullEmail_UsesEmptyString() {
         User user = new User();
+        user.id = 1L;
         user.setUsername("testuser");
         user.setEmail(null); // Null email
         user.setRoles(new HashSet<>(Collections.singletonList("USER")));
@@ -139,6 +142,7 @@ public class TokenServiceTest {
             mockedJwt.when(() -> Jwt.upn(user.getUsername())).thenReturn(claimsBuilder);
             when(claimsBuilder.groups(user.getRoles())).thenReturn(claimsBuilder);
             when(claimsBuilder.claim(Claims.email, "")).thenReturn(claimsBuilder);
+            when(claimsBuilder.claim("uid", user.id)).thenReturn(claimsBuilder);
             when(claimsBuilder.issuedAt(any())).thenReturn(claimsBuilder);
             when(claimsBuilder.expiresIn(any(Duration.class))).thenReturn(claimsBuilder);
             when(claimsBuilder.sign()).thenReturn("mockedToken");
@@ -153,6 +157,7 @@ public class TokenServiceTest {
     @Test
     void generateToken_EmptyRoles_HandlesCorrectly() {
         User user = new User();
+        user.id = 1L;
         user.setUsername("testuser");
         user.setEmail("test@example.com");
         user.setRoles(new HashSet<>()); // Empty roles
@@ -163,6 +168,7 @@ public class TokenServiceTest {
             mockedJwt.when(() -> Jwt.upn(user.getUsername())).thenReturn(claimsBuilder);
             when(claimsBuilder.groups(user.getRoles())).thenReturn(claimsBuilder);
             when(claimsBuilder.claim(Claims.email, user.getEmail())).thenReturn(claimsBuilder);
+            when(claimsBuilder.claim("uid", user.id)).thenReturn(claimsBuilder);
             when(claimsBuilder.issuedAt(any())).thenReturn(claimsBuilder);
             when(claimsBuilder.expiresIn(any(Duration.class))).thenReturn(claimsBuilder);
             when(claimsBuilder.sign()).thenReturn("mockedToken");
@@ -199,6 +205,7 @@ public class TokenServiceTest {
     void generateToken_IntegrationTest_WithRealJwt() {
         // Integration test that actually calls the real Jwt library
         User user = new User();
+        user.id = 1L;
         user.setUsername("integrationTestUser");
         user.setEmail("integration@test.com");
         user.setRoles(new HashSet<>(Arrays.asList("USER", "ADMIN")));
@@ -218,6 +225,7 @@ public class TokenServiceTest {
     @Test
     void generateToken_IntegrationTest_WithNullEmail() {
         User user = new User();
+        user.id = 2L;
         user.setUsername("testUserNullEmail");
         user.setEmail(null);
         user.setRoles(new HashSet<>(Collections.singletonList("USER")));
@@ -234,6 +242,7 @@ public class TokenServiceTest {
     @Test
     void generateToken_IntegrationTest_WithEmptyRoles() {
         User user = new User();
+        user.id = 3L;
         user.setUsername("testUserEmptyRoles");
         user.setEmail("empty@roles.com");
         user.setRoles(new HashSet<>());

--- a/src/test/java/de/felixhertweck/seatreservation/supervisor/resource/CheckInResourceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/supervisor/resource/CheckInResourceTest.java
@@ -46,6 +46,9 @@ import io.quarkus.hibernate.orm.panache.PanacheQuery;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.security.TestSecurity;
+import io.quarkus.test.security.jwt.Claim;
+import io.quarkus.test.security.jwt.ClaimType;
+import io.quarkus.test.security.jwt.JwtSecurity;
 import io.restassured.http.ContentType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -91,6 +94,12 @@ class CheckInResourceTest {
         otherSupervisor.setRoles(Set.of(Roles.SUPERVISOR));
         when(userRepository.findByUsername("otherSupervisor")).thenReturn(otherSupervisor);
         when(userRepository.findById(4L)).thenReturn(otherSupervisor);
+
+        // getReference is used instead of a full fetch for FK/query parameters
+        when(userRepository.getReference(1L)).thenReturn(supervisorUser);
+        when(userRepository.getReference(2L)).thenReturn(adminUser);
+        when(userRepository.getReference(3L)).thenReturn(managerUser);
+        when(userRepository.getReference(4L)).thenReturn(otherSupervisor);
 
         // Build events
         Event event10 = new Event();
@@ -155,6 +164,7 @@ class CheckInResourceTest {
 
     @Test
     @TestSecurity(user = "testUser", roles = Roles.SUPERVISOR)
+    @JwtSecurity(claims = @Claim(key = "uid", value = "1", type = ClaimType.LONG))
     void testPostCheckInInfoWithEmptyTokens() {
         CheckInInfoRequestDTO requestDTO = new CheckInInfoRequestDTO();
         requestDTO.userId = 1L;
@@ -172,6 +182,7 @@ class CheckInResourceTest {
 
     @Test
     @TestSecurity(user = "testUser", roles = Roles.SUPERVISOR)
+    @JwtSecurity(claims = @Claim(key = "uid", value = "1", type = ClaimType.LONG))
     void testPostCheckInInfoWithInvalidTokens() {
         CheckInInfoRequestDTO requestDTO = new CheckInInfoRequestDTO();
         requestDTO.userId = 1L;
@@ -188,6 +199,7 @@ class CheckInResourceTest {
 
     @Test
     @TestSecurity(user = "testUser", roles = Roles.SUPERVISOR)
+    @JwtSecurity(claims = @Claim(key = "uid", value = "1", type = ClaimType.LONG))
     void testPostCheckInInfoWithMissingUserId() {
         CheckInInfoRequestDTO requestDTO = new CheckInInfoRequestDTO();
         requestDTO.userId = null;
@@ -204,6 +216,7 @@ class CheckInResourceTest {
 
     @Test
     @TestSecurity(user = "testUser", roles = Roles.SUPERVISOR)
+    @JwtSecurity(claims = @Claim(key = "uid", value = "1", type = ClaimType.LONG))
     void testPostCheckInInfoWithMissingEventId() {
         CheckInInfoRequestDTO requestDTO = new CheckInInfoRequestDTO();
         requestDTO.userId = 1L;
@@ -220,6 +233,7 @@ class CheckInResourceTest {
 
     @Test
     @TestSecurity(user = "testUser", roles = Roles.SUPERVISOR)
+    @JwtSecurity(claims = @Claim(key = "uid", value = "1", type = ClaimType.LONG))
     void testProcessCheckInWithEmptyLists() {
         CheckInProcessRequestDTO requestDTO =
                 new CheckInProcessRequestDTO(
@@ -235,6 +249,7 @@ class CheckInResourceTest {
 
     @Test
     @TestSecurity(user = "testUser", roles = Roles.SUPERVISOR)
+    @JwtSecurity(claims = @Claim(key = "uid", value = "1", type = ClaimType.LONG))
     void testProcessCheckInWithNonExistentCheckInIds() {
         CheckInProcessRequestDTO requestDTO =
                 new CheckInProcessRequestDTO(10L, 1L, List.of(1L, 2L, 3L), Collections.emptyList());
@@ -249,6 +264,7 @@ class CheckInResourceTest {
 
     @Test
     @TestSecurity(user = "testUser", roles = Roles.SUPERVISOR)
+    @JwtSecurity(claims = @Claim(key = "uid", value = "1", type = ClaimType.LONG))
     void testProcessCheckInWithCancelListAndNonExistentCheckInIds() {
         CheckInProcessRequestDTO requestDTO =
                 new CheckInProcessRequestDTO(10L, 1L, Collections.emptyList(), List.of(4L, 5L));
@@ -263,6 +279,7 @@ class CheckInResourceTest {
 
     @Test
     @TestSecurity(user = "testUser", roles = Roles.SUPERVISOR)
+    @JwtSecurity(claims = @Claim(key = "uid", value = "1", type = ClaimType.LONG))
     void testProcessCheckInWithNonExistentCheckInIdsInMixedList() {
         CheckInProcessRequestDTO requestDTO =
                 new CheckInProcessRequestDTO(10L, 1L, List.of(1L, 2L), List.of(3L, 4L));
@@ -306,6 +323,7 @@ class CheckInResourceTest {
 
     @Test
     @TestSecurity(user = "testUser", roles = Roles.SUPERVISOR)
+    @JwtSecurity(claims = @Claim(key = "uid", value = "1", type = ClaimType.LONG))
     void testGetUsernamesWithReservations() {
         // Assuming event with ID 10 exists and has reservations
         given().when()
@@ -317,6 +335,7 @@ class CheckInResourceTest {
 
     @Test
     @TestSecurity(user = "admin", roles = Roles.ADMIN)
+    @JwtSecurity(claims = @Claim(key = "uid", value = "2", type = ClaimType.LONG))
     void testGetUsernamesWithReservations_AsAdmin() {
         given().when()
                 .get("/api/supervisor/checkin/usernames/10")
@@ -327,6 +346,7 @@ class CheckInResourceTest {
 
     @Test
     @TestSecurity(user = "manager", roles = Roles.MANAGER)
+    @JwtSecurity(claims = @Claim(key = "uid", value = "3", type = ClaimType.LONG))
     void testGetUsernamesWithReservations_AsManagerForEvent() {
         given().when()
                 .get("/api/supervisor/checkin/usernames/10")
@@ -337,12 +357,14 @@ class CheckInResourceTest {
 
     @Test
     @TestSecurity(user = "otherSupervisor", roles = Roles.SUPERVISOR)
+    @JwtSecurity(claims = @Claim(key = "uid", value = "4", type = ClaimType.LONG))
     void testGetUsernamesWithReservations_SupervisorNoAccess() {
         given().when().get("/api/supervisor/checkin/usernames/20").then().statusCode(403);
     }
 
     @Test
     @TestSecurity(user = "testUser", roles = Roles.SUPERVISOR)
+    @JwtSecurity(claims = @Claim(key = "uid", value = "1", type = ClaimType.LONG))
     void testGetUsernamesWithReservations_SupervisorAccess() {
         given().when()
                 .get("/api/supervisor/checkin/usernames/10")
@@ -358,12 +380,14 @@ class CheckInResourceTest {
 
     @Test
     @TestSecurity(user = "testUser", roles = Roles.SUPERVISOR)
+    @JwtSecurity(claims = @Claim(key = "uid", value = "1", type = ClaimType.LONG))
     void testGetAllEvents() {
         given().when().get("/api/supervisor/checkin/events").then().statusCode(200);
     }
 
     @Test
     @TestSecurity(user = "admin", roles = Roles.ADMIN)
+    @JwtSecurity(claims = @Claim(key = "uid", value = "2", type = ClaimType.LONG))
     void testGetAllEvents_AsAdmin_SeesAll() {
         given().when()
                 .get("/api/supervisor/checkin/events")
@@ -374,6 +398,7 @@ class CheckInResourceTest {
 
     @Test
     @TestSecurity(user = "testUser", roles = Roles.SUPERVISOR)
+    @JwtSecurity(claims = @Claim(key = "uid", value = "1", type = ClaimType.LONG))
     void testGetAllEvents_AsSupervisor_SeesAuthorizedOnly() {
         given().when()
                 .get("/api/supervisor/checkin/events")
@@ -384,6 +409,7 @@ class CheckInResourceTest {
 
     @Test
     @TestSecurity(user = "otherSupervisor", roles = Roles.SUPERVISOR)
+    @JwtSecurity(claims = @Claim(key = "uid", value = "4", type = ClaimType.LONG))
     void testGetAllEvents_AsOtherSupervisor_SeesNone() {
         given().when()
                 .get("/api/supervisor/checkin/events")
@@ -394,6 +420,7 @@ class CheckInResourceTest {
 
     @Test
     @TestSecurity(user = "manager", roles = Roles.MANAGER)
+    @JwtSecurity(claims = @Claim(key = "uid", value = "3", type = ClaimType.LONG))
     void testGetAllEvents_AsManager_SeesManaged() {
         given().when()
                 .get("/api/supervisor/checkin/events")
@@ -409,6 +436,7 @@ class CheckInResourceTest {
 
     @Test
     @TestSecurity(user = "testUser", roles = Roles.SUPERVISOR)
+    @JwtSecurity(claims = @Claim(key = "uid", value = "1", type = ClaimType.LONG))
     void testGetCheckInInfoByUsernameNotFound() {
         given().when().post("/api/supervisor/checkin/info/nonExistentUser").then().statusCode(404);
     }

--- a/src/test/java/de/felixhertweck/seatreservation/supervisor/service/CheckInServiceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/supervisor/service/CheckInServiceTest.java
@@ -47,12 +47,14 @@ import de.felixhertweck.seatreservation.model.entity.Roles;
 import de.felixhertweck.seatreservation.model.entity.Seat;
 import de.felixhertweck.seatreservation.model.entity.User;
 import de.felixhertweck.seatreservation.model.repository.ReservationRepository;
+import de.felixhertweck.seatreservation.model.repository.UserRepository;
 import de.felixhertweck.seatreservation.supervisor.dto.CheckInInfoResponseDTO;
 import de.felixhertweck.seatreservation.supervisor.dto.CheckInProcessRequestDTO;
 import de.felixhertweck.seatreservation.supervisor.exception.CheckInException;
 import de.felixhertweck.seatreservation.supervisor.exception.CheckInTokenNotFoundException;
 import de.felixhertweck.seatreservation.supervisor.exception.EventMismatchException;
 import de.felixhertweck.seatreservation.supervisor.exception.UserMismatchException;
+import de.felixhertweck.seatreservation.utils.AuthenticatedUser;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.BeforeEach;
@@ -65,11 +67,16 @@ class CheckInServiceTest {
 
     @InjectMock ReservationRepository reservationRepository;
     @InjectMock de.felixhertweck.seatreservation.model.repository.EventRepository eventRepository;
+    @InjectMock UserRepository userRepository;
 
     @BeforeEach
     void setup() {
         // Authorize the test user (id 1) for any event in these tests
         when(eventRepository.isUserSupervisor(anyLong(), eq(1L))).thenReturn(true);
+    }
+
+    private static AuthenticatedUser auth(User user) {
+        return new AuthenticatedUser(user.id, user.getRoles());
     }
 
     // Tests for processCheckIn(CheckInProcessRequestDTO) method
@@ -117,7 +124,7 @@ class CheckInServiceTest {
                         Collections.emptyList());
 
         // current user is user with userId
-        checkInService.processCheckIn(requestDTO, user);
+        checkInService.processCheckIn(requestDTO, auth(user));
 
         assertEquals(ReservationLiveStatus.CHECKED_IN, reservation1.getLiveStatus());
         assertEquals(ReservationLiveStatus.CHECKED_IN, reservation2.getLiveStatus());
@@ -160,7 +167,7 @@ class CheckInServiceTest {
                         Collections.emptyList(),
                         Collections.singletonList(reservationId1));
 
-        checkInService.processCheckIn(requestDTO, user);
+        checkInService.processCheckIn(requestDTO, auth(user));
 
         assertEquals(ReservationLiveStatus.CANCELLED, reservation1.getLiveStatus());
 
@@ -211,7 +218,7 @@ class CheckInServiceTest {
                         Collections.singletonList(checkInId),
                         Collections.singletonList(cancelId));
 
-        checkInService.processCheckIn(requestDTO, user);
+        checkInService.processCheckIn(requestDTO, auth(user));
 
         assertEquals(ReservationLiveStatus.CHECKED_IN, checkInReservation.getLiveStatus());
         assertEquals(ReservationLiveStatus.CANCELLED, cancelReservation.getLiveStatus());
@@ -252,7 +259,7 @@ class CheckInServiceTest {
                 new CheckInProcessRequestDTO(
                         eventId, userId, Collections.emptyList(), Collections.emptyList());
 
-        checkInService.processCheckIn(requestDTO, user);
+        checkInService.processCheckIn(requestDTO, auth(user));
 
         verify(reservationRepository, never()).persist(any(Reservation.class));
     }
@@ -294,10 +301,11 @@ class CheckInServiceTest {
 
         when(reservationRepository.findByCheckInCodeIn(Arrays.asList(token1, token2)))
                 .thenReturn(Arrays.asList(reservation1, reservation2));
+        when(userRepository.findById(userId)).thenReturn(user);
 
         CheckInInfoResponseDTO result =
                 checkInService.getReservationInfos(
-                        user, userId, eventId, Arrays.asList(token1, token2));
+                        auth(user), userId, eventId, Arrays.asList(token1, token2));
 
         assertNotNull(result);
         assertEquals(2, result.reservations().size());
@@ -310,9 +318,11 @@ class CheckInServiceTest {
         long eventId = 10L;
         User user = new User();
         user.id = userId;
+        when(userRepository.findById(userId)).thenReturn(user);
 
         CheckInInfoResponseDTO result =
-                checkInService.getReservationInfos(user, userId, eventId, Collections.emptyList());
+                checkInService.getReservationInfos(
+                        auth(user), userId, eventId, Collections.emptyList());
 
         assertNotNull(result);
         assertEquals(0, result.reservations().size());
@@ -354,7 +364,7 @@ class CheckInServiceTest {
                         Collections.emptyList(),
                         Collections.singletonList(reservationId));
 
-        checkInService.processCheckIn(requestDTO, user);
+        checkInService.processCheckIn(requestDTO, auth(user));
 
         assertEquals(ReservationLiveStatus.CANCELLED, reservation1.getLiveStatus());
 
@@ -386,7 +396,7 @@ class CheckInServiceTest {
                 UserMismatchException.class,
                 () ->
                         checkInService.getReservationInfos(
-                                user, userId, eventId, Collections.singletonList(token1)));
+                                auth(user), userId, eventId, Collections.singletonList(token1)));
     }
 
     @Test
@@ -474,6 +484,7 @@ class CheckInServiceTest {
 
         when(reservationRepository.findByCheckInCodeIn(Arrays.asList(token1, token2)))
                 .thenReturn(Arrays.asList(reservation1, reservation2));
+        when(userRepository.findById(userId)).thenReturn(user);
 
         CheckInInfoResponseDTO result =
                 checkInService.getReservationInfos(userId, eventId, Arrays.asList(token1, token2));
@@ -491,7 +502,7 @@ class CheckInServiceTest {
         when(eventRepository.isUserSupervisor(eq(eventId), eq(1L))).thenReturn(false);
         assertThrows(
                 SecurityException.class,
-                () -> checkInService.getUsernamesWithReservations(user, eventId));
+                () -> checkInService.getUsernamesWithReservations(auth(user), eventId));
     }
 
     @Test
@@ -516,7 +527,7 @@ class CheckInServiceTest {
         when(q.stream()).thenReturn(Stream.of(r1));
         when(reservationRepository.find("event.id", eventId)).thenReturn(q);
 
-        List<String> usernames = checkInService.getUsernamesWithReservations(admin, eventId);
+        List<String> usernames = checkInService.getUsernamesWithReservations(auth(admin), eventId);
         assertEquals(1, usernames.size());
     }
 
@@ -535,10 +546,11 @@ class CheckInServiceTest {
         when(eq.stream()).thenReturn(Stream.of(e1, e2));
         when(eq.list()).thenReturn(List.of(e1, e2));
         when(eventRepository.findAll()).thenReturn(eq);
+        when(userRepository.getReference(supervisor.id)).thenReturn(supervisor);
         when(eventRepository.findAuthorizedEvents(supervisor)).thenReturn(List.of(e1));
 
         List<de.felixhertweck.seatreservation.supervisor.dto.SupervisorEventResponseDTO> events =
-                checkInService.getAllEventsForSupervisor(supervisor);
+                checkInService.getAllEventsForSupervisor(auth(supervisor));
         assertEquals(1, events.size());
     }
 }

--- a/src/test/java/de/felixhertweck/seatreservation/utils/UserSecurityContextTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/utils/UserSecurityContextTest.java
@@ -24,6 +24,7 @@ import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -36,6 +37,7 @@ import de.felixhertweck.seatreservation.model.entity.Roles;
 import de.felixhertweck.seatreservation.model.entity.User;
 import de.felixhertweck.seatreservation.model.repository.UserRepository;
 import io.quarkus.security.identity.SecurityIdentity;
+import org.eclipse.microprofile.jwt.JsonWebToken;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -51,6 +53,8 @@ class UserSecurityContextTest {
     @Mock private UserRepository userRepository;
 
     @Mock private Principal principal;
+
+    @Mock private JsonWebToken jsonWebToken;
 
     @InjectMocks private UserSecurityContext userSecurityContext;
 
@@ -210,5 +214,23 @@ class UserSecurityContextTest {
         verify(securityContext, times(2)).getPrincipal();
         verify(userRepository).findByUsername("testuser");
         verify(userRepository).findByUsername("seconduser");
+    }
+
+    @Test
+    void getCurrentUserReference_ValidUidClaim_ReturnsRepositoryReference() {
+        // Arrange
+        when(jsonWebToken.getClaim("uid")).thenReturn("42");
+        User reference = new User();
+        reference.id = 42L;
+        when(userRepository.getReference(42L)).thenReturn(reference);
+
+        // Act
+        User result = userSecurityContext.getCurrentUserReference();
+
+        // Assert
+        assertSame(reference, result);
+        verify(jsonWebToken).getClaim("uid");
+        verify(userRepository).getReference(42L);
+        verifyNoInteractions(principal);
     }
 }

--- a/webapp/api/types.gen.ts
+++ b/webapp/api/types.gen.ts
@@ -2558,10 +2558,6 @@ export type GetApiUserEventsErrors = {
      * Forbidden: Only authenticated users can access this resource
      */
     403: unknown;
-    /**
-     * Not Found: User not found
-     */
-    404: unknown;
 };
 
 export type GetApiUserEventsResponses = {

--- a/webapp/docs/openapi.json
+++ b/webapp/docs/openapi.json
@@ -3722,9 +3722,6 @@
           },
           "403" : {
             "description" : "Forbidden: Only authenticated users can access this resource"
-          },
-          "404" : {
-            "description" : "Not Found: User not found"
           }
         },
         "summary" : "Get Events",


### PR DESCRIPTION
## Summary
- Add a `uid` claim to issued JWTs and a lightweight `AuthenticatedUser(id, roles)` derived directly from the validated token/`SecurityIdentity` — no DB access.
- Switch the ~30 endpoints that only ever checked the caller's id/role (Area/Seat/Entrance/Marker/EventLocation management, event and reservation listings, check-in authorization, logout, etc.) to use it instead of fetching the full `User` entity via `UserSecurityContext.getCurrentUser()` on every request.
- Where an entity is still needed as an FK/query parameter, use a Hibernate reference (`EntityManager.getReference`) instead of a full `SELECT`.
- Endpoints that need real entity fields (email verification, ownership equality against loaded associations) keep the existing full fetch — unchanged.
- Tests supply the `uid` claim via `quarkus-test-security-jwt`'s `@JwtSecurity` alongside `@TestSecurity`, so production code carries no test-only fallback logic.

## Breaking changes
- `GET /api/user/events` no longer returns `404 Not Found`. The endpoint used to look up the caller by username via `UserRepository.findByUsername` and throw `UserNotFoundException` if that returned `null`; it now resolves the caller via `UserSecurityContext#getCurrentUserReference()`, an unchecked Hibernate reference built from the JWT's `uid` claim, which never fails. The `@APIResponse(responseCode = "404", ...)` annotation was removed accordingly.

## Test plan
- [x] `mvn test` — full suite green (920 tests)
- [x] Manual review of each changed endpoint against the Bucket A/B split (role/id-only vs. needs full entity)