### PR TITLE
🧹 Extract helper methods in GlobalExceptionHandler

### DIFF
--- a/src/main/java/de/felixhertweck/seatreservation/GlobalExceptionHandler.java
+++ b/src/main/java/de/felixhertweck/seatreservation/GlobalExceptionHandler.java
@@ -78,59 +78,16 @@ public class GlobalExceptionHandler implements ExceptionMapper<Exception> {
      */
     @Override
     public Response toResponse(Exception exception) {
+        if (exception instanceof AccountLockedException accountLockedException) {
+            return handleAccountLocked(accountLockedException);
+        }
+
         ErrorResponseDTO errorResponse = new ErrorResponseDTO(exception.getMessage());
-        Response.Status status;
+        Response.Status status = determineStatus(exception);
         List<NewCookie> cookies = new ArrayList<>();
 
-        switch (exception) {
-            case EventBookingClosedException ignored -> status = Response.Status.BAD_REQUEST;
-            case EventNotFoundException ignored -> status = Response.Status.NOT_FOUND;
-            case EventLocationNotFoundException ignored -> status = Response.Status.NOT_FOUND;
-            case ReservationNotFoundException ignored -> status = Response.Status.NOT_FOUND;
-            case SeatNotFoundException ignored -> status = Response.Status.NOT_FOUND;
-            case AreaNotFoundException ignored -> status = Response.Status.NOT_FOUND;
-            case EntranceNotFoundException ignored -> status = Response.Status.NOT_FOUND;
-            case MarkerNotFoundException ignored -> status = Response.Status.NOT_FOUND;
-            case AreaInUseException ignored -> status = Response.Status.CONFLICT;
-            case EntranceInUseException ignored -> status = Response.Status.CONFLICT;
-            case NoSeatsAvailableException ignored -> status = Response.Status.BAD_REQUEST;
-            case SeatAlreadyReservedException ignored -> status = Response.Status.CONFLICT;
-            case SeatBlockedException ignored -> status = Response.Status.CONFLICT;
-            case CheckInTokenNotFoundException ignored -> status = Response.Status.NOT_FOUND;
-            case CheckInException ignored -> status = Response.Status.BAD_REQUEST;
-            case JwtInvalidException ignored -> {
-                NewCookie jwtAccessCookie = tokenService.createNewNullCookie("jwt", true);
-                NewCookie refreshTokenCookie =
-                        tokenService.createNewNullCookie("refreshToken", true);
-                NewCookie refreshTokenExpirationCookie =
-                        tokenService.createNewNullCookie("refreshToken_expiration", false);
-                cookies.add(jwtAccessCookie);
-                cookies.add(refreshTokenCookie);
-                cookies.add(refreshTokenExpirationCookie);
-                status = Response.Status.UNAUTHORIZED;
-            }
-            case AuthenticationFailedException ignored -> status = Response.Status.UNAUTHORIZED;
-            case LastCredentialException ignored -> status = Response.Status.CONFLICT;
-            case DuplicateUserException ignored -> status = Response.Status.CONFLICT;
-            case InvalidUserException ignored -> status = Response.Status.BAD_REQUEST;
-            case RegistrationDisabledException ignored -> status = Response.Status.FORBIDDEN;
-            case VerificationCodeNotFoundException ignored -> status = Response.Status.BAD_REQUEST;
-            case VerifyTokenExpiredException ignored -> status = Response.Status.GONE;
-            case UserNotFoundException ignored -> status = Response.Status.NOT_FOUND;
-            case IllegalArgumentException ignored -> status = Response.Status.BAD_REQUEST;
-            case SecurityException ignored -> status = Response.Status.FORBIDDEN;
-            case IllegalStateException ignored -> status = Response.Status.BAD_REQUEST;
-            case AccountLockedException accountLockedException -> {
-                status = Response.Status.TOO_MANY_REQUESTS;
-                LoginLockedDTO errorResponseLogin =
-                        new LoginLockedDTO(
-                                accountLockedException.getMessage(),
-                                accountLockedException.getRetryAfter());
-                return Response.status(status).entity(errorResponseLogin).build();
-            }
-            default -> {
-                status = Response.Status.INTERNAL_SERVER_ERROR;
-            }
+        if (exception instanceof JwtInvalidException) {
+            cookies.addAll(clearJwtCookies());
         }
 
         LOG.warnf(
@@ -140,5 +97,59 @@ public class GlobalExceptionHandler implements ExceptionMapper<Exception> {
                 .entity(errorResponse)
                 .cookie(cookies.toArray(NewCookie[]::new))
                 .build();
+    }
+
+    private Response.Status determineStatus(Exception exception) {
+        return switch (exception) {
+            case EventBookingClosedException ignored -> Response.Status.BAD_REQUEST;
+            case EventNotFoundException ignored -> Response.Status.NOT_FOUND;
+            case EventLocationNotFoundException ignored -> Response.Status.NOT_FOUND;
+            case ReservationNotFoundException ignored -> Response.Status.NOT_FOUND;
+            case SeatNotFoundException ignored -> Response.Status.NOT_FOUND;
+            case AreaNotFoundException ignored -> Response.Status.NOT_FOUND;
+            case EntranceNotFoundException ignored -> Response.Status.NOT_FOUND;
+            case MarkerNotFoundException ignored -> Response.Status.NOT_FOUND;
+            case AreaInUseException ignored -> Response.Status.CONFLICT;
+            case EntranceInUseException ignored -> Response.Status.CONFLICT;
+            case NoSeatsAvailableException ignored -> Response.Status.BAD_REQUEST;
+            case SeatAlreadyReservedException ignored -> Response.Status.CONFLICT;
+            case SeatBlockedException ignored -> Response.Status.CONFLICT;
+            case CheckInTokenNotFoundException ignored -> Response.Status.NOT_FOUND;
+            case CheckInException ignored -> Response.Status.BAD_REQUEST;
+            case JwtInvalidException ignored -> Response.Status.UNAUTHORIZED;
+            case AuthenticationFailedException ignored -> Response.Status.UNAUTHORIZED;
+            case LastCredentialException ignored -> Response.Status.CONFLICT;
+            case DuplicateUserException ignored -> Response.Status.CONFLICT;
+            case InvalidUserException ignored -> Response.Status.BAD_REQUEST;
+            case RegistrationDisabledException ignored -> Response.Status.FORBIDDEN;
+            case VerificationCodeNotFoundException ignored -> Response.Status.BAD_REQUEST;
+            case VerifyTokenExpiredException ignored -> Response.Status.GONE;
+            case UserNotFoundException ignored -> Response.Status.NOT_FOUND;
+            case IllegalArgumentException ignored -> Response.Status.BAD_REQUEST;
+            case SecurityException ignored -> Response.Status.FORBIDDEN;
+            case IllegalStateException ignored -> Response.Status.BAD_REQUEST;
+            default -> Response.Status.INTERNAL_SERVER_ERROR;
+        };
+    }
+
+    private List<NewCookie> clearJwtCookies() {
+        List<NewCookie> cookies = new ArrayList<>();
+        NewCookie jwtAccessCookie = tokenService.createNewNullCookie("jwt", true);
+        NewCookie refreshTokenCookie = tokenService.createNewNullCookie("refreshToken", true);
+        NewCookie refreshTokenExpirationCookie =
+                tokenService.createNewNullCookie("refreshToken_expiration", false);
+        cookies.add(jwtAccessCookie);
+        cookies.add(refreshTokenCookie);
+        cookies.add(refreshTokenExpirationCookie);
+        return cookies;
+    }
+
+    private Response handleAccountLocked(AccountLockedException accountLockedException) {
+        Response.Status status = Response.Status.TOO_MANY_REQUESTS;
+        LoginLockedDTO errorResponseLogin =
+                new LoginLockedDTO(
+                        accountLockedException.getMessage(),
+                        accountLockedException.getRetryAfter());
+        return Response.status(status).entity(errorResponseLogin).build();
     }
 }

--- a/src/test/java/de/felixhertweck/seatreservation/GlobalExceptionHandlerTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/GlobalExceptionHandlerTest.java
@@ -19,6 +19,7 @@
  */
 package de.felixhertweck.seatreservation;
 
+import java.time.Instant;
 import java.util.Map;
 import jakarta.ws.rs.core.NewCookie;
 import jakarta.ws.rs.core.Response;
@@ -41,6 +42,8 @@ import de.felixhertweck.seatreservation.reservation.exception.EventBookingClosed
 import de.felixhertweck.seatreservation.reservation.exception.NoSeatsAvailableException;
 import de.felixhertweck.seatreservation.reservation.exception.SeatAlreadyReservedException;
 import de.felixhertweck.seatreservation.reservation.exception.SeatBlockedException;
+import de.felixhertweck.seatreservation.security.dto.LoginLockedDTO;
+import de.felixhertweck.seatreservation.security.exceptions.AccountLockedException;
 import de.felixhertweck.seatreservation.security.exceptions.AuthenticationFailedException;
 import de.felixhertweck.seatreservation.security.exceptions.JwtInvalidException;
 import de.felixhertweck.seatreservation.security.service.TokenService;
@@ -307,5 +310,18 @@ class GlobalExceptionHandlerTest {
         assertTrue(response.getEntity() instanceof ErrorResponseDTO);
         ErrorResponseDTO errorResponse = (ErrorResponseDTO) response.getEntity();
         assertEquals(customMessage, errorResponse.getMessage());
+    }
+
+    @Test
+    void testAccountLockedException() {
+        Instant retryAfter = Instant.ofEpochSecond(1700000000L);
+        AccountLockedException exception = new AccountLockedException("Account locked", retryAfter);
+        Response response = exceptionHandler.toResponse(exception);
+
+        assertEquals(Response.Status.TOO_MANY_REQUESTS.getStatusCode(), response.getStatus());
+        assertTrue(response.getEntity() instanceof LoginLockedDTO);
+        LoginLockedDTO errorResponse = (LoginLockedDTO) response.getEntity();
+        assertEquals("Account locked", errorResponse.getMessage());
+        assertEquals(retryAfter, errorResponse.getRetryAfter());
     }
 }


### PR DESCRIPTION
### 🎯 **What:**
The code health issue addressed is a large and complex exception-to-response mapping switch statement in `GlobalExceptionHandler.java`. We have extracted focused private sub-methods to simplify the main `toResponse` handler:
1. `determineStatus(Exception exception)`: Maps exceptions to corresponding `Response.Status` values.
2. `clearJwtCookies()`: Handles creating empty/null JWT and Refresh tokens to force re-authentication.
3. `handleAccountLocked(AccountLockedException exception)`: Builds and returns the specific response entity (`LoginLockedDTO`) for a locked account.

### 💡 **Why:**
By extracting these helper methods, the main entry point `toResponse` is now extremely clean, self-documenting, and easy to maintain. It reduces cognitive load, separates concerns, and simplifies future extensions.

### ✅ **Verification:**
1. Ran `mvn spotless:apply` to ensure code styles and headers conform strictly to formatting specifications.
2. Created a comprehensive unit test for `AccountLockedException` response mapping.
3. Successfully executed all unit tests via `mvn test -Dtest=GlobalExceptionHandlerTest` with 100% success rate (21/21 passed).

### ✨ **Result:**
The main exception mapper is highly readable, easily readable, and maintains exact behavioral equivalence with the original code, backed by robust unit tests.

---
*PR created automatically by Jules for task [17090935631128445202](https://jules.google.com/task/17090935631128445202) started by @FelixHertweck*