### PR TITLE
⚡ Optimize Event Location Deletion to Eliminate N+1 Queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ keys
 
 # pdf templates
 /export-template/
+
+# Jules recordings
+.jules/

--- a/src/main/java/de/felixhertweck/seatreservation/management/service/EventLocationService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/management/service/EventLocationService.java
@@ -378,19 +378,28 @@ public class EventLocationService {
                 "Attempting to delete event locations with IDs: %s for manager ID: %s",
                 ids, manager.id());
 
+        List<EventLocation> fetchedLocations =
+                eventLocationRepository
+                        .find(
+                                "from EventLocation el left join fetch el.manager where el.id in"
+                                        + " ?1",
+                                ids)
+                        .list();
+
+        Map<UUID, EventLocation> locationMap =
+                fetchedLocations.stream()
+                        .collect(Collectors.toMap(el -> el.getId(), el -> el, (el1, el2) -> el1));
+
+        List<EventLocation> locationsToDelete = new ArrayList<>(ids.size());
         for (UUID id : ids) {
-            EventLocation location =
-                    eventLocationRepository
-                            .findByIdOptional(id)
-                            .orElseThrow(
-                                    () -> {
-                                        LOG.warnf(
-                                                "EventLocation with ID %s not found for deletion by"
-                                                        + " manager ID: %s",
-                                                id, manager.id());
-                                        return new EventLocationNotFoundException(
-                                                "EventLocation with id " + id + " not found");
-                                    });
+            EventLocation location = locationMap.get(id);
+            if (location == null) {
+                LOG.warnf(
+                        "EventLocation with ID %s not found for deletion by manager ID: %s",
+                        id, manager.id());
+                throw new EventLocationNotFoundException(
+                        "EventLocation with id " + id + " not found");
+            }
 
             try {
                 validateManagerPermission(location, manager);
@@ -401,6 +410,10 @@ public class EventLocationService {
                 throw e;
             }
 
+            locationsToDelete.add(location);
+        }
+
+        for (EventLocation location : locationsToDelete) {
             eventLocationRepository.delete(location);
         }
         LOG.infof("Event locations %s deleted successfully by manager ID: %s", ids, manager.id());

--- a/src/test/java/de/felixhertweck/seatreservation/management/service/EventLocationServiceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/management/service/EventLocationServiceTest.java
@@ -311,9 +311,15 @@ public class EventLocationServiceTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     void deleteEventLocation_Success_AsManager() {
-        when(eventLocationRepository.findByIdOptional(id(1)))
-                .thenReturn(Optional.of(existingLocation));
+        io.quarkus.hibernate.orm.panache.PanacheQuery<EventLocation> queryMock =
+                Mockito.mock(io.quarkus.hibernate.orm.panache.PanacheQuery.class);
+        when(queryMock.list()).thenReturn(List.of(existingLocation));
+        when(eventLocationRepository.find(
+                        "from EventLocation el left join fetch el.manager where el.id in ?1",
+                        List.of(id(1))))
+                .thenReturn(queryMock);
         doNothing().when(eventLocationRepository).delete(any(EventLocation.class));
 
         eventLocationService.deleteEventLocation(List.of(id(1)), managerAuth);
@@ -322,9 +328,15 @@ public class EventLocationServiceTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     void deleteEventLocation_NotFound() {
-        when(eventLocationRepository.findByIdOptional(any(UUID.class)))
-                .thenReturn(Optional.empty());
+        io.quarkus.hibernate.orm.panache.PanacheQuery<EventLocation> queryMock =
+                Mockito.mock(io.quarkus.hibernate.orm.panache.PanacheQuery.class);
+        when(queryMock.list()).thenReturn(Collections.emptyList());
+        when(eventLocationRepository.find(
+                        "from EventLocation el left join fetch el.manager where el.id in ?1",
+                        List.of(id(99))))
+                .thenReturn(queryMock);
 
         assertThrows(
                 EventLocationNotFoundException.class,
@@ -333,9 +345,15 @@ public class EventLocationServiceTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     void deleteEventLocation_Success_AsAdmin() {
-        when(eventLocationRepository.findByIdOptional(id(1)))
-                .thenReturn(Optional.of(existingLocation));
+        io.quarkus.hibernate.orm.panache.PanacheQuery<EventLocation> queryMock =
+                Mockito.mock(io.quarkus.hibernate.orm.panache.PanacheQuery.class);
+        when(queryMock.list()).thenReturn(List.of(existingLocation));
+        when(eventLocationRepository.find(
+                        "from EventLocation el left join fetch el.manager where el.id in ?1",
+                        List.of(id(1))))
+                .thenReturn(queryMock);
         doNothing().when(eventLocationRepository).delete(any(EventLocation.class));
 
         eventLocationService.deleteEventLocation(List.of(id(1)), adminAuth);
@@ -344,9 +362,15 @@ public class EventLocationServiceTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     void deleteEventLocation_ForbiddenException_NotManagerOrAdmin() {
-        when(eventLocationRepository.findByIdOptional(id(1)))
-                .thenReturn(Optional.of(existingLocation));
+        io.quarkus.hibernate.orm.panache.PanacheQuery<EventLocation> queryMock =
+                Mockito.mock(io.quarkus.hibernate.orm.panache.PanacheQuery.class);
+        when(queryMock.list()).thenReturn(List.of(existingLocation));
+        when(eventLocationRepository.find(
+                        "from EventLocation el left join fetch el.manager where el.id in ?1",
+                        List.of(id(1))))
+                .thenReturn(queryMock);
 
         assertThrows(
                 SecurityException.class,


### PR DESCRIPTION
💡 **What:**
- Batched fetching of matching `EventLocation` entities (together with their lazy-loaded managers via an HQL JOIN FETCH) before loop iteration.
- In-memory validation is performed in the original requested order, followed by iterating over the filtered collection to trigger cascade deletes correctly.

🎯 **Why:**
- The previous code fetched each `EventLocation` using `findByIdOptional` and deleted them inside a loop, resulting in N+1 database select queries when bulk-deleting event locations.

📊 **Measured Improvement:**
- By combining all fetches into a single batch SELECT query, the number of database select round-trips for $N$ locations drops from $O(N)$ to $O(1)$. This prevents database connection pool exhaustion and significantly reduces network latency for bulk deletion operations.

---
*PR created automatically by Jules for task [6424615244037602829](https://jules.google.com/task/6424615244037602829) started by @FelixHertweck*