### PR TITLE
⚡ Bolt: Optimize EventUserAllowance retrieval avoiding stream filtering memory overhead

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,0 @@
-## 2026-07-27 - Stream Filter Optimization
-**Learning:** Found N+1-like issue where all `EventUserAllowance`s for a user are fetched from the database, then filtered in-memory using `.stream().filter(...)` instead of directly querying the database with `findByUserAndEventId` (which exists!). Memory notes mention: "Avoid fetching large entity collections to filter them in-memory using Java Streams... Instead, use targeted Panache database queries (e.g., repository.findByUserAndEventId)".
-**Action:** Replace `allowances.stream().filter(...)` with direct query calls for performance boost when filtering in collections.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-07-27 - Stream Filter Optimization
+**Learning:** Found N+1-like issue where all `EventUserAllowance`s for a user are fetched from the database, then filtered in-memory using `.stream().filter(...)` instead of directly querying the database with `findByUserAndEventId` (which exists!). Memory notes mention: "Avoid fetching large entity collections to filter them in-memory using Java Streams... Instead, use targeted Panache database queries (e.g., repository.findByUserAndEventId)".
+**Action:** Replace `allowances.stream().filter(...)` with direct query calls for performance boost when filtering in collections.

--- a/src/main/java/de/felixhertweck/seatreservation/reservation/service/ReservationService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/reservation/service/ReservationService.java
@@ -194,11 +194,12 @@ public class ReservationService {
 
         // Check if the user has an allowance for this event
         // And if the user is allowed to reserve that amount of seats
-        List<EventUserAllowance> allowances = eventUserAllowanceRepository.findByUser(currentUser);
+        // Optimization: Use direct Panache query `findByUserAndEventId` instead of fetching all
+        // user allowances
+        // and stream-filtering them in memory, which solves a potential N+1 / memory bottleneck.
         EventUserAllowance eventUserAllowance =
-                allowances.stream()
-                        .filter(a -> a.getEvent().id.equals(event.id))
-                        .findFirst()
+                eventUserAllowanceRepository
+                        .findByUserAndEventId(currentUser, event.id)
                         .orElseThrow(
                                 () -> {
                                     LOG.warnf(

--- a/src/main/java/de/felixhertweck/seatreservation/reservation/service/ReservationService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/reservation/service/ReservationService.java
@@ -194,9 +194,6 @@ public class ReservationService {
 
         // Check if the user has an allowance for this event
         // And if the user is allowed to reserve that amount of seats
-        // Optimization: Use direct Panache query `findByUserAndEventId` instead of fetching all
-        // user allowances
-        // and stream-filtering them in memory, which solves a potential N+1 / memory bottleneck.
         EventUserAllowance eventUserAllowance =
                 eventUserAllowanceRepository
                         .findByUserAndEventId(currentUser, event.id)

--- a/src/test/java/de/felixhertweck/seatreservation/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/reservation/service/ReservationServiceTest.java
@@ -218,7 +218,8 @@ class ReservationServiceTest {
 
         when(eventRepository.findByIdOptional(event.id)).thenReturn(Optional.of(event));
         mockSeatFind(dto.getSeatIds(), List.of(seat1));
-        when(eventUserAllowanceRepository.findByUser(currentUser)).thenReturn(List.of(allowance));
+        when(eventUserAllowanceRepository.findByUserAndEventId(currentUser, event.id))
+                .thenReturn(Optional.of(allowance));
         when(reservationRepository.findByEventId(event.id)).thenReturn(Collections.emptyList());
         doNothing().when(eventUserAllowanceRepository).persist(any(EventUserAllowance.class));
 
@@ -238,7 +239,8 @@ class ReservationServiceTest {
 
         when(eventRepository.findByIdOptional(event.id)).thenReturn(Optional.of(event));
         mockSeatFind(dto.getSeatIds(), List.of(seat1));
-        when(eventUserAllowanceRepository.findByUser(currentUser)).thenReturn(List.of(allowance));
+        when(eventUserAllowanceRepository.findByUserAndEventId(currentUser, event.id))
+                .thenReturn(Optional.of(allowance));
         when(reservationRepository.findByEventId(event.id)).thenReturn(Collections.emptyList());
         when(seatCartService.isHeldByAnotherUser(event.id, seat1.id, currentUser.id))
                 .thenReturn(true);
@@ -312,8 +314,8 @@ class ReservationServiceTest {
 
         when(eventRepository.findByIdOptional(event.id)).thenReturn(Optional.of(event));
         mockSeatFind(dto.getSeatIds(), List.of(seat1));
-        when(eventUserAllowanceRepository.findByUser(currentUser))
-                .thenReturn(Collections.emptyList());
+        when(eventUserAllowanceRepository.findByUserAndEventId(currentUser, event.id))
+                .thenReturn(Optional.empty());
 
         assertThrows(
                 EventNotFoundException.class,
@@ -333,7 +335,8 @@ class ReservationServiceTest {
 
         when(eventRepository.findByIdOptional(event.id)).thenReturn(Optional.of(event));
         mockSeatFind(dto.getSeatIds(), List.of(seat1, seat2, seat3));
-        when(eventUserAllowanceRepository.findByUser(currentUser)).thenReturn(List.of(allowance));
+        when(eventUserAllowanceRepository.findByUserAndEventId(currentUser, event.id))
+                .thenReturn(Optional.of(allowance));
 
         assertThrows(
                 NoSeatsAvailableException.class,
@@ -349,7 +352,8 @@ class ReservationServiceTest {
 
         when(eventRepository.findByIdOptional(event.id)).thenReturn(Optional.of(event));
         mockSeatFind(dto.getSeatIds(), List.of(seat1));
-        when(eventUserAllowanceRepository.findByUser(currentUser)).thenReturn(List.of(allowance));
+        when(eventUserAllowanceRepository.findByUserAndEventId(currentUser, event.id))
+                .thenReturn(Optional.of(allowance));
 
         assertThrows(
                 EventBookingClosedException.class,
@@ -369,7 +373,8 @@ class ReservationServiceTest {
 
         when(eventRepository.findByIdOptional(event.id)).thenReturn(Optional.of(event));
         mockSeatFind(dto.getSeatIds(), List.of(seat1));
-        when(eventUserAllowanceRepository.findByUser(currentUser)).thenReturn(List.of(allowance));
+        when(eventUserAllowanceRepository.findByUserAndEventId(currentUser, event.id))
+                .thenReturn(Optional.of(allowance));
 
         assertThrows(
                 EventBookingClosedException.class,
@@ -392,7 +397,8 @@ class ReservationServiceTest {
                         CodeGenerator.generateRandomCode());
         when(eventRepository.findByIdOptional(event.id)).thenReturn(Optional.of(event));
         mockSeatFind(dto.getSeatIds(), List.of(seat1));
-        when(eventUserAllowanceRepository.findByUser(currentUser)).thenReturn(List.of(allowance));
+        when(eventUserAllowanceRepository.findByUserAndEventId(currentUser, event.id))
+                .thenReturn(Optional.of(allowance));
         when(reservationRepository.findByEventId(event.id))
                 .thenReturn(List.of(existingReservation));
 
@@ -417,7 +423,8 @@ class ReservationServiceTest {
 
         when(eventRepository.findByIdOptional(event.id)).thenReturn(Optional.of(event));
         mockSeatFind(dto.getSeatIds(), List.of(seat1));
-        when(eventUserAllowanceRepository.findByUser(currentUser)).thenReturn(List.of(allowance));
+        when(eventUserAllowanceRepository.findByUserAndEventId(currentUser, event.id))
+                .thenReturn(Optional.of(allowance));
         when(reservationRepository.findByEventId(event.id))
                 .thenReturn(List.of(existingReservation));
 
@@ -435,7 +442,8 @@ class ReservationServiceTest {
         when(reservationRepository.find("id in ?1", List.of(id(1)))).thenReturn(queryMock);
         when(queryMock.list()).thenReturn(List.of(reservation));
 
-        when(eventUserAllowanceRepository.findByUser(currentUser)).thenReturn(List.of(allowance));
+        when(eventUserAllowanceRepository.findByUserAndEventId(currentUser, event.id))
+                .thenReturn(Optional.of(allowance));
         when(eventUserAllowanceRepository.findByUserAndEventId(currentUser, event.id))
                 .thenReturn(Optional.of(allowance));
 
@@ -451,7 +459,8 @@ class ReservationServiceTest {
         when(reservationRepository.find("id in ?1", List.of(id(1)))).thenReturn(queryMock);
         when(queryMock.list()).thenReturn(List.of(reservation));
 
-        when(eventUserAllowanceRepository.findByUser(currentUser)).thenReturn(List.of(allowance));
+        when(eventUserAllowanceRepository.findByUserAndEventId(currentUser, event.id))
+                .thenReturn(Optional.of(allowance));
         when(eventUserAllowanceRepository.findByUserAndEventId(currentUser, event.id))
                 .thenReturn(Optional.of(allowance));
 
@@ -470,8 +479,8 @@ class ReservationServiceTest {
         when(reservationRepository.find("id in ?1", List.of(id(1)))).thenReturn(queryMock);
         when(queryMock.list()).thenReturn(List.of(reservation));
 
-        when(eventUserAllowanceRepository.findByUser(currentUser))
-                .thenReturn(Collections.emptyList());
+        when(eventUserAllowanceRepository.findByUserAndEventId(currentUser, event.id))
+                .thenReturn(Optional.empty());
 
         assertDoesNotThrow(
                 () -> reservationService.deleteReservationForUser(List.of(id(1)), currentUser));
@@ -508,7 +517,8 @@ class ReservationServiceTest {
 
         when(eventRepository.findByIdOptional(event.id)).thenReturn(Optional.of(event));
         mockSeatFind(dto.getSeatIds(), List.of(seat1));
-        when(eventUserAllowanceRepository.findByUser(currentUser)).thenReturn(List.of(allowance));
+        when(eventUserAllowanceRepository.findByUserAndEventId(currentUser, event.id))
+                .thenReturn(Optional.of(allowance));
         when(reservationRepository.findByEventId(event.id)).thenReturn(Collections.emptyList());
         doNothing().when(eventUserAllowanceRepository).persist(any(EventUserAllowance.class));
 


### PR DESCRIPTION
💡 What: The optimization replaces an inefficient fetch-all-and-filter-in-memory strategy for `EventUserAllowance` (i.e. `eventUserAllowanceRepository.findByUser(currentUser)` followed by a `.stream().filter(...)`) with a targeted Panache database query (`eventUserAllowanceRepository.findByUserAndEventId`).
🎯 Why: It solves a potential memory and query time bottleneck (especially if a user has many past allowances).
📊 Impact: Eliminates unnecessary object instantiation and N+1-like memory processing scaling linearly with the number of a user's events, reducing it to a fast O(1) targeted lookup.
🔬 Measurement: Verify by monitoring database query logs when `ReservationService.createReservationForUser` is invoked; observe the single SQL query executing `WHERE user_id = ? AND event_id = ?` without iterating over all user allowances in Java space.

---
*PR created automatically by Jules for task [3801074420697707900](https://jules.google.com/task/3801074420697707900) started by @FelixHertweck*