### PR TITLE
🧪 [testing improvement] Add comprehensive tests for CSVToDto CLI and error paths

### DIFF
--- a/src/main/java/de/felixhertweck/seatreservation/importer/CSVToDto.java
+++ b/src/main/java/de/felixhertweck/seatreservation/importer/CSVToDto.java
@@ -49,6 +49,13 @@ public class CSVToDto {
     private static final String DEFAULT_JSON = "importer/output.json";
 
     public static void main(String[] args) {
+        int exitCode = run(args);
+        if (exitCode != 0) {
+            System.exit(exitCode);
+        }
+    }
+
+    public static int run(String[] args) {
         String input =
                 args.length > 0 ? args[0] : System.getProperty("importer.input", DEFAULT_CSV);
         String output =
@@ -59,7 +66,7 @@ public class CSVToDto {
         Path inputPath = Path.of(input);
         if (!Files.exists(inputPath)) {
             LOG.errorf("Input file does not exist: %s", inputPath.toAbsolutePath());
-            System.exit(2);
+            return 2;
         }
 
         CSVFormat format =
@@ -90,9 +97,9 @@ public class CSVToDto {
                 processRecord(record, users);
             }
 
-        } catch (IOException e) {
+        } catch (IOException | UncheckedIOException e) {
             LOG.error("Error reading CSV", e);
-            System.exit(3);
+            return 3;
         }
 
         // Write JSON using Jackson
@@ -105,8 +112,10 @@ public class CSVToDto {
             LOG.infof("Wrote %d users to %s", users.size(), outPath.toAbsolutePath());
         } catch (IOException e) {
             LOG.error("Error writing JSON", e);
-            System.exit(4);
+            return 4;
         }
+
+        return 0;
     }
 
     private static String safeGet(CSVRecord record, String header, int index) {

--- a/src/test/java/de/felixhertweck/seatreservation/importer/CSVToDtoTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/importer/CSVToDtoTest.java
@@ -1,0 +1,147 @@
+/*
+ * #%L
+ * seat-reservation
+ * %%
+ * Copyright (C) 2025 Felix Hertweck
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package de.felixhertweck.seatreservation.importer;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class CSVToDtoTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    void run_WithValidCSVAndHeader_ReturnsZeroAndWritesJSON(@TempDir Path tempDir)
+            throws IOException {
+        Path inputCSV = tempDir.resolve("input.csv");
+        Path outputJSON = tempDir.resolve("output.json");
+
+        String csvContent =
+                "firstname;lastname;password;email\n"
+                        + "John;Doe;secret123;john.doe@example.com\n"
+                        + "Jane;Smith;pwd456;jane.smith@example.com\n"
+                        + "Max;Müller;umlautPass;max.mueller@example.com\n"
+                        + "  ;MissingFirstname;nopass;email@example.com\n"; // should skip due to
+        // missing mandatory
+        // fields
+
+        Files.writeString(inputCSV, csvContent);
+
+        int exitCode = CSVToDto.run(new String[] {inputCSV.toString(), outputJSON.toString()});
+
+        assertEquals(0, exitCode, "CSVToDto.run should return 0 on successful processing");
+        assertTrue(Files.exists(outputJSON), "Output JSON file should be created");
+
+        // Deserialize as Map to avoid direct DTO instantiation issue
+        List<Map<String, Object>> users =
+                mapper.readValue(
+                        outputJSON.toFile(), new TypeReference<List<Map<String, Object>>>() {});
+
+        assertEquals(3, users.size(), "Only three valid users should be processed");
+
+        // Assert first user
+        Map<String, Object> user1 = users.get(0);
+        assertEquals("john.doe", user1.get("username"));
+        assertEquals("John", user1.get("firstname"));
+        assertEquals("Doe", user1.get("lastname"));
+        assertEquals("secret123", user1.get("password"));
+        assertEquals("john.doe@example.com", user1.get("email"));
+        assertEquals(Boolean.FALSE, user1.get("sendEmailVerification"));
+        assertEquals(List.of("USER"), user1.get("roles"));
+        assertEquals(List.of("imported"), user1.get("tags"));
+
+        // Assert third user (with German umlaut replaced in username)
+        Map<String, Object> user3 = users.get(2);
+        assertEquals("max.mueller", user3.get("username"));
+        assertEquals("Max", user3.get("firstname"));
+        assertEquals("Müller", user3.get("lastname"));
+    }
+
+    @Test
+    void run_WithValidCSVNoHeader_ReturnsZeroAndWritesJSON(@TempDir Path tempDir)
+            throws IOException {
+        Path inputCSV = tempDir.resolve("input_no_header.csv");
+        Path outputJSON = tempDir.resolve("output.json");
+
+        String csvContent = "Alice;Wonderland;alice123;alice@example.com\n";
+        Files.writeString(inputCSV, csvContent);
+
+        int exitCode = CSVToDto.run(new String[] {inputCSV.toString(), outputJSON.toString()});
+
+        assertEquals(0, exitCode, "CSVToDto.run should return 0 even without header");
+        assertTrue(Files.exists(outputJSON), "Output JSON file should be created");
+
+        List<Map<String, Object>> users =
+                mapper.readValue(
+                        outputJSON.toFile(), new TypeReference<List<Map<String, Object>>>() {});
+        assertEquals(1, users.size());
+
+        Map<String, Object> user = users.get(0);
+        assertEquals("alice.wonderland", user.get("username"));
+        assertEquals("Alice", user.get("firstname"));
+        assertEquals("Wonderland", user.get("lastname"));
+    }
+
+    @Test
+    void run_WithNonExistentInputFile_ReturnsTwo(@TempDir Path tempDir) {
+        Path nonExistent = tempDir.resolve("doesnotexist.csv");
+        Path outputJSON = tempDir.resolve("output.json");
+
+        int exitCode = CSVToDto.run(new String[] {nonExistent.toString(), outputJSON.toString()});
+
+        assertEquals(2, exitCode, "CSVToDto.run should return 2 if input file does not exist");
+    }
+
+    @Test
+    void run_WithCSVReadingError_ReturnsThree(@TempDir Path tempDir) {
+        // Passing a directory path as the CSV file should fail to read
+        Path directoryAsInput = tempDir;
+        Path outputJSON = tempDir.resolve("output.json");
+
+        int exitCode =
+                CSVToDto.run(new String[] {directoryAsInput.toString(), outputJSON.toString()});
+
+        assertEquals(3, exitCode, "CSVToDto.run should return 3 on reading/parsing failure");
+    }
+
+    @Test
+    void run_WithJSONWritingError_ReturnsFour(@TempDir Path tempDir) throws IOException {
+        Path inputCSV = tempDir.resolve("input.csv");
+        Files.writeString(inputCSV, "John;Doe;secret123;john.doe@example.com\n");
+
+        // Passing a directory path as the output JSON file should trigger IOException during JSON
+        // writing
+        Path directoryAsOutput = tempDir;
+
+        int exitCode =
+                CSVToDto.run(new String[] {inputCSV.toString(), directoryAsOutput.toString()});
+
+        assertEquals(4, exitCode, "CSVToDto.run should return 4 on JSON writing failure");
+    }
+}


### PR DESCRIPTION
### 🎯 **What:**
Refactored `CSVToDto.java` to extract its core CLI logic into a testable `public static int run(String[] args)` method. This allows unit testing error paths that previously triggered `System.exit()`, which is difficult to mock and test reliably in Java. Also handled catching both `IOException` and `UncheckedIOException` during CSV processing.

### 📊 **Coverage:**
Added a comprehensive JUnit 5 test suite (`CSVToDtoTest.java`) covering:
- Happy path with a header, valid user data processing, missing mandatory field skipping, and German umlaut mapping.
- Happy path with no header.
- Non-existent input CSV file error path (returning exit code `2`).
- CSV reading and lazy parsing error paths (`IOException` or `UncheckedIOException`, returning exit code `3`) triggered using a directory as input CSV file.
- JSON writing failure error path (returning exit code `4`) triggered using a directory as output JSON path.

### ✨ **Result:**
Significant improvement in test coverage for the CSV importer module, verifying correct CLI exit codes and behavior under both normal and exceptional runtime conditions without terminating the test runner JVM.

---
*PR created automatically by Jules for task [10693303786591617577](https://jules.google.com/task/10693303786591617577) started by @FelixHertweck*