### PR TITLE
🧹 [refactor] Break down monolithic useAuth hook into modular sub-hooks

### DIFF
--- a/webapp/hooks/auth/use-login.ts
+++ b/webapp/hooks/auth/use-login.ts
@@ -1,0 +1,73 @@
+"use client";
+
+import { useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { useT } from "@/lib/i18n/hooks";
+import { postApiAuthLoginMutation } from "@/api/@tanstack/react-query.gen";
+import { Instant, LoginLockedDto } from "@/api";
+import { ErrorWithResponse } from "@/components/init-query-client";
+import { redirectUser } from "@/lib/redirect-User";
+import { useSession } from "./use-session";
+
+export function useLogin() {
+  const t = useT();
+  const params = useParams();
+  const locale = params.locale as string;
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const { user, refetchUser } = useSession();
+
+  const [retryAfter, setRetryAfter] = useState<Instant | null>(null);
+
+  const { mutateAsync: loginMutation } = useMutation({
+    ...postApiAuthLoginMutation(),
+  });
+
+  const login = async (
+    username: string,
+    password: string,
+    returnToUrl?: string | null,
+  ) => {
+    const request = loginMutation({ body: { username, password } });
+    toast.promise(request, {
+      loading: t("common.loading"),
+      success: async () => {
+        setRetryAfter(null);
+        await queryClient.invalidateQueries();
+        await refetchUser();
+        redirectUser(router, locale, user, returnToUrl);
+        return t("login.success.title");
+      },
+      error: (error: ErrorWithResponse) => {
+        const status = error.response?.status;
+        if (status === 429) {
+          try {
+            const parsed: LoginLockedDto = JSON.parse(error.response?.rawData);
+            if (parsed?.retryAfter) {
+              setRetryAfter(parsed.retryAfter);
+            }
+          } catch (error) {
+            console.log(
+              "Failed to parse retryAfter from error response: ",
+              error,
+            );
+          }
+          return t("login.error.tooManyAttemptsDescription");
+        } else if (status !== 401) {
+          return t("login.error.description");
+        }
+        return t("common.error.default");
+      },
+    });
+
+    return request;
+  };
+
+  return {
+    login,
+    retryAfter,
+    setRetryAfter,
+  };
+}

--- a/webapp/hooks/auth/use-logout.ts
+++ b/webapp/hooks/auth/use-logout.ts
@@ -1,0 +1,66 @@
+"use client";
+
+import { useParams, useRouter } from "next/navigation";
+import { useMutation } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { useT } from "@/lib/i18n/hooks";
+import {
+  postApiAuthLogoutAllDevicesMutation,
+  postApiAuthLogoutMutation,
+} from "@/api/@tanstack/react-query.gen";
+import { ErrorWithResponse } from "@/components/init-query-client";
+
+export function useLogout() {
+  const t = useT();
+  const params = useParams();
+  const locale = params.locale as string;
+  const router = useRouter();
+
+  const { mutateAsync: logoutMutation } = useMutation({
+    ...postApiAuthLogoutMutation(),
+  });
+
+  const logout = async () => {
+    const request = logoutMutation({});
+    toast.promise(request, {
+      loading: t("common.loading"),
+      success: () => {
+        router.push(`/${locale}/`);
+        router.refresh();
+        return t("logout.success.title");
+      },
+      error: (error: ErrorWithResponse) => ({
+        message: t("logout.error.title"),
+        description: error.response?.description ?? t("common.error.default"),
+      }),
+    });
+
+    return request;
+  };
+
+  const { mutateAsync: logoutAllMutation } = useMutation({
+    ...postApiAuthLogoutAllDevicesMutation(),
+  });
+
+  const logoutAll = async () => {
+    const request = logoutAllMutation({});
+    toast.promise(request, {
+      loading: t("common.loading"),
+      success: () => {
+        router.push(`/${locale}/`);
+        router.refresh();
+        return t("logoutAll.success.title");
+      },
+      error: (error: ErrorWithResponse) => ({
+        message: t("logoutAll.error.title"),
+        description: error.response?.description ?? t("common.error.default"),
+      }),
+    });
+    return request;
+  };
+
+  return {
+    logout,
+    logoutAll,
+  };
+}

--- a/webapp/hooks/auth/use-password-reset.ts
+++ b/webapp/hooks/auth/use-password-reset.ts
@@ -1,0 +1,62 @@
+"use client";
+
+import { useMutation } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { useT } from "@/lib/i18n/hooks";
+import {
+  postApiAuthPasswordResetMutation,
+  postApiAuthPasswordResetConfirmMutation,
+} from "@/api/@tanstack/react-query.gen";
+import type { PasswordResetConfirmDto, PasswordResetRequestDto } from "@/api";
+import { ErrorWithResponse } from "@/components/init-query-client";
+
+export function usePasswordReset() {
+  const t = useT();
+
+  const { mutateAsync: requestPasswordResetMutation } = useMutation({
+    ...postApiAuthPasswordResetMutation(),
+  });
+
+  const requestPasswordReset = async (requestData: PasswordResetRequestDto) => {
+    const request = requestPasswordResetMutation({ body: requestData });
+    // No success toast: the page already renders an inline success Alert with the same message.
+    toast.promise(request, {
+      loading: t("common.loading"),
+      error: (error: ErrorWithResponse) => ({
+        message: t("forgotPassword.error"),
+        description: error.response?.description ?? t("common.error.default"),
+      }),
+    });
+    return request;
+  };
+
+  const { mutateAsync: confirmPasswordResetMutation } = useMutation({
+    ...postApiAuthPasswordResetConfirmMutation(),
+  });
+
+  const confirmPasswordReset = async (confirmData: PasswordResetConfirmDto) => {
+    const request = confirmPasswordResetMutation({ body: confirmData });
+    // No success toast: the page already renders an inline success Alert with the same message.
+    toast.promise(request, {
+      loading: t("common.loading"),
+      error: (error: ErrorWithResponse) => {
+        const status = error.response?.status;
+        // The component renders its own inline message for a known-bad token;
+        // only toast a generic message for anything unexpected.
+        if (status === 400 || status === 410) {
+          return { message: t("common.error.default") };
+        }
+        return {
+          message: t("resetPassword.error.general"),
+          description: error.response?.description ?? t("common.error.default"),
+        };
+      },
+    });
+    return request;
+  };
+
+  return {
+    requestPasswordReset,
+    confirmPasswordReset,
+  };
+}

--- a/webapp/hooks/auth/use-register.ts
+++ b/webapp/hooks/auth/use-register.ts
@@ -1,0 +1,49 @@
+"use client";
+
+import { useParams, useRouter } from "next/navigation";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { useT } from "@/lib/i18n/hooks";
+import { postApiAuthRegisterMutation } from "@/api/@tanstack/react-query.gen";
+import { RegisterRequestDto } from "@/api";
+import { ErrorWithResponse } from "@/components/init-query-client";
+import { redirectUser } from "@/lib/redirect-User";
+import { useSession } from "./use-session";
+
+export function useRegister() {
+  const t = useT();
+  const params = useParams();
+  const locale = params.locale as string;
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const { user, refetchUser } = useSession();
+
+  const { mutateAsync: registerMutation } = useMutation({
+    ...postApiAuthRegisterMutation(),
+  });
+
+  const register = async (
+    userData: RegisterRequestDto,
+    returnToUrl?: string | null,
+  ) => {
+    const request = registerMutation({ body: userData });
+    toast.promise(request, {
+      loading: t("common.loading"),
+      success: async () => {
+        await queryClient.invalidateQueries();
+        await refetchUser();
+        redirectUser(router, locale, user, returnToUrl);
+        return t("register.success.title");
+      },
+      error: (error: ErrorWithResponse) => ({
+        message: t("register.error.title"),
+        description: error.response?.description ?? t("common.error.default"),
+      }),
+    });
+    return request;
+  };
+
+  return {
+    register,
+  };
+}

--- a/webapp/hooks/auth/use-session.ts
+++ b/webapp/hooks/auth/use-session.ts
@@ -1,0 +1,45 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import {
+  getApiUsersMeOptions,
+  getApiAuthRegistrationStatusOptions,
+} from "@/api/@tanstack/react-query.gen";
+import { RegistrationStatusDto } from "@/api";
+
+export interface RegistrationStatus {
+  data: RegistrationStatusDto | undefined;
+  isLoading: boolean;
+  isSuccess: boolean;
+}
+
+export function useSession() {
+  const {
+    data: user,
+    isLoading,
+    isSuccess,
+    refetch: refetchUser,
+  } = useQuery(getApiUsersMeOptions());
+
+  const {
+    data: registrationStatus,
+    isLoading: isLoadingRegistrationStatus,
+    isSuccess: isSuccessRegistrationStatus,
+  } = useQuery({
+    ...getApiAuthRegistrationStatusOptions(),
+    staleTime: Infinity,
+    gcTime: Infinity,
+  });
+
+  return {
+    user,
+    isLoading,
+    isLoggedIn: isSuccess,
+    refetchUser,
+    registrationStatus: {
+      data: registrationStatus,
+      isLoading: isLoadingRegistrationStatus,
+      isSuccess: isSuccessRegistrationStatus,
+    } as RegistrationStatus,
+  };
+}

--- a/webapp/hooks/auth/use-username-recovery.ts
+++ b/webapp/hooks/auth/use-username-recovery.ts
@@ -1,0 +1,35 @@
+"use client";
+
+import { useMutation } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { useT } from "@/lib/i18n/hooks";
+import { postApiAuthUsernameRecoveryMutation } from "@/api/@tanstack/react-query.gen";
+import type { UsernameRecoveryRequestDto } from "@/api";
+import { ErrorWithResponse } from "@/components/init-query-client";
+
+export function useUsernameRecovery() {
+  const t = useT();
+
+  const { mutateAsync: requestUsernameRecoveryMutation } = useMutation({
+    ...postApiAuthUsernameRecoveryMutation(),
+  });
+
+  const requestUsernameRecovery = async (
+    requestData: UsernameRecoveryRequestDto,
+  ) => {
+    const request = requestUsernameRecoveryMutation({ body: requestData });
+    // No success toast: the page already renders an inline success Alert with the same message.
+    toast.promise(request, {
+      loading: t("common.loading"),
+      error: (error: ErrorWithResponse) => ({
+        message: t("forgotUsername.error"),
+        description: error.response?.description ?? t("common.error.default"),
+      }),
+    });
+    return request;
+  };
+
+  return {
+    requestUsernameRecovery,
+  };
+}

--- a/webapp/hooks/auth/use-verify-email.ts
+++ b/webapp/hooks/auth/use-verify-email.ts
@@ -1,0 +1,70 @@
+"use client";
+
+import { useParams, useRouter } from "next/navigation";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { useT } from "@/lib/i18n/hooks";
+import {
+  postApiUserResendEmailConfirmationMutation,
+  postApiUserVerifyEmailCodeMutation,
+} from "@/api/@tanstack/react-query.gen";
+import { ErrorWithResponse } from "@/components/init-query-client";
+import { redirectUser } from "@/lib/redirect-User";
+import { useSession } from "./use-session";
+
+const EMAIL_VERIFICATION_REDIRECT_DELAY_MS = 2000;
+
+export function useVerifyEmail() {
+  const t = useT();
+  const params = useParams();
+  const locale = params.locale as string;
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const { user } = useSession();
+
+  const { mutateAsync: verifyEmailMutation } = useMutation({
+    ...postApiUserVerifyEmailCodeMutation(),
+  });
+
+  const verifyEmail = async (code: string, returnToUrl?: string | null) => {
+    const request = verifyEmailMutation({ body: { verificationCode: code } });
+    toast.promise(request, {
+      loading: t("common.loading"),
+      success: async () => {
+        await queryClient.invalidateQueries();
+        await new Promise((resolve) =>
+          setTimeout(resolve, EMAIL_VERIFICATION_REDIRECT_DELAY_MS),
+        );
+        redirectUser(router, locale, user, returnToUrl);
+        return t("emailVerification.success.title");
+      },
+      error: (error: ErrorWithResponse) => ({
+        message: t("emailVerification.error.title"),
+        description: error.response?.description ?? t("common.error.default"),
+      }),
+    });
+    return request;
+  };
+
+  const resendConfirmationMutation = useMutation({
+    ...postApiUserResendEmailConfirmationMutation(),
+  });
+
+  const resendConfirmation = async (): Promise<void> => {
+    const request = resendConfirmationMutation.mutateAsync({});
+    toast.promise(request, {
+      loading: t("emailVerification.resendingConfirmationEmail"),
+      success: t("email.confirmationEmailSentTitle"),
+      error: (error: ErrorWithResponse) => ({
+        message: t("emailVerification.resendConfirmationEmailFailed"),
+        description: error.response?.description ?? t("common.error.default"),
+      }),
+    });
+    return request;
+  };
+
+  return {
+    verifyEmail,
+    resendConfirmation,
+  };
+}

--- a/webapp/hooks/use-auth.ts
+++ b/webapp/hooks/use-auth.ts
@@ -1,291 +1,27 @@
 "use client";
 
-import { useParams, useRouter } from "next/navigation";
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { toast } from "sonner";
-import { useT } from "@/lib/i18n/hooks";
-import {
-  getApiAuthRegistrationStatusOptions,
-  getApiUsersMeOptions,
-  postApiAuthLoginMutation,
-  postApiAuthLogoutAllDevicesMutation,
-  postApiAuthLogoutMutation,
-  postApiAuthPasswordResetConfirmMutation,
-  postApiAuthPasswordResetMutation,
-  postApiAuthRegisterMutation,
-  postApiAuthUsernameRecoveryMutation,
-  postApiUserResendEmailConfirmationMutation,
-  postApiUserVerifyEmailCodeMutation,
-} from "@/api/@tanstack/react-query.gen";
-import {
-  Instant,
-  LoginLockedDto,
-  type PasswordResetConfirmDto,
-  type PasswordResetRequestDto,
-  type RegisterRequestDto,
-  type RegistrationStatusDto,
-  type UsernameRecoveryRequestDto,
-} from "@/api";
-import { ErrorWithResponse } from "@/components/init-query-client";
-import { useState } from "react";
-import { redirectUser } from "@/lib/redirect-User";
-
-const EMAIL_VERIFICATION_REDIRECT_DELAY_MS = 2000;
+import { useSession, type RegistrationStatus } from "./auth/use-session";
+import { useLogin } from "./auth/use-login";
+import { useRegister } from "./auth/use-register";
+import { useLogout } from "./auth/use-logout";
+import { useVerifyEmail } from "./auth/use-verify-email";
+import { usePasswordReset } from "./auth/use-password-reset";
+import { useUsernameRecovery } from "./auth/use-username-recovery";
 
 export function useAuth() {
-  const t = useT();
-  const params = useParams();
-  const locale = params.locale as string;
-
-  const router = useRouter();
-  const queryClient = useQueryClient();
-
-  const [retryAfter, setRetryAfter] = useState<Instant | null>(null);
-
-  const {
-    data: user,
-    isLoading,
-    isSuccess,
-    refetch: refetchUser,
-  } = useQuery(getApiUsersMeOptions());
-
-  const { mutateAsync: loginMutation } = useMutation({
-    ...postApiAuthLoginMutation(),
-  });
-
-  const login = async (
-    username: string,
-    password: string,
-    returnToUrl?: string | null,
-  ) => {
-    const request = loginMutation({ body: { username, password } });
-    toast.promise(request, {
-      loading: t("common.loading"),
-      success: async () => {
-        setRetryAfter(null);
-        await queryClient.invalidateQueries();
-        await refetchUser();
-        redirectUser(router, locale, user, returnToUrl);
-        return t("login.success.title");
-      },
-      error: (error: ErrorWithResponse) => {
-        const status = error.response?.status;
-        if (status === 429) {
-          try {
-            // parse json
-            const parsed: LoginLockedDto = JSON.parse(error.response?.rawData);
-            if (parsed?.retryAfter) {
-              setRetryAfter(parsed.retryAfter);
-            }
-          } catch (error) {
-            console.log(
-              "Failed to parse retryAfter from error response: ",
-              error,
-            );
-          }
-          return t("login.error.tooManyAttemptsDescription");
-        }
-        // Only show toast for non-401 errors, let 401s be handled by the component
-        else if (status !== 401) {
-          return t("login.error.description");
-        }
-        return t("common.error.default"); // Fallback
-      },
-    });
-
-    return request;
-  };
-
-  const { mutateAsync: registerMutation } = useMutation({
-    ...postApiAuthRegisterMutation(),
-  });
-
-  const register = async (
-    userData: RegisterRequestDto,
-    returnToUrl?: string | null,
-  ) => {
-    const request = registerMutation({ body: userData });
-    toast.promise(request, {
-      loading: t("common.loading"),
-      success: async () => {
-        await queryClient.invalidateQueries();
-        await refetchUser();
-        redirectUser(router, locale, user, returnToUrl);
-        return t("register.success.title");
-      },
-      error: (error: ErrorWithResponse) => ({
-        message: t("register.error.title"),
-        description: error.response?.description ?? t("common.error.default"),
-      }),
-    });
-    return request;
-  };
-
-  const { mutateAsync: logoutMutation } = useMutation({
-    ...postApiAuthLogoutMutation(),
-  });
-
-  const logout = async () => {
-    const request = logoutMutation({});
-    toast.promise(request, {
-      loading: t("common.loading"),
-      success: () => {
-        router.push(`/${locale}/`);
-        router.refresh();
-        return t("logout.success.title");
-      },
-      error: (error: ErrorWithResponse) => ({
-        message: t("logout.error.title"),
-        description: error.response?.description ?? t("common.error.default"),
-      }),
-    });
-
-    return request;
-  };
-
-  const { mutateAsync: logoutAllMutation } = useMutation({
-    ...postApiAuthLogoutAllDevicesMutation(),
-  });
-
-  const logoutAll = async () => {
-    const request = logoutAllMutation({});
-    toast.promise(request, {
-      loading: t("common.loading"),
-      success: () => {
-        router.push(`/${locale}/`);
-        router.refresh();
-
-        return t("logoutAll.success.title");
-      },
-      error: (error: ErrorWithResponse) => ({
-        message: t("logoutAll.error.title"),
-        description: error.response?.description ?? t("common.error.default"),
-      }),
-    });
-    return request;
-  };
-
-  const { mutateAsync: verifyEmailMutation } = useMutation({
-    ...postApiUserVerifyEmailCodeMutation(),
-  });
-
-  const verifyEmail = async (code: string, returnToUrl?: string | null) => {
-    const request = verifyEmailMutation({ body: { verificationCode: code } });
-    toast.promise(request, {
-      loading: t("common.loading"),
-      success: async () => {
-        await queryClient.invalidateQueries();
-        await new Promise((resolve) =>
-          setTimeout(resolve, EMAIL_VERIFICATION_REDIRECT_DELAY_MS),
-        );
-        redirectUser(router, locale, user, returnToUrl);
-        return t("emailVerification.success.title");
-      },
-      error: (error: ErrorWithResponse) => ({
-        message: t("emailVerification.error.title"),
-        description: error.response?.description ?? t("common.error.default"),
-      }),
-    });
-    return request;
-  };
-
-  const { mutateAsync: requestPasswordResetMutation } = useMutation({
-    ...postApiAuthPasswordResetMutation(),
-  });
-
-  const requestPasswordReset = async (requestData: PasswordResetRequestDto) => {
-    const request = requestPasswordResetMutation({ body: requestData });
-    // No success toast: the page already renders an inline success Alert with the same message.
-    toast.promise(request, {
-      loading: t("common.loading"),
-      error: (error: ErrorWithResponse) => ({
-        message: t("forgotPassword.error"),
-        description: error.response?.description ?? t("common.error.default"),
-      }),
-    });
-    return request;
-  };
-
-  const { mutateAsync: requestUsernameRecoveryMutation } = useMutation({
-    ...postApiAuthUsernameRecoveryMutation(),
-  });
-
-  const requestUsernameRecovery = async (
-    requestData: UsernameRecoveryRequestDto,
-  ) => {
-    const request = requestUsernameRecoveryMutation({ body: requestData });
-    // No success toast: the page already renders an inline success Alert with the same message.
-    toast.promise(request, {
-      loading: t("common.loading"),
-      error: (error: ErrorWithResponse) => ({
-        message: t("forgotUsername.error"),
-        description: error.response?.description ?? t("common.error.default"),
-      }),
-    });
-    return request;
-  };
-
-  const { mutateAsync: confirmPasswordResetMutation } = useMutation({
-    ...postApiAuthPasswordResetConfirmMutation(),
-  });
-
-  const confirmPasswordReset = async (confirmData: PasswordResetConfirmDto) => {
-    const request = confirmPasswordResetMutation({ body: confirmData });
-    // No success toast: the page already renders an inline success Alert with the same message.
-    toast.promise(request, {
-      loading: t("common.loading"),
-      error: (error: ErrorWithResponse) => {
-        const status = error.response?.status;
-        // The component renders its own inline message for a known-bad token;
-        // only toast a generic message for anything unexpected.
-        if (status === 400 || status === 410) {
-          return { message: t("common.error.default") };
-        }
-        return {
-          message: t("resetPassword.error.general"),
-          description: error.response?.description ?? t("common.error.default"),
-        };
-      },
-    });
-    return request;
-  };
-
-  const resendConfirmationMutation = useMutation({
-    ...postApiUserResendEmailConfirmationMutation(),
-  });
-
-  const resendConfirmation = async (): Promise<void> => {
-    const request = resendConfirmationMutation.mutateAsync({});
-    toast.promise(request, {
-      loading: t("emailVerification.resendingConfirmationEmail"),
-      success: t("email.confirmationEmailSentTitle"),
-      error: (error: ErrorWithResponse) => ({
-        message: t("emailVerification.resendConfirmationEmailFailed"),
-        description: error.response?.description ?? t("common.error.default"),
-      }),
-    });
-    return request;
-  };
-
-  const {
-    data: registrationStatus,
-    isLoading: isLoadingRegistrationStatus,
-    isSuccess: isSuccessRegistrationStatus,
-  } = useQuery({
-    ...getApiAuthRegistrationStatusOptions(),
-    staleTime: Infinity,
-    gcTime: Infinity,
-  });
+  const { user, isLoading, isLoggedIn, registrationStatus } = useSession();
+  const { login, retryAfter } = useLogin();
+  const { register } = useRegister();
+  const { logout, logoutAll } = useLogout();
+  const { verifyEmail, resendConfirmation } = useVerifyEmail();
+  const { requestPasswordReset, confirmPasswordReset } = usePasswordReset();
+  const { requestUsernameRecovery } = useUsernameRecovery();
 
   return {
     user,
-    isLoggedIn: isSuccess,
+    isLoggedIn,
     isLoading,
-    registrationStatus: {
-      data: registrationStatus,
-      isLoading: isLoadingRegistrationStatus,
-      isSuccess: isSuccessRegistrationStatus,
-    } as RegistrationStatus,
+    registrationStatus,
     login,
     register,
     logout,
@@ -299,8 +35,4 @@ export function useAuth() {
   };
 }
 
-interface RegistrationStatus {
-  data: RegistrationStatusDto | undefined;
-  isLoading: boolean;
-  isSuccess: boolean;
-}
+export type { RegistrationStatus };


### PR DESCRIPTION
🎯 **What:** Broken down the monolithic `useAuth` authentication hook into smaller, modular sub-hooks located in `webapp/hooks/auth/`:
- `use-session.ts`: Manages current user state and registration status queries.
- `use-login.ts`: Handles login mutation and account lock/retryAfter state.
- `use-register.ts`: Handles register mutation.
- `use-logout.ts`: Handles log out and log out of all devices.
- `use-verify-email.ts`: Handles verification code processing and email resends.

The main `useAuth` hook in `webapp/hooks/use-auth.ts` has been refactored into a simple composer/facade of these sub-hooks.

💡 **Why:** The single `useAuth` hook was doing too many things, handling both session state query and numerous distinct operations like registration, logging out, locking, and verify email. This created high complexity and reduced readability. Factoring them into specific custom hooks dramatically increases readability, testability, and separation of concerns.

✅ **Verification:** 
- Successfully ran `npm run lint:check` to verify no lint or type warnings.
- Successfully ran `npm run format:check` to ensure Prettier styles are met.
- Successfully ran `npm run build` to compile the entire project without any errors.
- Verified that the interface of the orchestrator is 100% backward-compatible.

✨ **Result:** Made the authentication hook code significantly cleaner, modular, and easier to read and maintain while preserving 100% of the existing behavior.

---
*PR created automatically by Jules for task [6860175224630536568](https://jules.google.com/task/6860175224630536568) started by @FelixHertweck*