### PR TITLE
⚡ Optimize seat deletion by batching entity fetching and deletion

### DIFF
--- a/src/main/java/de/felixhertweck/seatreservation/management/service/SeatService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/management/service/SeatService.java
@@ -20,7 +20,9 @@
 package de.felixhertweck.seatreservation.management.service;
 
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
@@ -283,10 +285,41 @@ public class SeatService {
         }
 
         LOG.debugf("Attempting to delete seats with IDs: %s for manager ID: %s", ids, manager.id());
+
+        // Fetch all seats in a single query to avoid the N+1 problem
+        List<Seat> seats = seatRepository.find("id in ?1", ids).list();
+
+        // Map seats by ID for quick lookup and to preserve iterative validation and exception
+        // behavior
+        Map<UUID, Seat> seatMap = seats.stream().collect(Collectors.toMap(s -> s.id, s -> s));
+
         for (UUID id : ids) {
-            Seat seat = findSeatEntityById(id, manager); // This already checks for ownership
-            seatRepository.delete(seat);
-            LOG.infof("Seat ID: %s deleted successfully", seat.id);
+            LOG.debugf(
+                    "Attempting to find seat entity by ID: %s for user ID: %s", id, manager.id());
+            Seat seat = seatMap.get(id);
+            if (seat == null) {
+                LOG.warnf("Seat with ID %s not found for user ID: %s", id, manager.id());
+                throw new SeatNotFoundException("Seat with id " + id + " not found");
+            }
+
+            if (manager.isAdmin()) {
+                LOG.debugf("User is ADMIN, allowing access to seat ID %s.", id);
+            } else {
+                if (!seat.getLocation().getManager().getId().equals(manager.id())) {
+                    LOG.warnf(
+                            "user ID: %s does not have permission to access seat ID %s.",
+                            manager.id(), id);
+                    throw new SecurityException("You do not have permission to access this seat");
+                }
+                LOG.debugf("user ID: %s has permission to access seat ID %s.", manager.id(), id);
+            }
+        }
+
+        // Batch delete the seats
+        seatRepository.delete("id in ?1", ids);
+
+        for (UUID id : ids) {
+            LOG.infof("Seat ID: %s deleted successfully", id);
         }
         LOG.debugf("Seats with IDs %s deleted successfully by manager ID: %s", ids, manager.id());
     }

--- a/src/test/java/de/felixhertweck/seatreservation/management/service/SeatServiceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/management/service/SeatServiceTest.java
@@ -32,8 +32,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -59,6 +60,7 @@ import de.felixhertweck.seatreservation.model.repository.EventLocationRepository
 import de.felixhertweck.seatreservation.model.repository.SeatRepository;
 import de.felixhertweck.seatreservation.model.repository.UserRepository;
 import de.felixhertweck.seatreservation.utils.AuthenticatedUser;
+import io.quarkus.hibernate.orm.panache.PanacheQuery;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.BeforeEach;
@@ -662,12 +664,19 @@ public class SeatServiceTest {
         verify(seatRepository, never()).persist(any(Seat.class));
     }
 
+    private void mockSeatFind(List<UUID> seatIds, List<Seat> seats) {
+        @SuppressWarnings("unchecked")
+        PanacheQuery<Seat> seatQuery = mock(PanacheQuery.class);
+        when(seatQuery.list()).thenReturn(seats);
+        when(seatRepository.find("id in ?1", seatIds)).thenReturn(seatQuery);
+    }
+
     @Test
     void deleteSeat_InvalidInput_EmptyIds() {
         assertThrows(
                 IllegalArgumentException.class,
                 () -> seatService.deleteSeatForManager(List.of(), managerAuth));
-        verify(seatRepository, never()).delete(any(Seat.class));
+        verify(seatRepository, never()).delete(anyString(), any(Object[].class));
     }
 
     @Test
@@ -718,34 +727,32 @@ public class SeatServiceTest {
 
     @Test
     void deleteSeat_Success_AsManager() {
-        when(seatRepository.findByIdOptional(existingSeat.id))
-                .thenReturn(Optional.of(existingSeat));
-        doNothing().when(seatRepository).delete(any(Seat.class));
+        mockSeatFind(List.of(existingSeat.id), List.of(existingSeat));
+        when(seatRepository.delete("id in ?1", List.of(existingSeat.id))).thenReturn(1L);
 
         seatService.deleteSeatForManager(List.of(existingSeat.id), managerAuth);
 
-        verify(seatRepository, times(1)).delete(existingSeat);
+        verify(seatRepository, times(1)).delete("id in ?1", List.of(existingSeat.id));
     }
 
     @Test
     void deleteSeat_Success_AsAdmin() {
-        when(seatRepository.findByIdOptional(existingSeat.id))
-                .thenReturn(Optional.of(existingSeat));
-        doNothing().when(seatRepository).delete(any(Seat.class));
+        mockSeatFind(List.of(existingSeat.id), List.of(existingSeat));
+        when(seatRepository.delete("id in ?1", List.of(existingSeat.id))).thenReturn(1L);
 
         seatService.deleteSeatForManager(List.of(existingSeat.id), adminAuth);
 
-        verify(seatRepository, times(1)).delete(existingSeat);
+        verify(seatRepository, times(1)).delete("id in ?1", List.of(existingSeat.id));
     }
 
     @Test
     void deleteSeat_NotFound() {
-        when(seatRepository.findByIdOptional(any(UUID.class))).thenReturn(Optional.empty());
+        mockSeatFind(List.of(id(99)), List.of());
 
         assertThrows(
                 SeatNotFoundException.class,
                 () -> seatService.deleteSeatForManager(List.of(id(99)), managerAuth));
-        verify(seatRepository, never()).delete(any(Seat.class));
+        verify(seatRepository, never()).delete("id in ?1", List.of(id(99)));
     }
 
     @Test
@@ -756,15 +763,14 @@ public class SeatServiceTest {
         Seat seatInOtherLocation = new Seat("X1", "", otherLocation);
         seatInOtherLocation.id = id(2);
 
-        when(seatRepository.findByIdOptional(seatInOtherLocation.id))
-                .thenReturn(Optional.of(seatInOtherLocation));
+        mockSeatFind(List.of(seatInOtherLocation.id), List.of(seatInOtherLocation));
 
         assertThrows(
                 SecurityException.class,
                 () ->
                         seatService.deleteSeatForManager(
                                 List.of(seatInOtherLocation.id), managerAuth));
-        verify(seatRepository, never()).delete(any(Seat.class));
+        verify(seatRepository, never()).delete("id in ?1", List.of(seatInOtherLocation.id));
     }
 
     @Test


### PR DESCRIPTION
💡 **What:**
Optimized the seat deletion process in `SeatService` by batch-fetching the requested `Seat` entities in a single query using Panache's query by list (`id in ?1`), validating and performing ownership checks in memory, and then deleting the seats in a single bulk/batch query. Also updated the mock setups in `SeatServiceTest` to align with the optimized service method.

🎯 **Why:**
The previous implementation looped through the seat IDs and called `findSeatEntityById(id, manager)` and `seatRepository.delete(seat)` for each individual seat, causing an N+1 query problem (2N queries overall). Batch fetching and batch deleting reduces the query count to O(1) database interactions.

📊 **Measured Improvement:**
Since running the full integration test suite with Testcontainers is not supported in the offline sandboxed environment due to lack of Docker access, a direct performance benchmark could not be executed. However, the theoretical database round-trip performance is optimized from O(N) queries to O(1) queries, yielding a massive performance improvement for multi-seat deletions.

---
*PR created automatically by Jules for task [13581385105202068459](https://jules.google.com/task/13581385105202068459) started by @FelixHertweck*