### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix predictable random number generation in native builds

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-15 - [Predictable Codes in Native Builds]
+**Vulnerability:** `CodeGenerator` instantiated a static `SecureRandom` instance without being configured for runtime initialization.
+**Learning:** In GraalVM native images (Quarkus), static fields are initialized at build time by default. A static `SecureRandom` caches its initial state/seed during the build, leading to predictable random number sequences across application restarts.
+**Prevention:** Always use the centralized `SecurityUtils` (which is configured in `pom.xml` via `--initialize-at-run-time=...`) for random number generation in Quarkus applications to ensure a fresh, unpredictable seed at runtime.

--- a/src/main/java/de/felixhertweck/seatreservation/utils/CodeGenerator.java
+++ b/src/main/java/de/felixhertweck/seatreservation/utils/CodeGenerator.java
@@ -19,18 +19,15 @@
  */
 package de.felixhertweck.seatreservation.utils;
 
-import java.security.SecureRandom;
-
 public class CodeGenerator {
 
     private static final String CHARACTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
     private static final int CODE_LENGTH = 8;
-    private static final SecureRandom random = new SecureRandom();
 
     public static String generateRandomCode() {
         StringBuilder code = new StringBuilder(CODE_LENGTH);
         for (int i = 0; i < CODE_LENGTH; i++) {
-            code.append(CHARACTERS.charAt(random.nextInt(CHARACTERS.length())));
+            code.append(CHARACTERS.charAt(SecurityUtils.nextInt(CHARACTERS.length())));
         }
         return code.toString();
     }


### PR DESCRIPTION
🚨 **Severity**: CRITICAL/HIGH
💡 **Vulnerability**: `CodeGenerator` instantiated a static `SecureRandom` instance without being configured for runtime initialization.
🎯 **Impact**: In GraalVM native images (Quarkus), static fields are initialized at build time by default. A static `SecureRandom` caches its initial state/seed during the build, leading to predictable random number sequences across application restarts, which compromises any generated codes.
🔧 **Fix**: Replaced the static `SecureRandom` instance with the centralized `SecurityUtils.nextInt()`, which is explicitly configured in `pom.xml` via `--initialize-at-run-time=de.felixhertweck.seatreservation.utils.SecurityUtils` to guarantee a fresh runtime seed.
✅ **Verification**: Verified the change via backend test-compilation and execution of `CodeGeneratorTest`. No regression introduced and codes remain correctly sized.

---
*PR created automatically by Jules for task [8090492750757721997](https://jules.google.com/task/8090492750757721997) started by @FelixHertweck*