### PR TITLE
⚡ [MarkerService] Optimize marker deletion by resolving N+1 query issue

### DIFF
--- a/src/main/java/de/felixhertweck/seatreservation/management/service/MarkerService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/management/service/MarkerService.java
@@ -20,7 +20,9 @@
 package de.felixhertweck.seatreservation.management.service;
 
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
@@ -138,9 +140,23 @@ public class MarkerService {
         if (ids == null || ids.isEmpty()) {
             throw new IllegalArgumentException("No marker IDs provided for deletion");
         }
+
+        List<EventLocationMarker> markers = markerRepository.findByIdsWithEventLocation(ids);
+
+        Map<UUID, EventLocationMarker> markerMap =
+                markers.stream().collect(Collectors.toMap(m -> m.id, m -> m));
+
         for (UUID id : ids) {
-            EventLocationMarker marker = findMarkerEntityById(id, manager);
-            markerRepository.delete(marker);
+            EventLocationMarker marker = markerMap.get(id);
+            if (marker == null) {
+                throw new MarkerNotFoundException("Marker with id " + id + " not found");
+            }
+            eventLocationAccessService.requireAccess(marker.getEventLocation(), manager);
+        }
+
+        markerRepository.delete("id in ?1", ids);
+
+        for (UUID id : ids) {
             LOG.infof("Marker ID: %s deleted successfully", id);
         }
     }

--- a/src/main/java/de/felixhertweck/seatreservation/model/repository/EventLocationMarkerRepository.java
+++ b/src/main/java/de/felixhertweck/seatreservation/model/repository/EventLocationMarkerRepository.java
@@ -57,4 +57,21 @@ public class EventLocationMarkerRepository
                         id)
                 .firstResultOptional();
     }
+
+    /**
+     * Finds multiple markers by their IDs, eagerly fetching their event locations and those
+     * locations' managers to optimize bulk checks.
+     *
+     * @param ids the list of marker IDs to find
+     * @return the list of markers found including their event locations and managers
+     */
+    public List<EventLocationMarker> findByIdsWithEventLocation(List<UUID> ids) {
+        return find(
+                        "select e from EventLocationMarker e"
+                                + " join fetch e.eventLocation el"
+                                + " join fetch el.manager"
+                                + " where e.id in ?1",
+                        ids)
+                .list();
+    }
 }

--- a/src/test/java/de/felixhertweck/seatreservation/management/service/MarkerServiceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/management/service/MarkerServiceTest.java
@@ -281,23 +281,22 @@ public class MarkerServiceTest {
         assertThrows(
                 IllegalArgumentException.class,
                 () -> markerService.deleteMarkers(List.of(), managerAuth));
-        verify(markerRepository, never()).delete(any(EventLocationMarker.class));
+        verify(markerRepository, never()).delete(any(String.class), any(Object[].class));
     }
 
     @Test
     void deleteMarkers_Success() {
-        when(markerRepository.findByIdWithEventLocation(existingMarker.id))
-                .thenReturn(Optional.of(existingMarker));
+        when(markerRepository.findByIdsWithEventLocation(List.of(existingMarker.id)))
+                .thenReturn(List.of(existingMarker));
 
         markerService.deleteMarkers(List.of(existingMarker.id), managerAuth);
 
-        verify(markerRepository, times(1)).delete(existingMarker);
+        verify(markerRepository, times(1)).delete("id in ?1", List.of(existingMarker.id));
     }
 
     @Test
     void deleteMarkers_NotFound() {
-        when(markerRepository.findByIdWithEventLocation(any(UUID.class)))
-                .thenReturn(Optional.empty());
+        when(markerRepository.findByIdsWithEventLocation(List.of(id(999)))).thenReturn(List.of());
 
         assertThrows(
                 MarkerNotFoundException.class,
@@ -309,8 +308,8 @@ public class MarkerServiceTest {
         EventLocationMarker markerInOtherLocation = new EventLocationMarker("X", 1, 1);
         markerInOtherLocation.id = id(20);
         markerInOtherLocation.setEventLocation(otherLocation);
-        when(markerRepository.findByIdWithEventLocation(markerInOtherLocation.id))
-                .thenReturn(Optional.of(markerInOtherLocation));
+        when(markerRepository.findByIdsWithEventLocation(List.of(markerInOtherLocation.id)))
+                .thenReturn(List.of(markerInOtherLocation));
 
         assertThrows(
                 SecurityException.class,


### PR DESCRIPTION
🎯 **What:**
- Refactored the marker deletion process in `MarkerService#deleteMarkers` to fetch markers in a single batch query (`findByIdsWithEventLocation`) rather than loading them individually in a loop.
- Batch-validated the permissions of the fetched markers in-memory to ensure correctness and exact exception propagation.
- Replaced the iterative deletion loop with a single bulk delete statement (`markerRepository.delete("id in ?1", ids)`).
- Updated `MarkerServiceTest` mock verifications and setups to support and test the batch-fetching and bulk-deletion behavior correctly.

💡 **Why:**
Deleting $N$ markers previously resulted in:
1. $N$ individual database select queries (with dual join fetches for event location and manager) to retrieve each marker and verify ownership.
2. $N$ individual database delete queries to delete each marker.
This resulted in $2N$ database round-trips (the N+1 query problem), causing high latency, CPU overhead, and increased connection pool pressure.

📊 **Measured Improvement:**
In this sandbox environment, direct database benchmarking was impractical due to the offline sandbox setting and Testcontainers' inability to pull or run Ryuk/Docker.
However, theoretically, the database round-trips have been optimized from $2N$ down to exactly $2$ (one batch fetch and one batch delete query):
- $O(N)$ database round-trips reduced to $O(1)$.
- Reduces database connection load and significantly speeds up delete operations as the number of deleted markers increases.

---
*PR created automatically by Jules for task [15662164864711491228](https://jules.google.com/task/15662164864711491228) started by @FelixHertweck*