### PR TITLE
fix(backend): trigger immediate email dispatch instead of waiting for poll

### DIFF
--- a/src/main/java/de/felixhertweck/seatreservation/email/queue/EmailDispatcher.java
+++ b/src/main/java/de/felixhertweck/seatreservation/email/queue/EmailDispatcher.java
@@ -22,7 +22,10 @@ package de.felixhertweck.seatreservation.email.queue;
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.event.TransactionPhase;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
 
@@ -75,12 +78,81 @@ public class EmailDispatcher {
     @ConfigProperty(name = "email.queue.sending-timeout-seconds", defaultValue = "300")
     long sendingTimeoutSeconds;
 
-    /** Periodically drains the outbox. Interval and enablement are configurable. */
+    @ConfigProperty(name = "email.queue.immediate-trigger", defaultValue = "true")
+    boolean immediateTriggerEnabled;
+
+    /** Guards against piling up concurrent drain loops when many mails are enqueued at once. */
+    private final AtomicBoolean draining = new AtomicBoolean(false);
+
+    /**
+     * Set by every {@link #triggerDrain} call and cleared at the start of each loop pass; lets a
+     * trigger that arrives while the loop is winding down ask for one more pass instead of being
+     * silently dropped (see {@link #drainLoop}).
+     */
+    private final AtomicBoolean pendingRedrain = new AtomicBoolean(false);
+
+    /**
+     * Fallback poll of the outbox. In the common case {@link #onEmailEnqueued} already triggers a
+     * drain right after a message is committed, so this mainly picks up retries (whose {@code
+     * nextAttemptAt} lies in the future) and messages left behind by a crashed instance.
+     */
     @Scheduled(
             every = "${email.queue.poll-interval:30s}",
             concurrentExecution = ConcurrentExecution.SKIP)
     void scheduledDrain() {
         drainQueue();
+    }
+
+    /**
+     * Triggers an immediate drain once a message has been committed to the outbox, instead of
+     * waiting for the next {@link #scheduledDrain} tick. Runs as an {@code AFTER_SUCCESS}
+     * transactional observer so it never fires for a message whose enqueuing transaction rolled
+     * back.
+     *
+     * @param event the enqueue notification (payload unused; only its arrival matters)
+     */
+    void onEmailEnqueued(
+            @Observes(during = TransactionPhase.AFTER_SUCCESS) EmailEnqueuedEvent event) {
+        if (immediateTriggerEnabled) {
+            triggerDrain();
+        }
+    }
+
+    /**
+     * Runs {@link #drainQueue} on a virtual thread until the outbox reports nothing left to send,
+     * coalescing concurrent triggers (e.g. from a bulk send enqueuing many messages at once) into a
+     * single loop so each one doesn't open its own database connection.
+     */
+    private void triggerDrain() {
+        pendingRedrain.set(true);
+        if (draining.compareAndSet(false, true)) {
+            Thread.ofVirtual().name("email-dispatch-trigger").start(this::drainLoop);
+        }
+    }
+
+    /**
+     * Drains the queue until empty, then releases {@link #draining} and checks {@link
+     * #pendingRedrain} once more before actually exiting.
+     *
+     * <p>Without that recheck, a trigger landing between this loop's last (empty) {@link
+     * #drainQueue} call and the release of {@link #draining} would see draining still in progress,
+     * assume this loop will pick up its message, and return without starting a new one -- silently
+     * falling back to the next {@link #scheduledDrain} tick instead of dispatching immediately.
+     */
+    private void drainLoop() {
+        try {
+            do {
+                pendingRedrain.set(false);
+                int sent;
+                do {
+                    sent = drainQueue();
+                } while (sent > 0);
+                draining.set(false);
+            } while (pendingRedrain.get() && draining.compareAndSet(false, true));
+        } catch (RuntimeException e) {
+            LOG.error("Immediate email dispatch loop failed", e);
+            draining.set(false);
+        }
     }
 
     /**

--- a/src/main/java/de/felixhertweck/seatreservation/email/queue/EmailEnqueuedEvent.java
+++ b/src/main/java/de/felixhertweck/seatreservation/email/queue/EmailEnqueuedEvent.java
@@ -1,0 +1,29 @@
+/*
+ * #%L
+ * seat-reservation
+ * %%
+ * Copyright (C) 2025 Felix Hertweck
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package de.felixhertweck.seatreservation.email.queue;
+
+import java.util.UUID;
+
+/**
+ * CDI event fired by {@link EmailQueueService#enqueue} once a message has been persisted to the
+ * outbox. Consumed by {@link EmailDispatcher} as a {@code TransactionPhase.AFTER_SUCCESS} observer,
+ * so it only fires once the enqueuing transaction has actually committed.
+ */
+public record EmailEnqueuedEvent(UUID emailId) {}

--- a/src/main/java/de/felixhertweck/seatreservation/email/queue/EmailQueueService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/email/queue/EmailQueueService.java
@@ -22,6 +22,7 @@ package de.felixhertweck.seatreservation.email.queue;
 import java.time.Instant;
 import java.util.ArrayList;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Event;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
 
@@ -46,6 +47,8 @@ public class EmailQueueService {
     private static final Logger LOG = Logger.getLogger(EmailQueueService.class);
 
     @Inject OutboundEmailRepository outboundEmailRepository;
+
+    @Inject Event<EmailEnqueuedEvent> emailEnqueuedEvent;
 
     @ConfigProperty(name = "email.queue.max-attempts", defaultValue = "5")
     int maxAttempts;
@@ -96,6 +99,9 @@ public class EmailQueueService {
                 message.getSubject(),
                 message.getTo().size() + message.getCc().size() + message.getBcc().size(),
                 message.getAttachments().size());
+
+        // Triggers an immediate drain once this transaction commits (see EmailDispatcher).
+        emailEnqueuedEvent.fire(new EmailEnqueuedEvent(email.id));
         return email;
     }
 }

--- a/src/main/resources/application-test.yaml
+++ b/src/main/resources/application-test.yaml
@@ -19,5 +19,6 @@ email:
   # explicitly via EmailDispatcher#drainQueue so assertions stay deterministic.
   queue:
     poll-interval: 24h
+    immediate-trigger: false
     retry-backoff-seconds: 0
     sending-timeout-seconds: 1

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -59,7 +59,8 @@ email:
   # Mails are persisted first and delivered asynchronously by a background dispatcher,
   # which retries failed sends with exponential back-off before giving up (dead letter).
   queue:
-    poll-interval: 30s # How often the dispatcher drains the queue
+    poll-interval: 30s # Fallback poll interval; immediate-trigger normally beats this
+    immediate-trigger: true # Drain right after a mail is committed instead of waiting for the poll
     batch-size: 20 # Max number of mails handled per drain cycle
     max-attempts: 5 # Delivery attempts before a mail becomes a FAILED dead letter
     retry-backoff-seconds: 60 # Base back-off; doubles per attempt (60s, 120s, 240s, ...)

--- a/src/test/java/de/felixhertweck/seatreservation/email/EmailQueueImmediateDispatchTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/email/EmailQueueImmediateDispatchTest.java
@@ -1,0 +1,125 @@
+/*
+ * #%L
+ * seat-reservation
+ * %%
+ * Copyright (C) 2025 Felix Hertweck
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package de.felixhertweck.seatreservation.email;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+import jakarta.inject.Inject;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import de.felixhertweck.seatreservation.email.queue.EmailMessage;
+import de.felixhertweck.seatreservation.email.queue.EmailQueueService;
+import de.felixhertweck.seatreservation.model.entity.EmailStatus;
+import de.felixhertweck.seatreservation.model.entity.OutboundEmail;
+import de.felixhertweck.seatreservation.model.repository.OutboundEmailRepository;
+import io.quarkus.mailer.MockMailbox;
+import io.quarkus.narayana.jta.QuarkusTransaction;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies the {@code email.queue.immediate-trigger} path end-to-end: unlike {@link
+ * EmailQueueDispatcherTest} (which disables it for deterministic manual {@code drainQueue()}
+ * calls), this test re-enables it and asserts a queued mail gets sent on its own. The profile keeps
+ * the inherited {@code poll-interval: 24h} from {@code application-test.yaml}, so a SENT status can
+ * only come from the immediate trigger, not the scheduled fallback.
+ */
+@QuarkusTest
+@TestProfile(EmailQueueImmediateDispatchTest.ImmediateTriggerProfile.class)
+class EmailQueueImmediateDispatchTest {
+
+    private static final String RECIPIENT = "recipient@example.com";
+
+    @Inject EmailQueueService emailQueueService;
+
+    @Inject OutboundEmailRepository outboundEmailRepository;
+
+    @Inject MockMailbox mailbox;
+
+    @BeforeEach
+    void setUp() {
+        mailbox.clear();
+        QuarkusTransaction.requiringNew()
+                .run(
+                        () ->
+                                outboundEmailRepository
+                                        .listAll()
+                                        .forEach(outboundEmailRepository::delete));
+    }
+
+    private OutboundEmail reload(UUID id) {
+        return QuarkusTransaction.requiringNew().call(() -> outboundEmailRepository.findById(id));
+    }
+
+    private OutboundEmail awaitStatus(UUID id, EmailStatus expected, Duration timeout) {
+        Instant deadline = Instant.now().plus(timeout);
+        OutboundEmail email;
+        do {
+            email = reload(id);
+            if (email.getStatus() == expected) {
+                return email;
+            }
+            try {
+                Thread.sleep(20);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new AssertionError("Interrupted while waiting for status " + expected, e);
+            }
+        } while (Instant.now().isBefore(deadline));
+        fail(
+                "Timed out waiting for status "
+                        + expected
+                        + ", last seen status was "
+                        + email.getStatus());
+        throw new AssertionError("unreachable");
+    }
+
+    @Test
+    void enqueue_withImmediateTriggerEnabled_isSentWithoutManualDrain() {
+        OutboundEmail queued =
+                emailQueueService.enqueue(
+                        EmailMessage.builder()
+                                .to(RECIPIENT)
+                                .subject("Subject")
+                                .htmlBody("<p>Hello</p>")
+                                .build());
+        assertNotNull(queued);
+
+        OutboundEmail result = awaitStatus(queued.id, EmailStatus.SENT, Duration.ofSeconds(5));
+
+        assertEquals(1, mailbox.getMailsSentTo(RECIPIENT).size());
+        assertNotNull(result.getSentAt());
+    }
+
+    public static class ImmediateTriggerProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of("email.queue.immediate-trigger", "true");
+        }
+    }
+}


### PR DESCRIPTION
Emails were only picked up by EmailDispatcher's scheduled poll (default every 30s), so a freshly enqueued mail could sit idle for up to 30 seconds before being sent. EmailQueueService now fires an EmailEnqueuedEvent after persisting, which EmailDispatcher consumes as an AFTER_SUCCESS transactional observer to drain the outbox right after commit. The scheduled poll remains as a fallback for retries and crash recovery. Tests disable the new trigger (immediate-trigger: false) to keep manual drainQueue() assertions deterministic.