### PR TITLE
🛡️ Sentinel: [HIGH] Fix predictable SecureRandom sequence in native builds

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-07-26 - Predictable SecureRandom sequence in GraalVM native builds
+**Vulnerability:** A static `SecureRandom` instance was used for random code generation.
+**Learning:** In Quarkus GraalVM native builds, static `SecureRandom` fields cache their seed at build time, causing predictable sequences.
+**Prevention:** Always use the centralized `SecurityUtils` (configured with `--initialize-at-run-time` in `pom.xml`) for random number generation (e.g., `SecurityUtils.nextInt()`) to ensure a fresh runtime seed.

--- a/src/main/java/de/felixhertweck/seatreservation/utils/CodeGenerator.java
+++ b/src/main/java/de/felixhertweck/seatreservation/utils/CodeGenerator.java
@@ -19,18 +19,15 @@
  */
 package de.felixhertweck.seatreservation.utils;
 
-import java.security.SecureRandom;
-
 public class CodeGenerator {
 
     private static final String CHARACTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
     private static final int CODE_LENGTH = 8;
-    private static final SecureRandom random = new SecureRandom();
 
     public static String generateRandomCode() {
         StringBuilder code = new StringBuilder(CODE_LENGTH);
         for (int i = 0; i < CODE_LENGTH; i++) {
-            code.append(CHARACTERS.charAt(random.nextInt(CHARACTERS.length())));
+            code.append(CHARACTERS.charAt(SecurityUtils.nextInt(CHARACTERS.length())));
         }
         return code.toString();
     }


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** A static `SecureRandom` instance was used in `CodeGenerator.java`. In Quarkus GraalVM native builds, static fields are initialized at build time, causing the random seed to be cached. This results in the same predictable sequence of random numbers being generated on every application restart.
🎯 **Impact:** Highly predictable random codes could allow attackers to guess access codes, verification codes, or tokens generated by this utility, leading to unauthorized access or security bypass.
🔧 **Fix:** Replaced the static `SecureRandom` instance with calls to the centralized `SecurityUtils` which is properly configured in `pom.xml` with `--initialize-at-run-time`.
✅ **Verification:** Ran backend tests for `CodeGenerator` and verified they pass. Verified code diff ensuring no static `SecureRandom` is used.

---
*PR created automatically by Jules for task [7655892042528659369](https://jules.google.com/task/7655892042528659369) started by @FelixHertweck*