### PR TITLE
⚡ Optimize event deletion using bulk operations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-07-25 - Safe Parent Entity Bulk Deletion with JPA Cascades
+**Learning:** In Quarkus/Panache Hibernate, performing a bulk delete (such as `repository.delete("id in ?1", ids)`) bypasses JPA lifecycle events and cascades (e.g., `CascadeType.ALL`, `orphanRemoval = true`). If the underlying database does not have `ON DELETE CASCADE` constraints on the foreign keys, executing a direct parent bulk delete will fail with foreign key constraint violations.
+**Action:** Before bulk-deleting parent entities, manually delete all cascading and dependent child entities using bulk delete operations (HQL deletes or native SQL queries for element collections and join tables) in the correct topological order.

--- a/src/main/java/de/felixhertweck/seatreservation/management/service/EventService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/management/service/EventService.java
@@ -39,8 +39,11 @@ import de.felixhertweck.seatreservation.model.entity.Event;
 import de.felixhertweck.seatreservation.model.entity.EventLocation;
 import de.felixhertweck.seatreservation.model.entity.Roles;
 import de.felixhertweck.seatreservation.model.entity.User;
+import de.felixhertweck.seatreservation.model.repository.EmailSeatMapTokenRepository;
 import de.felixhertweck.seatreservation.model.repository.EventLocationRepository;
 import de.felixhertweck.seatreservation.model.repository.EventRepository;
+import de.felixhertweck.seatreservation.model.repository.EventUserAllowanceRepository;
+import de.felixhertweck.seatreservation.model.repository.ReservationRepository;
 import de.felixhertweck.seatreservation.model.repository.UserRepository;
 import de.felixhertweck.seatreservation.utils.AuthenticatedUser;
 import org.jboss.logging.Logger;
@@ -57,6 +60,12 @@ public class EventService {
     @Inject UserRepository userRepository;
 
     @Inject NotificationService notificationService;
+
+    @Inject ReservationRepository reservationRepository;
+
+    @Inject EventUserAllowanceRepository eventUserAllowanceRepository;
+
+    @Inject EmailSeatMapTokenRepository emailSeatMapTokenRepository;
 
     /**
      * Creates a new Event and assigns the currently authenticated manager as its creator. Access
@@ -360,8 +369,35 @@ public class EventService {
             eventsToDelete.add(event);
         }
 
+        // 1. Delete associated email_seat_map_token_seats
+        eventRepository
+                .getEntityManager()
+                .createNativeQuery(
+                        "DELETE FROM email_seat_map_token_seats WHERE token_id IN (SELECT id"
+                                + " FROM email_seat_map_tokens WHERE event_id IN :ids)")
+                .setParameter("ids", ids)
+                .executeUpdate();
+
+        // 2. Delete email_seat_map_tokens
+        emailSeatMapTokenRepository.delete("event.id in ?1", ids);
+
+        // 3. Delete reservations
+        reservationRepository.delete("event.id in ?1", ids);
+
+        // 4. Delete eventuserallowance
+        eventUserAllowanceRepository.delete("event.id in ?1", ids);
+
+        // 5. Delete event_supervisors join table entries
+        eventRepository
+                .getEntityManager()
+                .createNativeQuery("DELETE FROM event_supervisors WHERE event_id IN :ids")
+                .setParameter("ids", ids)
+                .executeUpdate();
+
+        // 6. Bulk delete events
+        eventRepository.delete("id in ?1", ids);
+
         for (Event event : eventsToDelete) {
-            eventRepository.delete(event);
             LOG.debugf(
                     "Event '%s' (ID: %s) deleted successfully by user ID: %s (ID: %s)",
                     event.getName(), event.getId(), currentUser.id, currentUser.getId());

--- a/src/test/java/de/felixhertweck/seatreservation/management/service/EventServiceDeleteEventTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/management/service/EventServiceDeleteEventTest.java
@@ -23,6 +23,8 @@ import static de.felixhertweck.seatreservation.testutil.TestIds.id;
 
 import java.util.List;
 import java.util.Set;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.eq;
@@ -32,7 +34,10 @@ import de.felixhertweck.seatreservation.common.exception.EventNotFoundException;
 import de.felixhertweck.seatreservation.model.entity.Event;
 import de.felixhertweck.seatreservation.model.entity.Roles;
 import de.felixhertweck.seatreservation.model.entity.User;
+import de.felixhertweck.seatreservation.model.repository.EmailSeatMapTokenRepository;
 import de.felixhertweck.seatreservation.model.repository.EventRepository;
+import de.felixhertweck.seatreservation.model.repository.EventUserAllowanceRepository;
+import de.felixhertweck.seatreservation.model.repository.ReservationRepository;
 import io.quarkus.hibernate.orm.panache.PanacheQuery;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -43,6 +48,12 @@ import org.mockito.MockitoAnnotations;
 public class EventServiceDeleteEventTest {
 
     @Mock EventRepository eventRepository;
+
+    @Mock ReservationRepository reservationRepository;
+
+    @Mock EventUserAllowanceRepository eventUserAllowanceRepository;
+
+    @Mock EmailSeatMapTokenRepository emailSeatMapTokenRepository;
 
     @InjectMocks EventService eventService;
 
@@ -86,10 +97,22 @@ public class EventServiceDeleteEventTest {
                         eq(List.of(id(101), id(102)))))
                 .thenReturn(queryMock);
 
+        EntityManager entityManagerMock = mock(EntityManager.class);
+        Query nativeQueryMock = mock(Query.class);
+        when(entityManagerMock.createNativeQuery(anyString())).thenReturn(nativeQueryMock);
+        when(nativeQueryMock.setParameter(anyString(), any())).thenReturn(nativeQueryMock);
+        when(eventRepository.getEntityManager()).thenReturn(entityManagerMock);
+
         eventService.deleteEvent(List.of(id(101), id(102)), managerUser);
 
-        verify(eventRepository, times(1)).delete(event1);
-        verify(eventRepository, times(1)).delete(event2);
+        verify(eventRepository, times(1)).delete(eq("id in ?1"), eq(List.of(id(101), id(102))));
+        verify(reservationRepository, times(1))
+                .delete(eq("event.id in ?1"), eq(List.of(id(101), id(102))));
+        verify(eventUserAllowanceRepository, times(1))
+                .delete(eq("event.id in ?1"), eq(List.of(id(101), id(102))));
+        verify(emailSeatMapTokenRepository, times(1))
+                .delete(eq("event.id in ?1"), eq(List.of(id(101), id(102))));
+        verify(entityManagerMock, times(2)).createNativeQuery(anyString());
     }
 
     @Test


### PR DESCRIPTION
💡 **What:**
Optimized the event deletion process (`EventService.deleteEvent`) to use transactional bulk operations instead of performing recursive single-record deletion inside a loop. The implementation safely performs bulk deletes for all cascading and join-table relationships (such as reservations, allowances, supervisors, and email seat map tokens) in topological order to prevent database foreign-key constraint violations, followed by a bulk delete of the target event records themselves.

🎯 **Why:**
Previously, deleting a list of events executed multiple SQL queries per event record to delete the children individually and then the event. For a large batch of event deletions, this caused a significant N+1 query performance bottleneck with high database I/O overhead.

📊 **Measured Improvement:**
Using bulk deletes reduces the query complexity from $O(N)$ database roundtrips to $O(1)$ database updates, drastically reducing connection lease times and database server resource utilization. While direct micro-benchmarking is impractical within this offline test environment due to missing real database integration setups, this is a standard and mathematically proven performance improvement that significantly reduces I/O wait times.

---
*PR created automatically by Jules for task [10933327796528494042](https://jules.google.com/task/10933327796528494042) started by @FelixHertweck*