### PR TITLE
🛡️ Sentinel: [security improvement] Fix uncaught NullPointerException during JWT validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,4 +1,0 @@
-## 2026-07-27 - Safely Parsing UUID Claims in JWTs
-**Vulnerability:** A `NullPointerException` occurs when `UUID.fromString(jwt.getClaim("...").toString())` is called and the underlying claim is missing (null). The code assumed it would throw an `IllegalArgumentException` (which it catches), but instead, it threw an unhandled `NullPointerException`.
-**Learning:** In Quarkus (and Java broadly), passing null to `UUID.fromString()` or calling `.toString()` on a null object skips `IllegalArgumentException` catches and propagates an unhandled `NullPointerException`.
-**Prevention:** Always extract claims into an `Object` or `String` variable, check for null, and explicitly throw a mapped application exception (like `JwtInvalidException` or `IllegalStateException`) before attempting to parse as a UUID.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-07-27 - Safely Parsing UUID Claims in JWTs
+**Vulnerability:** A `NullPointerException` occurs when `UUID.fromString(jwt.getClaim("...").toString())` is called and the underlying claim is missing (null). The code assumed it would throw an `IllegalArgumentException` (which it catches), but instead, it threw an unhandled `NullPointerException`.
+**Learning:** In Quarkus (and Java broadly), passing null to `UUID.fromString()` or calling `.toString()` on a null object skips `IllegalArgumentException` catches and propagates an unhandled `NullPointerException`.
+**Prevention:** Always extract claims into an `Object` or `String` variable, check for null, and explicitly throw a mapped application exception (like `JwtInvalidException` or `IllegalStateException`) before attempting to parse as a UUID.

--- a/src/main/java/de/felixhertweck/seatreservation/security/service/TokenService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/security/service/TokenService.java
@@ -166,7 +166,11 @@ public class TokenService {
         // Extract token id and value from JWT
         UUID tokenId;
         try {
-            tokenId = UUID.fromString(jwt.getClaim("token_id"));
+            Object tokenIdClaim = jwt.getClaim("token_id");
+            if (tokenIdClaim == null) {
+                throw new JwtInvalidException("Missing token_id in JWT");
+            }
+            tokenId = UUID.fromString(tokenIdClaim.toString());
         } catch (IllegalArgumentException e) {
             throw new JwtInvalidException("Invalid token_id in JWT", e);
         }

--- a/src/main/java/de/felixhertweck/seatreservation/utils/UserSecurityContext.java
+++ b/src/main/java/de/felixhertweck/seatreservation/utils/UserSecurityContext.java
@@ -63,7 +63,11 @@ public class UserSecurityContext {
      * @return the authenticated user's ID and roles
      */
     public AuthenticatedUser getAuthenticatedUser() {
-        UUID id = UUID.fromString(jsonWebToken.getClaim("uid").toString());
+        Object uidClaim = jsonWebToken.getClaim("uid");
+        if (uidClaim == null) {
+            throw new IllegalStateException("JWT missing uid claim");
+        }
+        UUID id = UUID.fromString(uidClaim.toString());
         return new AuthenticatedUser(id, securityIdentity.getRoles());
     }
 

--- a/src/test/java/de/felixhertweck/seatreservation/utils/UserSecurityContextTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/utils/UserSecurityContextTest.java
@@ -235,4 +235,18 @@ class UserSecurityContextTest {
         verify(userRepository).getReference(id(42));
         verifyNoInteractions(principal);
     }
+
+    @Test
+    void getAuthenticatedUser_NullUid_ThrowsIllegalStateException() {
+        // Arrange
+        when(jsonWebToken.getClaim("uid")).thenReturn(null);
+
+        // Act & Assert
+        IllegalStateException exception =
+                assertThrows(
+                        IllegalStateException.class,
+                        () -> userSecurityContext.getAuthenticatedUser());
+
+        assertEquals("JWT missing uid claim", exception.getMessage());
+    }
 }


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: When parsing a JWT, if the `token_id` or `uid` claims were missing, the system called `toString()` on a null reference or passed null into `UUID.fromString()`. This bypassed the caught `IllegalArgumentException` handling and propagated an unhandled `NullPointerException`.
🎯 Impact: Attackers could potentially submit malformed JWTs that lacked specific claims, resulting in unhandled server-side 500 errors, stack trace logging, and potential Denial of Service.
🔧 Fix: Updated `TokenService` and `UserSecurityContext` to defensively check if claims are null, explicitly throwing appropriate application exceptions (`JwtInvalidException` / `IllegalStateException`) *before* parsing the UUID. 
✅ Verification: Ran `TokenServiceTest` and added explicit verification in `UserSecurityContextTest` via `getAuthenticatedUser_NullUid_ThrowsIllegalStateException` to confirm correct behavior. Included findings in the Sentinel journal.

---
*PR created automatically by Jules for task [718305580542772775](https://jules.google.com/task/718305580542772775) started by @FelixHertweck*