### PR TITLE
🛡️ Sentinel: [HIGH] Fix predictable secure random sequences in native builds

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,4 +1,0 @@
-## 2026-07-26 - Predictable SecureRandom in Quarkus Native Builds
-**Vulnerability:** Static `SecureRandom` fields initialized at class-loading time result in predictable random sequences (e.g. check-in codes, tokens) in Quarkus GraalVM native builds.
-**Learning:** In GraalVM native builds, static fields are often initialized at build time, and their state is baked into the executable. For `SecureRandom`, this means the seed is generated once during the build, leading to the same sequence of random numbers being generated every time the native application runs.
-**Prevention:** Avoid statically initializing `SecureRandom` instances unless explicitly configured for runtime initialization. Use a centralized utility (e.g., `SecurityUtils`) that is configured with `--initialize-at-run-time` for all random number generation to ensure a fresh, unpredictable seed at application startup.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-07-26 - Predictable SecureRandom in Quarkus Native Builds
+**Vulnerability:** Static `SecureRandom` fields initialized at class-loading time result in predictable random sequences (e.g. check-in codes, tokens) in Quarkus GraalVM native builds.
+**Learning:** In GraalVM native builds, static fields are often initialized at build time, and their state is baked into the executable. For `SecureRandom`, this means the seed is generated once during the build, leading to the same sequence of random numbers being generated every time the native application runs.
+**Prevention:** Avoid statically initializing `SecureRandom` instances unless explicitly configured for runtime initialization. Use a centralized utility (e.g., `SecurityUtils`) that is configured with `--initialize-at-run-time` for all random number generation to ensure a fresh, unpredictable seed at application startup.

--- a/src/main/java/de/felixhertweck/seatreservation/utils/CodeGenerator.java
+++ b/src/main/java/de/felixhertweck/seatreservation/utils/CodeGenerator.java
@@ -19,18 +19,15 @@
  */
 package de.felixhertweck.seatreservation.utils;
 
-import java.security.SecureRandom;
-
 public class CodeGenerator {
 
     private static final String CHARACTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
     private static final int CODE_LENGTH = 8;
-    private static final SecureRandom random = new SecureRandom();
 
     public static String generateRandomCode() {
         StringBuilder code = new StringBuilder(CODE_LENGTH);
         for (int i = 0; i < CODE_LENGTH; i++) {
-            code.append(CHARACTERS.charAt(random.nextInt(CHARACTERS.length())));
+            code.append(CHARACTERS.charAt(SecurityUtils.nextInt(CHARACTERS.length())));
         }
         return code.toString();
     }


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Static `SecureRandom` fields initialized at class-loading time result in predictable random sequences in Quarkus GraalVM native builds.
🎯 **Impact:** Predictable check-in codes or other random tokens could allow attackers to bypass security mechanisms or guess valid codes.
🔧 **Fix:** Replaced the statically initialized `SecureRandom` in `CodeGenerator` with the `SecurityUtils.nextInt()` method. `SecurityUtils` is properly configured for runtime initialization (`--initialize-at-run-time`), guaranteeing a fresh, unpredictable seed at startup.
✅ **Verification:** Verified by compiling the code, running specific unit tests, and checking the code generation functionality.

---
*PR created automatically by Jules for task [9855723517312263404](https://jules.google.com/task/9855723517312263404) started by @FelixHertweck*