### PR TITLE
fix: batch N+1 queries in reservation, email and admin bulk-delete paths

### DIFF
--- a/src/main/java/de/felixhertweck/seatreservation/email/service/EmailSeatMapService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/email/service/EmailSeatMapService.java
@@ -38,6 +38,7 @@ import de.felixhertweck.seatreservation.model.entity.Reservation;
 import de.felixhertweck.seatreservation.model.entity.Seat;
 import de.felixhertweck.seatreservation.model.entity.User;
 import de.felixhertweck.seatreservation.model.repository.EmailSeatMapTokenRepository;
+import de.felixhertweck.seatreservation.model.repository.ReservationRepository;
 import de.felixhertweck.seatreservation.utils.SecurityUtils;
 import de.felixhertweck.seatreservation.utils.SvgRenderer;
 import de.felixhertweck.seatreservation.utils.SvgToPngConverter;
@@ -51,6 +52,8 @@ public class EmailSeatMapService {
     private static final Logger LOG = Logger.getLogger(EmailSeatMapService.class);
 
     @Inject EmailSeatMapTokenRepository tokenRepository;
+
+    @Inject ReservationRepository reservationRepository;
 
     @ConfigProperty(name = "email.seatmap.token.expiration.days", defaultValue = "30")
     long tokenExpirationDays;
@@ -149,8 +152,9 @@ public class EmailSeatMapService {
         List<Seat> allSeats = event.getEventLocation().getSeats();
         Set<String> newReservedSeatNumbers = emailSeatMapToken.getNewReservedSeatNumbers();
         Set<String> existingReservedSeatNumbers =
-                emailSeatMapToken.getUser().getReservations().stream()
-                        .filter(r -> r.getEvent().equals(event))
+                reservationRepository
+                        .findByUserAndEventWithSeat(emailSeatMapToken.getUser(), event)
+                        .stream()
                         .map(Reservation::getSeat)
                         .map(Seat::getSeatNumber)
                         .collect(java.util.stream.Collectors.toSet());

--- a/src/main/java/de/felixhertweck/seatreservation/email/service/EmailService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/email/service/EmailService.java
@@ -25,7 +25,9 @@ import java.time.Year;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
@@ -328,17 +330,39 @@ public class EmailService {
     }
 
     /**
+     * Bulk-loads the seats (with area and entrance pre-fetched) referenced by the given reservation
+     * lists, keyed by seat ID. Avoids triggering one lazy-load query per reservation when the
+     * seat's number, row, area, or entrance is read afterwards.
+     *
+     * @param reservationLists the reservation lists whose seats should be loaded (entries may be
+     *     {@code null})
+     * @return the referenced seats, keyed by seat ID
+     */
+    @SafeVarargs
+    private final Map<UUID, Seat> loadSeatsForReservations(List<Reservation>... reservationLists) {
+        Set<UUID> seatIds = new HashSet<>();
+        for (List<Reservation> reservations : reservationLists) {
+            if (reservations != null) {
+                reservations.forEach(r -> seatIds.add(r.getSeat().getId()));
+            }
+        }
+        return seatRepository.findByIdsWithAreaAndEntrance(seatIds).stream()
+                .collect(Collectors.toMap(s -> s.id, s -> s));
+    }
+
+    /**
      * Maps reservations to the seat views rendered by the templates.
      *
      * @param reservations the reservations to map (may be {@code null})
+     * @param seatById the pre-loaded seats referenced by the reservations, keyed by seat ID
      * @return the seat views, in encounter order
      */
-    private List<SeatView> toSeatViews(List<Reservation> reservations) {
+    private List<SeatView> toSeatViews(List<Reservation> reservations, Map<UUID, Seat> seatById) {
         if (reservations == null) {
             return List.of();
         }
         return reservations.stream()
-                .map(Reservation::getSeat)
+                .map(r -> seatById.get(r.getSeat().getId()))
                 .map(
                         seat ->
                                 new SeatView(
@@ -431,27 +455,30 @@ public class EmailService {
         LOG.debugf("Retrieved PNG image with size: %d bytes", pngImage.length);
 
         // Prepare data for seat list rendering
-        List<Seat> allSeats = seatRepository.findByEventLocation(event.getEventLocation());
         List<Reservation> allUserReservationsForEvent =
                 reservationRepository.findByUserAndEvent(user, event);
         LOG.debugf(
-                "Retrieved %d total seats and %d user reservations for event %s.",
-                allSeats.size(), allUserReservationsForEvent.size(), eventName);
+                "Retrieved %d user reservations for event %s.",
+                allUserReservationsForEvent.size(), eventName);
 
-        Set<Seat> newSeatNumbers =
-                reservations.stream().map(Reservation::getSeat).collect(Collectors.toSet());
-        LOG.debugf("New seat numbers for confirmation: %s", newSeatNumbers);
+        Map<UUID, Seat> seatById =
+                loadSeatsForReservations(reservations, allUserReservationsForEvent);
 
-        Set<Seat> existingSeatNumbers =
+        Set<UUID> newSeatIds =
+                reservations.stream().map(r -> r.getSeat().getId()).collect(Collectors.toSet());
+        LOG.debugf("New seat ids for confirmation: %s", newSeatIds);
+
+        Set<UUID> existingSeatIds =
                 allUserReservationsForEvent.stream()
-                        .map(Reservation::getSeat)
+                        .map(r -> r.getSeat().getId())
                         .collect(Collectors.toSet());
-        existingSeatNumbers.removeAll(newSeatNumbers); // Keep only previously reserved seats
-        LOG.debugf("Existing seat numbers (excluding new ones): %s", existingSeatNumbers);
+        existingSeatIds.removeAll(newSeatIds); // Keep only previously reserved seats
+        LOG.debugf("Existing seat ids (excluding new ones): %s", existingSeatIds);
 
-        List<SeatView> newSeats = toSeatViews(reservations);
+        List<SeatView> newSeats = toSeatViews(reservations, seatById);
         List<SeatView> existingSeats =
-                existingSeatNumbers.stream()
+                existingSeatIds.stream()
+                        .map(seatById::get)
                         .map(
                                 seat ->
                                         new SeatView(
@@ -462,7 +489,7 @@ public class EmailService {
                                                         : null))
                         .collect(Collectors.toList());
 
-        String entranceInfo = generateEntranceInfo(reservations);
+        String entranceInfo = generateEntranceInfo(reservations, seatById);
 
         String htmlContent =
                 reservationConfirmationTemplate
@@ -565,18 +592,17 @@ public class EmailService {
         LOG.debugf("Retrieved PNG image with size: %d bytes", pngImage.length);
 
         // Prepare data for seat list rendering
-        List<Seat> allSeats = seatRepository.findByEventLocation(event.getEventLocation());
-
         LOG.debugf(
-                "Retrieved %d total seats and %d user reservations for event %s.",
-                allSeats.size(),
-                activeReservations != null ? activeReservations.size() : 0,
-                eventName);
+                "Retrieved %d user reservations for event %s.",
+                activeReservations != null ? activeReservations.size() : 0, eventName);
 
-        List<SeatView> deletedSeats = toSeatViews(deletedReservations);
-        List<SeatView> activeSeats = toSeatViews(activeReservations);
+        Map<UUID, Seat> seatById =
+                loadSeatsForReservations(deletedReservations, activeReservations);
 
-        String entranceInfo = generateEntranceInfo(activeReservations);
+        List<SeatView> deletedSeats = toSeatViews(deletedReservations, seatById);
+        List<SeatView> activeSeats = toSeatViews(activeReservations, seatById);
+
+        String entranceInfo = generateEntranceInfo(activeReservations, seatById);
 
         String htmlContent =
                 reservationUpdateTemplate
@@ -686,8 +712,9 @@ public class EmailService {
         byte[] pngImage = pngImageOpt.orElse(new byte[0]);
         LOG.debugf("Retrieved PNG image with size: %d bytes", pngImage.length);
 
-        List<SeatView> seats = toSeatViews(reservations);
-        String entranceInfo = generateEntranceInfo(reservations);
+        Map<UUID, Seat> seatById = loadSeatsForReservations(reservations);
+        List<SeatView> seats = toSeatViews(reservations, seatById);
+        String entranceInfo = generateEntranceInfo(reservations, seatById);
 
         String htmlContent =
                 eventReminderTemplate
@@ -882,10 +909,11 @@ public class EmailService {
      * entrance and creates a formatted text according to the configured template.
      *
      * @param reservations the list of reservations to process
+     * @param seatById the pre-loaded seats referenced by the reservations, keyed by seat ID
      * @return a formatted text describing which entrance to use for which seats, or an empty string
      *     if no valid entrance information is available
      */
-    private String generateEntranceInfo(List<Reservation> reservations) {
+    private String generateEntranceInfo(List<Reservation> reservations, Map<UUID, Seat> seatById) {
         if (reservations == null || reservations.isEmpty()) {
             return "";
         }
@@ -893,7 +921,7 @@ public class EmailService {
         // Group seats by entrance
         var seatsByEntrance =
                 reservations.stream()
-                        .map(Reservation::getSeat)
+                        .map(r -> seatById.get(r.getSeat().getId()))
                         .filter(
                                 seat ->
                                         seat.getEntrance() != null

--- a/src/main/java/de/felixhertweck/seatreservation/management/service/AreaService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/management/service/AreaService.java
@@ -20,7 +20,10 @@
 package de.felixhertweck.seatreservation.management.service;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -164,9 +167,19 @@ public class AreaService {
         if (ids == null || ids.isEmpty()) {
             throw new IllegalArgumentException("No area IDs provided for deletion");
         }
+
+        Map<UUID, EventLocationArea> areaMap =
+                areaRepository.findByIdsWithEventLocation(ids).stream()
+                        .collect(Collectors.toMap(a -> a.id, a -> a));
+        Set<UUID> usedAreaIds = new HashSet<>(seatRepository.findUsedAreaIds(ids));
+
         for (UUID id : ids) {
-            EventLocationArea area = findAreaEntityById(id, manager);
-            if (seatRepository.countByArea(area) > 0) {
+            EventLocationArea area = areaMap.get(id);
+            if (area == null) {
+                throw new AreaNotFoundException("Area with id " + id + " not found");
+            }
+            eventLocationAccessService.requireAccess(area.getEventLocation(), manager);
+            if (usedAreaIds.contains(id)) {
                 throw new AreaInUseException(
                         "Area with id " + id + " is still referenced by at least one seat");
             }

--- a/src/main/java/de/felixhertweck/seatreservation/management/service/EntranceService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/management/service/EntranceService.java
@@ -19,8 +19,12 @@
  */
 package de.felixhertweck.seatreservation.management.service;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
@@ -151,9 +155,19 @@ public class EntranceService {
         if (ids == null || ids.isEmpty()) {
             throw new IllegalArgumentException("No entrance IDs provided for deletion");
         }
+
+        Map<UUID, EventLocationEntrance> entranceMap =
+                entranceRepository.findByIdsWithEventLocation(ids).stream()
+                        .collect(Collectors.toMap(e -> e.id, e -> e));
+        Set<UUID> usedEntranceIds = new HashSet<>(seatRepository.findUsedEntranceIds(ids));
+
         for (UUID id : ids) {
-            EventLocationEntrance entrance = findEntranceEntityById(id, manager);
-            if (seatRepository.countByEntrance(entrance) > 0) {
+            EventLocationEntrance entrance = entranceMap.get(id);
+            if (entrance == null) {
+                throw new EntranceNotFoundException("Entrance with id " + id + " not found");
+            }
+            eventLocationAccessService.requireAccess(entrance.getEventLocation(), manager);
+            if (usedEntranceIds.contains(id)) {
                 throw new EntranceInUseException(
                         "Entrance with id " + id + " is still referenced by at least one seat");
             }

--- a/src/main/java/de/felixhertweck/seatreservation/management/service/EventReservationAllowanceService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/management/service/EventReservationAllowanceService.java
@@ -21,6 +21,7 @@ package de.felixhertweck.seatreservation.management.service;
 
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -85,26 +86,31 @@ public class EventReservationAllowanceService {
 
         Set<EventUserAllowancesDto> resultAllowances = new HashSet<>();
 
-        dto.getUserIds()
-                .forEach(
-                        userId -> {
-                            User user = getUserById(userId);
-                            EventUserAllowance allowance =
-                                    eventUserAllowanceRepository
-                                            .find("user = ?1 and event = ?2", user, event)
-                                            .firstResultOptional()
-                                            .orElse(
-                                                    new EventUserAllowance(
-                                                            user,
-                                                            event,
-                                                            dto.getReservationsAllowedCount()));
+        Map<UUID, User> userMap =
+                userRepository.find("id in ?1", dto.getUserIds()).list().stream()
+                        .collect(Collectors.toMap(u -> u.id, u -> u));
 
-                            allowance.setReservationsAllowedCount(
-                                    dto.getReservationsAllowedCount());
-                            eventUserAllowanceRepository.persist(allowance);
+        Map<UUID, EventUserAllowance> allowanceByUserId =
+                eventUserAllowanceRepository.findByEventAndUserIds(event, dto.getUserIds()).stream()
+                        .collect(Collectors.toMap(a -> a.getUser().id, a -> a));
 
-                            resultAllowances.add(new EventUserAllowancesDto((allowance)));
-                        });
+        for (UUID userId : dto.getUserIds()) {
+            User user = userMap.get(userId);
+            if (user == null) {
+                LOG.warnf("User with ID %s not found.", userId);
+                throw new UserNotFoundException("User with id " + userId + " not found");
+            }
+
+            EventUserAllowance allowance = allowanceByUserId.get(userId);
+            if (allowance == null) {
+                allowance = new EventUserAllowance(user, event, dto.getReservationsAllowedCount());
+            }
+
+            allowance.setReservationsAllowedCount(dto.getReservationsAllowedCount());
+            eventUserAllowanceRepository.persist(allowance);
+
+            resultAllowances.add(new EventUserAllowancesDto(allowance));
+        }
 
         LOG.infof(
                 "Successfully set reservation allowance for user IDs %s and event ID %s",
@@ -304,22 +310,23 @@ public class EventReservationAllowanceService {
                     "No reservation allowance IDs provided for deletion.");
         }
 
+        Map<UUID, EventUserAllowance> allowanceMap =
+                eventUserAllowanceRepository.findByIdsWithEventAndManager(ids).stream()
+                        .collect(Collectors.toMap(a -> a.id, a -> a));
+
         for (UUID id : ids) {
             LOG.debugf(
                     "Attempting to delete reservation allowance with ID: %s for user ID: %s (ID:"
                             + " %s)",
                     id, currentUser.id, currentUser.getId());
-            EventUserAllowance allowance =
-                    eventUserAllowanceRepository
-                            .findByIdOptional(id)
-                            .orElseThrow(
-                                    () -> {
-                                        LOG.warnf(
-                                                "Reservation allowance with ID %s not found for"
-                                                        + " deletion by user: %s (ID: %s)",
-                                                id, currentUser.id, currentUser.getId());
-                                        return new EventNotFoundException("Allowance not found");
-                                    });
+            EventUserAllowance allowance = allowanceMap.get(id);
+            if (allowance == null) {
+                LOG.warnf(
+                        "Reservation allowance with ID %s not found for deletion by user: %s (ID:"
+                                + " %s)",
+                        id, currentUser.id, currentUser.getId());
+                throw new EventNotFoundException("Allowance not found");
+            }
 
             if (!allowance.getEvent().getManager().equals(currentUser)
                     && !currentUser.getRoles().contains(Roles.ADMIN)) {
@@ -347,17 +354,6 @@ public class EventReservationAllowanceService {
                         () -> {
                             LOG.warnf("Event with ID %s not found.", id);
                             return new EventNotFoundException("Event with id " + id + " not found");
-                        });
-    }
-
-    private User getUserById(UUID id) throws UserNotFoundException {
-        LOG.debugf("Attempting to find user by ID: %s", id);
-        return userRepository
-                .findByIdOptional(id)
-                .orElseThrow(
-                        () -> {
-                            LOG.warnf("User with ID %s not found.", id);
-                            return new UserNotFoundException("User with id " + id + " not found");
                         });
     }
 }

--- a/src/main/java/de/felixhertweck/seatreservation/management/service/MarkerService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/management/service/MarkerService.java
@@ -20,7 +20,9 @@
 package de.felixhertweck.seatreservation.management.service;
 
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
@@ -138,8 +140,17 @@ public class MarkerService {
         if (ids == null || ids.isEmpty()) {
             throw new IllegalArgumentException("No marker IDs provided for deletion");
         }
+
+        Map<UUID, EventLocationMarker> markerMap =
+                markerRepository.findByIdsWithEventLocation(ids).stream()
+                        .collect(Collectors.toMap(m -> m.id, m -> m));
+
         for (UUID id : ids) {
-            EventLocationMarker marker = findMarkerEntityById(id, manager);
+            EventLocationMarker marker = markerMap.get(id);
+            if (marker == null) {
+                throw new MarkerNotFoundException("Marker with id " + id + " not found");
+            }
+            eventLocationAccessService.requireAccess(marker.getEventLocation(), manager);
             markerRepository.delete(marker);
             LOG.infof("Marker ID: %s deleted successfully", id);
         }

--- a/src/main/java/de/felixhertweck/seatreservation/management/service/ReservationService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/management/service/ReservationService.java
@@ -320,12 +320,13 @@ public class ReservationService {
                             Instant.now(),
                             ReservationStatus.RESERVED,
                             CodeGenerator.generateRandomCode());
-            reservationRepository.persist(reservation);
             existingReservations.add(reservation);
             LOG.infof(
                     "Reservation created successfully for seat ID %s, user ID %s, event ID %s.",
                     dtoSeatId, dto.getUserId(), dto.getEventId());
         }
+
+        reservationRepository.persistAll(existingReservations);
 
         try {
             emailService.sendReservationConfirmation(
@@ -403,30 +404,42 @@ public class ReservationService {
                         "Adding reservation ID %s to deleted reservations for email notification.",
                         reservation.id);
                 deletedReservations.add(reservation);
+            }
+        }
 
-                // Restore allowance count if it exists
-                eventUserAllowanceRepository
-                        .findByUserAndEvent(reservation.getUser(), reservation.getEvent())
-                        .ifPresentOrElse(
-                                allowance -> {
-                                    allowance.setReservationsAllowedCount(
-                                            allowance.getReservationsAllowedCount() + 1);
-                                    eventUserAllowanceRepository.persist(allowance);
-                                    LOG.debug(
-                                            String.format(
-                                                    "Incremented reservation allowance for user ID"
-                                                        + " %s and event ID %s. New allowance: %d",
-                                                    reservation.getUser().getId(),
-                                                    reservation.getEvent().getId(),
-                                                    allowance.getReservationsAllowedCount()));
-                                },
-                                () -> {
-                                    LOG.debugf(
-                                            "No allowance found for user ID %s and event ID %s,"
-                                                    + " skipping allowance increment.",
-                                            reservation.getUser().getId(),
-                                            reservation.getEvent().getId());
-                                });
+        // Restore allowance counts, grouped by event so each event needs only one allowance
+        // lookup regardless of how many of its reservations were deleted.
+        Map<Event, List<Reservation>> deletedByEvent =
+                deletedReservations.stream().collect(Collectors.groupingBy(Reservation::getEvent));
+        for (Map.Entry<Event, List<Reservation>> eventEntry : deletedByEvent.entrySet()) {
+            Event event = eventEntry.getKey();
+            List<Reservation> reservationsForEvent = eventEntry.getValue();
+            Set<UUID> userIds =
+                    reservationsForEvent.stream()
+                            .map(r -> r.getUser().id)
+                            .collect(Collectors.toSet());
+            Map<UUID, EventUserAllowance> allowanceByUserId =
+                    eventUserAllowanceRepository.findByEventAndUserIds(event, userIds).stream()
+                            .collect(Collectors.toMap(a -> a.getUser().id, a -> a));
+
+            for (Reservation reservation : reservationsForEvent) {
+                EventUserAllowance allowance = allowanceByUserId.get(reservation.getUser().id);
+                if (allowance == null) {
+                    LOG.debugf(
+                            "No allowance found for user ID %s and event ID %s, skipping allowance"
+                                    + " increment.",
+                            reservation.getUser().getId(), event.getId());
+                    continue;
+                }
+                allowance.setReservationsAllowedCount(allowance.getReservationsAllowedCount() + 1);
+                eventUserAllowanceRepository.persist(allowance);
+                LOG.debug(
+                        String.format(
+                                "Incremented reservation allowance for user ID %s and event ID %s."
+                                        + " New allowance: %d",
+                                reservation.getUser().getId(),
+                                event.getId(),
+                                allowance.getReservationsAllowedCount()));
             }
         }
 

--- a/src/main/java/de/felixhertweck/seatreservation/management/service/SeatService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/management/service/SeatService.java
@@ -20,7 +20,9 @@
 package de.felixhertweck.seatreservation.management.service;
 
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
@@ -283,8 +285,18 @@ public class SeatService {
         }
 
         LOG.debugf("Attempting to delete seats with IDs: %s for manager ID: %s", ids, manager.id());
+
+        Map<UUID, Seat> seatMap =
+                seatRepository.findByIdsWithLocation(ids).stream()
+                        .collect(Collectors.toMap(s -> s.id, s -> s));
+
         for (UUID id : ids) {
-            Seat seat = findSeatEntityById(id, manager); // This already checks for ownership
+            Seat seat = seatMap.get(id);
+            if (seat == null) {
+                LOG.warnf("Seat with ID %s not found for user ID: %s", id, manager.id());
+                throw new SeatNotFoundException("Seat with id " + id + " not found");
+            }
+            eventLocationAccessService.requireAccess(seat.getLocation(), manager);
             seatRepository.delete(seat);
             LOG.infof("Seat ID: %s deleted successfully", seat.id);
         }

--- a/src/main/java/de/felixhertweck/seatreservation/model/repository/EventLocationAreaRepository.java
+++ b/src/main/java/de/felixhertweck/seatreservation/model/repository/EventLocationAreaRepository.java
@@ -19,6 +19,7 @@
  */
 package de.felixhertweck.seatreservation.model.repository;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -55,5 +56,23 @@ public class EventLocationAreaRepository implements PanacheRepositoryBase<EventL
                                 + " where e.id = ?1",
                         id)
                 .firstResultOptional();
+    }
+
+    /**
+     * Finds areas by their IDs, eagerly fetching each one's event location and that location's
+     * manager. Used to batch the ownership check for bulk operations (e.g. deletion) instead of
+     * querying once per ID.
+     *
+     * @param ids the area IDs to find
+     * @return the matching areas, each including its event location and manager
+     */
+    public List<EventLocationArea> findByIdsWithEventLocation(Collection<UUID> ids) {
+        return find(
+                        "select e from EventLocationArea e"
+                                + " join fetch e.eventLocation el"
+                                + " join fetch el.manager"
+                                + " where e.id in ?1",
+                        ids)
+                .list();
     }
 }

--- a/src/main/java/de/felixhertweck/seatreservation/model/repository/EventLocationEntranceRepository.java
+++ b/src/main/java/de/felixhertweck/seatreservation/model/repository/EventLocationEntranceRepository.java
@@ -19,6 +19,7 @@
  */
 package de.felixhertweck.seatreservation.model.repository;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -56,5 +57,23 @@ public class EventLocationEntranceRepository
                                 + " where e.id = ?1",
                         id)
                 .firstResultOptional();
+    }
+
+    /**
+     * Finds entrances by their IDs, eagerly fetching each one's event location and that location's
+     * manager. Used to batch the ownership check for bulk operations (e.g. deletion) instead of
+     * querying once per ID.
+     *
+     * @param ids the entrance IDs to find
+     * @return the matching entrances, each including its event location and manager
+     */
+    public List<EventLocationEntrance> findByIdsWithEventLocation(Collection<UUID> ids) {
+        return find(
+                        "select e from EventLocationEntrance e"
+                                + " join fetch e.eventLocation el"
+                                + " join fetch el.manager"
+                                + " where e.id in ?1",
+                        ids)
+                .list();
     }
 }

--- a/src/main/java/de/felixhertweck/seatreservation/model/repository/EventLocationMarkerRepository.java
+++ b/src/main/java/de/felixhertweck/seatreservation/model/repository/EventLocationMarkerRepository.java
@@ -19,6 +19,7 @@
  */
 package de.felixhertweck.seatreservation.model.repository;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -56,5 +57,23 @@ public class EventLocationMarkerRepository
                                 + " where e.id = ?1",
                         id)
                 .firstResultOptional();
+    }
+
+    /**
+     * Finds markers by their IDs, eagerly fetching each one's event location and that location's
+     * manager. Used to batch the ownership check for bulk operations (e.g. deletion) instead of
+     * querying once per ID.
+     *
+     * @param ids the marker IDs to find
+     * @return the matching markers, each including its event location and manager
+     */
+    public List<EventLocationMarker> findByIdsWithEventLocation(Collection<UUID> ids) {
+        return find(
+                        "select e from EventLocationMarker e"
+                                + " join fetch e.eventLocation el"
+                                + " join fetch el.manager"
+                                + " where e.id in ?1",
+                        ids)
+                .list();
     }
 }

--- a/src/main/java/de/felixhertweck/seatreservation/model/repository/EventUserAllowanceRepository.java
+++ b/src/main/java/de/felixhertweck/seatreservation/model/repository/EventUserAllowanceRepository.java
@@ -19,6 +19,7 @@
  */
 package de.felixhertweck.seatreservation.model.repository;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -146,5 +147,70 @@ public class EventUserAllowanceRepository
      */
     public Optional<EventUserAllowance> findByUserIdAndEventId(UUID userId, UUID eventId) {
         return find("user.id = ?1 and event.id = ?2", userId, eventId).firstResultOptional();
+    }
+
+    /**
+     * Finds all event user allowances for a specific user, eagerly fetching each allowance's event.
+     *
+     * @param user the user to search for
+     * @return a list of event user allowances for the specified user, with the event pre-fetched
+     */
+    public List<EventUserAllowance> findByUserWithEvent(User user) {
+        return find("select a from EventUserAllowance a join fetch a.event where a.user = ?1", user)
+                .list();
+    }
+
+    /**
+     * Finds all event user allowances for a specific user, eagerly fetching each allowance's event
+     * and that event's event location.
+     *
+     * @param user the user to search for
+     * @return a list of event user allowances for the specified user, with the event and its
+     *     location pre-fetched
+     */
+    public List<EventUserAllowance> findByUserWithEventAndLocation(User user) {
+        return find(
+                        "select a from EventUserAllowance a"
+                                + " join fetch a.event e"
+                                + " join fetch e.event_location"
+                                + " where a.user = ?1",
+                        user)
+                .list();
+    }
+
+    /**
+     * Finds the event user allowances for a specific event among a set of user IDs. Used to batch
+     * the per-user allowance lookup for bulk operations instead of querying once per user.
+     *
+     * @param event the event to search for
+     * @param userIds the user IDs to restrict the search to
+     * @return a list of matching event user allowances
+     */
+    public List<EventUserAllowance> findByEventAndUserIds(Event event, Collection<UUID> userIds) {
+        if (userIds.isEmpty()) {
+            return List.of();
+        }
+        return find("event = ?1 and user.id in ?2", event, userIds).list();
+    }
+
+    /**
+     * Finds event user allowances by their IDs, eagerly fetching each one's event and that event's
+     * manager. Used to batch the ownership check for bulk operations (e.g. deletion) instead of
+     * querying once per ID.
+     *
+     * @param ids the allowance IDs to find
+     * @return the matching allowances, each including its event and manager
+     */
+    public List<EventUserAllowance> findByIdsWithEventAndManager(Collection<UUID> ids) {
+        if (ids.isEmpty()) {
+            return List.of();
+        }
+        return find(
+                        "select a from EventUserAllowance a"
+                                + " join fetch a.event e"
+                                + " join fetch e.manager"
+                                + " where a.id in ?1",
+                        ids)
+                .list();
     }
 }

--- a/src/main/java/de/felixhertweck/seatreservation/model/repository/ReservationRepository.java
+++ b/src/main/java/de/felixhertweck/seatreservation/model/repository/ReservationRepository.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 import java.util.UUID;
 import jakarta.enterprise.context.ApplicationScoped;
 
+import de.felixhertweck.seatreservation.model.entity.Event;
 import de.felixhertweck.seatreservation.model.entity.Reservation;
 import de.felixhertweck.seatreservation.model.entity.ReservationStatus;
 import de.felixhertweck.seatreservation.model.entity.User;
@@ -69,9 +70,60 @@ public class ReservationRepository implements PanacheRepositoryBase<Reservation,
      * @param event the event to search for
      * @return a list of reservations for the specified user and event
      */
-    public List<Reservation> findByUserAndEvent(
-            User user, de.felixhertweck.seatreservation.model.entity.Event event) {
+    public List<Reservation> findByUserAndEvent(User user, Event event) {
         return find("user = ?1 and event = ?2", user, event).list();
+    }
+
+    /**
+     * Finds all reservations for a specific user and event, eagerly fetching each reservation's
+     * seat.
+     *
+     * @param user the user to search for
+     * @param event the event to search for
+     * @return a list of reservations for the specified user and event, with the seat pre-fetched
+     */
+    public List<Reservation> findByUserAndEventWithSeat(User user, Event event) {
+        return find(
+                        "select r from Reservation r join fetch r.seat"
+                                + " where r.user = ?1 and r.event = ?2",
+                        user,
+                        event)
+                .list();
+    }
+
+    /**
+     * Finds all reservations for a given user that are not blocked, eagerly fetching each
+     * reservation's event.
+     *
+     * @param user the user to search for
+     * @return a list of non-blocked reservations for the specified user, with the event pre-fetched
+     */
+    public List<Reservation> findByUserWithEvent(User user) {
+        return find(
+                        "select r from Reservation r join fetch r.event"
+                                + " where r.user = ?1 and r.status != ?2",
+                        user,
+                        ReservationStatus.BLOCKED)
+                .list();
+    }
+
+    /**
+     * Finds all reservations for a given user that are not blocked, eagerly fetching each
+     * reservation's event and that event's event location.
+     *
+     * @param user the user to search for
+     * @return a list of non-blocked reservations for the specified user, with the event and its
+     *     location pre-fetched
+     */
+    public List<Reservation> findByUserWithEventAndLocation(User user) {
+        return find(
+                        "select r from Reservation r"
+                                + " join fetch r.event e"
+                                + " join fetch e.event_location"
+                                + " where r.user = ?1 and r.status != ?2",
+                        user,
+                        ReservationStatus.BLOCKED)
+                .list();
     }
 
     /**

--- a/src/main/java/de/felixhertweck/seatreservation/model/repository/SeatRepository.java
+++ b/src/main/java/de/felixhertweck/seatreservation/model/repository/SeatRepository.java
@@ -19,6 +19,7 @@
  */
 package de.felixhertweck.seatreservation.model.repository;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -68,5 +69,84 @@ public class SeatRepository implements PanacheRepositoryBase<Seat, UUID> {
      */
     public long countByEntrance(EventLocationEntrance entrance) {
         return count("entrance", entrance);
+    }
+
+    /**
+     * Finds seats by their IDs, eagerly fetching each one's area and entrance. Used to batch-load
+     * the seats referenced by a set of reservations instead of relying on lazy per-seat loads (e.g.
+     * when rendering reservation emails).
+     *
+     * @param ids the seat IDs to find
+     * @return the matching seats, each including its area and entrance
+     */
+    public List<Seat> findByIdsWithAreaAndEntrance(Collection<UUID> ids) {
+        if (ids.isEmpty()) {
+            return List.of();
+        }
+        return find(
+                        "select s from Seat s"
+                                + " left join fetch s.area"
+                                + " left join fetch s.entrance"
+                                + " where s.id in ?1",
+                        ids)
+                .list();
+    }
+
+    /**
+     * Finds seats by their IDs, eagerly fetching each one's event location and that location's
+     * manager. Used to batch the ownership check for bulk operations (e.g. deletion) instead of
+     * querying once per ID.
+     *
+     * @param ids the seat IDs to find
+     * @return the matching seats, each including its event location and manager
+     */
+    public List<Seat> findByIdsWithLocation(Collection<UUID> ids) {
+        if (ids.isEmpty()) {
+            return List.of();
+        }
+        return find(
+                        "select s from Seat s"
+                                + " join fetch s.location l"
+                                + " join fetch l.manager"
+                                + " where s.id in ?1",
+                        ids)
+                .list();
+    }
+
+    /**
+     * Finds which of the given area IDs are still referenced by at least one seat, used to guard
+     * bulk area deletion without one count query per area.
+     *
+     * @param areaIds the area IDs to check
+     * @return the subset of {@code areaIds} that are still referenced by a seat
+     */
+    public List<UUID> findUsedAreaIds(Collection<UUID> areaIds) {
+        if (areaIds.isEmpty()) {
+            return List.of();
+        }
+        return getEntityManager()
+                .createQuery(
+                        "select distinct s.area.id from Seat s where s.area.id in :ids", UUID.class)
+                .setParameter("ids", areaIds)
+                .getResultList();
+    }
+
+    /**
+     * Finds which of the given entrance IDs are still referenced by at least one seat, used to
+     * guard bulk entrance deletion without one count query per entrance.
+     *
+     * @param entranceIds the entrance IDs to check
+     * @return the subset of {@code entranceIds} that are still referenced by a seat
+     */
+    public List<UUID> findUsedEntranceIds(Collection<UUID> entranceIds) {
+        if (entranceIds.isEmpty()) {
+            return List.of();
+        }
+        return getEntityManager()
+                .createQuery(
+                        "select distinct s.entrance.id from Seat s where s.entrance.id in :ids",
+                        UUID.class)
+                .setParameter("ids", entranceIds)
+                .getResultList();
     }
 }

--- a/src/main/java/de/felixhertweck/seatreservation/model/repository/UserRepository.java
+++ b/src/main/java/de/felixhertweck/seatreservation/model/repository/UserRepository.java
@@ -19,6 +19,7 @@
  */
 package de.felixhertweck.seatreservation.model.repository;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -107,5 +108,24 @@ public class UserRepository implements PanacheRepositoryBase<User, UUID> {
      */
     public User getReference(UUID id) {
         return getEntityManager().getReference(User.class, id);
+    }
+
+    /**
+     * Finds which of the given usernames already exist, used to batch-check duplicates for a bulk
+     * user import instead of querying once per username.
+     *
+     * @param usernames the usernames to check
+     * @return the subset of {@code usernames} that already belong to an existing user
+     */
+    public List<String> findExistingUsernames(Collection<String> usernames) {
+        if (usernames.isEmpty()) {
+            return List.of();
+        }
+        return getEntityManager()
+                .createQuery(
+                        "select u.username from User u where u.username in :usernames",
+                        String.class)
+                .setParameter("usernames", usernames)
+                .getResultList();
     }
 }

--- a/src/main/java/de/felixhertweck/seatreservation/reservation/dto/UserEventResponseDTO.java
+++ b/src/main/java/de/felixhertweck/seatreservation/reservation/dto/UserEventResponseDTO.java
@@ -25,6 +25,7 @@ import java.util.UUID;
 
 import de.felixhertweck.seatreservation.common.dto.SeatStatusDTO;
 import de.felixhertweck.seatreservation.model.entity.Event;
+import de.felixhertweck.seatreservation.model.entity.Reservation;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 
 @RegisterForReflection
@@ -39,7 +40,16 @@ public record UserEventResponseDTO(
         List<SeatStatusDTO> seatStatuses,
         UUID locationId,
         Integer reservationsAllowed) {
-    public UserEventResponseDTO(Event event, Integer reservationsAllowed) {
+
+    /**
+     * @param event the event to map
+     * @param reservationsAllowed the reservations-allowed count to embed
+     * @param reservations the event's reservations, pre-fetched by the caller (e.g. via a single
+     *     bulk query for all events in a result set) instead of via the lazy {@code
+     *     event.getReservations()} collection
+     */
+    public UserEventResponseDTO(
+            Event event, Integer reservationsAllowed, List<Reservation> reservations) {
         this(
                 event.getId(),
                 event.getName(),
@@ -48,9 +58,9 @@ public record UserEventResponseDTO(
                 event.getEndTime(),
                 event.getBookingDeadline(),
                 event.getBookingStartTime(),
-                event.getReservations() == null
+                reservations == null
                         ? null
-                        : event.getReservations().stream().map(SeatStatusDTO::new).toList(),
+                        : reservations.stream().map(SeatStatusDTO::new).toList(),
                 event.getEventLocation() == null ? null : event.getEventLocation().getId(),
                 reservationsAllowed);
     }

--- a/src/main/java/de/felixhertweck/seatreservation/reservation/service/EventLocationService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/reservation/service/EventLocationService.java
@@ -30,6 +30,7 @@ import de.felixhertweck.seatreservation.common.exception.UserNotFoundException;
 import de.felixhertweck.seatreservation.model.entity.EventLocation;
 import de.felixhertweck.seatreservation.model.entity.User;
 import de.felixhertweck.seatreservation.model.repository.EventUserAllowanceRepository;
+import de.felixhertweck.seatreservation.model.repository.ReservationRepository;
 import de.felixhertweck.seatreservation.model.repository.UserRepository;
 import de.felixhertweck.seatreservation.reservation.dto.UserEventLocationResponseDTO;
 import org.jboss.logging.Logger;
@@ -40,6 +41,7 @@ public class EventLocationService {
 
     @Inject UserRepository userRepository;
     @Inject EventUserAllowanceRepository eventUserAllowanceRepository;
+    @Inject ReservationRepository reservationRepository;
 
     /**
      * Retrieves all event locations for which the specified user has event allowances or active
@@ -64,13 +66,13 @@ public class EventLocationService {
 
         // Get all locations from allowances
         locations.addAll(
-                eventUserAllowanceRepository.findByUser(user).stream()
+                eventUserAllowanceRepository.findByUserWithEventAndLocation(user).stream()
                         .map(allowance -> allowance.getEvent().getEventLocation())
                         .collect(Collectors.toSet()));
 
         // Get all locations from reservations
         locations.addAll(
-                user.getReservations().stream()
+                reservationRepository.findByUserWithEventAndLocation(user).stream()
                         .map(reservation -> reservation.getEvent().getEventLocation())
                         .collect(Collectors.toSet()));
 

--- a/src/main/java/de/felixhertweck/seatreservation/reservation/service/EventService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/reservation/service/EventService.java
@@ -31,6 +31,9 @@ import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
 
 import de.felixhertweck.seatreservation.common.dto.SeatStatusDTO;
+import de.felixhertweck.seatreservation.model.entity.Event;
+import de.felixhertweck.seatreservation.model.entity.EventUserAllowance;
+import de.felixhertweck.seatreservation.model.entity.Reservation;
 import de.felixhertweck.seatreservation.model.entity.ReservationStatus;
 import de.felixhertweck.seatreservation.model.entity.User;
 import de.felixhertweck.seatreservation.model.repository.EventUserAllowanceRepository;
@@ -56,38 +59,52 @@ public class EventService {
     public List<UserEventResponseDTO> getEventsForCurrentUser(User user) {
         LOG.debugf("Attempting to retrieve events for current user ID: %s", user.id);
 
-        Map<UUID, UserEventResponseDTO> eventMap = new HashMap<>();
+        Map<UUID, Event> events = new HashMap<>();
+        Map<UUID, Integer> reservationsAllowedByEvent = new HashMap<>();
 
         // Add allowances. Also grants seat-cart access for each event here, reusing this query
         // instead of SeatCartService doing its own DB lookup on every cart write.
-        eventUserAllowanceRepository
-                .findByUser(user)
-                .forEach(
-                        allowance -> {
-                            eventMap.put(
-                                    allowance.getEvent().getId(),
-                                    new UserEventResponseDTO(
-                                            allowance.getEvent(),
-                                            allowance.getReservationsAllowedCount()));
-                            seatCartService.grantAccess(
-                                    allowance.getEvent().getId(),
-                                    user.id,
-                                    allowance.getReservationsAllowedCount());
-                        });
+        for (EventUserAllowance allowance :
+                eventUserAllowanceRepository.findByUserWithEvent(user)) {
+            Event event = allowance.getEvent();
+            events.put(event.getId(), event);
+            reservationsAllowedByEvent.put(event.getId(), allowance.getReservationsAllowedCount());
+            seatCartService.grantAccess(
+                    event.getId(), user.id, allowance.getReservationsAllowedCount());
+        }
 
         // Reservations only add if event not already exists
-        reservationRepository
-                .findByUser(user)
-                .forEach(
-                        reservation ->
-                                eventMap.putIfAbsent(
-                                        reservation.getEvent().getId(),
-                                        new UserEventResponseDTO(reservation.getEvent(), 0)));
+        for (Reservation reservation : reservationRepository.findByUserWithEvent(user)) {
+            Event event = reservation.getEvent();
+            events.putIfAbsent(event.getId(), event);
+            reservationsAllowedByEvent.putIfAbsent(event.getId(), 0);
+        }
 
-        LOG.debugf("Returning %d events for user ID: %s", eventMap.size(), user.id);
-        return eventMap.values().stream()
-                .map(dto -> withPendingSeatStatuses(dto, user.id))
-                .toList();
+        // Bulk-load every relevant event's reservations in one query instead of relying on the
+        // lazy event.getReservations() collection (which would run one query per event).
+        Map<UUID, List<Reservation>> reservationsByEvent =
+                events.isEmpty()
+                        ? Map.of()
+                        : reservationRepository
+                                .find("event.id in ?1", events.keySet())
+                                .list()
+                                .stream()
+                                .collect(Collectors.groupingBy(r -> r.getEvent().getId()));
+
+        List<UserEventResponseDTO> result =
+                events.values().stream()
+                        .map(
+                                event ->
+                                        new UserEventResponseDTO(
+                                                event,
+                                                reservationsAllowedByEvent.get(event.getId()),
+                                                reservationsByEvent.getOrDefault(
+                                                        event.getId(), List.of())))
+                        .map(dto -> withPendingSeatStatuses(dto, user.id))
+                        .toList();
+
+        LOG.debugf("Returning %d events for user ID: %s", result.size(), user.id);
+        return result;
     }
 
     /**

--- a/src/main/java/de/felixhertweck/seatreservation/supervisor/service/CheckInService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/supervisor/service/CheckInService.java
@@ -183,9 +183,12 @@ public class CheckInService {
 
                 LOG.debugf("Setting reservation %s to CHECK_IN status.", reservationId);
                 reservation.setLiveStatus(ReservationLiveStatus.CHECKED_IN);
-                reservationRepository.persist(reservation);
                 LOG.infof("Reservation %s successfully checked in.", reservationId);
+            }
 
+            reservationRepository.persistAll(checkInReservations);
+
+            for (Reservation reservation : checkInReservations) {
                 // Broadcast check-in update to WebSocket clients
                 webSocketService.broadcastUpdate(reservation.getEvent().getId(), reservation);
             }
@@ -217,9 +220,12 @@ public class CheckInService {
 
                 LOG.debugf("Setting reservation %s to CANCEL status.", reservationId);
                 reservation.setLiveStatus(ReservationLiveStatus.CANCELLED);
-                reservationRepository.persist(reservation);
                 LOG.infof("Reservation %s successfully cancelled.", reservationId);
+            }
 
+            reservationRepository.persistAll(cancelReservations);
+
+            for (Reservation reservation : cancelReservations) {
                 // Broadcast cancellation update to WebSocket clients
                 webSocketService.broadcastUpdate(reservation.getEvent().getId(), reservation);
             }

--- a/src/main/java/de/felixhertweck/seatreservation/userManagment/service/UserService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/userManagment/service/UserService.java
@@ -79,9 +79,22 @@ public class UserService {
             throws InvalidUserException, DuplicateUserException {
         LOG.infof("Importing %d users.", adminUserCreationDtos.size());
 
+        Set<String> requestedUsernames =
+                adminUserCreationDtos.stream()
+                        .map(AdminUserCreationDto::getUsername)
+                        .collect(Collectors.toSet());
+        Set<String> knownExistingUsernames =
+                new HashSet<>(userRepository.findExistingUsernames(requestedUsernames));
+
         Set<UserDTO> importedUsers = new HashSet<>();
         for (AdminUserCreationDto adminUser : adminUserCreationDtos) {
-            UserDTO user = createUser(new UserCreationDTO(adminUser), adminUser.getRoles(), false);
+            UserDTO user =
+                    createUser(
+                            new UserCreationDTO(adminUser),
+                            adminUser.getRoles(),
+                            false,
+                            false,
+                            knownExistingUsernames);
             importedUsers.add(user);
         }
         return importedUsers;
@@ -123,6 +136,33 @@ public class UserService {
             boolean sendEmailVerification,
             boolean allowNoPassword)
             throws InvalidUserException, DuplicateUserException {
+        return createUser(userCreationDTO, roles, sendEmailVerification, allowNoPassword, null);
+    }
+
+    /**
+     * Creates a new user.
+     *
+     * @param userCreationDTO the data for the new user
+     * @param roles the roles to assign
+     * @param sendEmailVerification whether to send an email verification
+     * @param allowNoPassword when {@code true}, the user may be created without a password (e.g. a
+     *     passkey-only account); the stored password hash is {@code null} and password login is
+     *     unavailable for this user until a password is set
+     * @param knownExistingUsernames when non-{@code null}, the duplicate-username check is done
+     *     against this in-memory set instead of a per-call database query; used by {@link
+     *     #importUsers} to check all usernames of a batch in a single upfront query. The newly
+     *     created user's username is added to the set so later entries in the same batch still
+     *     detect duplicates against each other.
+     * @return the created user
+     */
+    @Transactional
+    public UserDTO createUser(
+            UserCreationDTO userCreationDTO,
+            Set<String> roles,
+            boolean sendEmailVerification,
+            boolean allowNoPassword,
+            Set<String> knownExistingUsernames)
+            throws InvalidUserException, DuplicateUserException {
         if (userCreationDTO == null) {
             LOG.warn("UserCreationDTO is null during user creation.");
             throw new InvalidUserException("User creation data cannot be null.");
@@ -143,7 +183,13 @@ public class UserService {
             throw new InvalidUserException("Password cannot be empty.");
         }
 
-        if (userRepository.findByUsernameOptional(userCreationDTO.getUsername()).isPresent()) {
+        boolean isDuplicate =
+                knownExistingUsernames != null
+                        ? knownExistingUsernames.contains(userCreationDTO.getUsername())
+                        : userRepository
+                                .findByUsernameOptional(userCreationDTO.getUsername())
+                                .isPresent();
+        if (isDuplicate) {
             LOG.warnf(
                     "Duplicate user creation attempt for username: %s",
                     userCreationDTO.getUsername());
@@ -191,6 +237,9 @@ public class UserService {
 
         userRepository.persist(user);
         LOG.debugf("User %s persisted successfully with ID: %s", user.getUsername(), user.id);
+        if (knownExistingUsernames != null) {
+            knownExistingUsernames.add(user.getUsername());
+        }
 
         if (sendEmailVerification) {
             if (user.getEmail() == null || user.getEmail().trim().isEmpty()) {

--- a/src/test/java/de/felixhertweck/seatreservation/email/EmailServiceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/email/EmailServiceTest.java
@@ -257,7 +257,7 @@ class EmailServiceTest {
         List<Reservation> reservations =
                 Collections.singletonList(createTestReservation(user, event, seat));
 
-        when(seatRepository.findByEventLocation(any())).thenReturn(Collections.singletonList(seat));
+        when(seatRepository.findByIdsWithAreaAndEntrance(any())).thenReturn(List.of(seat));
         when(emailSeatMapService.createEmailSeatMapToken(any(), any(), any()))
                 .thenReturn("test-token-123");
         when(emailSeatMapService.getPngImage(anyString())).thenReturn(Optional.of(new byte[0]));
@@ -302,6 +302,7 @@ class EmailServiceTest {
         List<Reservation> reservations =
                 Collections.singletonList(createTestReservation(user, event, seat));
 
+        when(seatRepository.findByIdsWithAreaAndEntrance(any())).thenReturn(List.of(seat));
         when(emailSeatMapService.createEmailSeatMapToken(any(), any(), any()))
                 .thenReturn("test-token-123");
         when(emailSeatMapService.getPngImage(anyString())).thenReturn(Optional.of(new byte[0]));

--- a/src/test/java/de/felixhertweck/seatreservation/email/EmailServiceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/email/EmailServiceTest.java
@@ -330,6 +330,7 @@ class EmailServiceTest {
         List<Reservation> reservations =
                 Collections.singletonList(createTestReservation(user, event, seat));
 
+        when(seatRepository.findByIdsWithAreaAndEntrance(any())).thenReturn(List.of(seat));
         when(emailSeatMapService.createEmailSeatMapToken(any(), any(), any()))
                 .thenReturn("test-token-123");
         when(emailSeatMapService.getPngImage(anyString())).thenReturn(Optional.of(new byte[0]));

--- a/src/test/java/de/felixhertweck/seatreservation/management/service/AreaServiceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/management/service/AreaServiceTest.java
@@ -373,9 +373,9 @@ public class AreaServiceTest {
 
     @Test
     void deleteAreas_Success() {
-        when(areaRepository.findByIdWithEventLocation(existingArea.id))
-                .thenReturn(Optional.of(existingArea));
-        when(seatRepository.countByArea(existingArea)).thenReturn(0L);
+        when(areaRepository.findByIdsWithEventLocation(List.of(existingArea.id)))
+                .thenReturn(List.of(existingArea));
+        when(seatRepository.findUsedAreaIds(List.of(existingArea.id))).thenReturn(List.of());
 
         areaService.deleteAreas(List.of(existingArea.id), managerAuth);
 
@@ -384,8 +384,7 @@ public class AreaServiceTest {
 
     @Test
     void deleteAreas_NotFound() {
-        when(areaRepository.findByIdWithEventLocation(any(UUID.class)))
-                .thenReturn(Optional.empty());
+        when(areaRepository.findByIdsWithEventLocation(List.of(id(999)))).thenReturn(List.of());
 
         assertThrows(
                 AreaNotFoundException.class,
@@ -397,8 +396,8 @@ public class AreaServiceTest {
         EventLocationArea areaInOtherLocation = new EventLocationArea("X");
         areaInOtherLocation.id = id(20);
         areaInOtherLocation.setEventLocation(otherLocation);
-        when(areaRepository.findByIdWithEventLocation(areaInOtherLocation.id))
-                .thenReturn(Optional.of(areaInOtherLocation));
+        when(areaRepository.findByIdsWithEventLocation(List.of(areaInOtherLocation.id)))
+                .thenReturn(List.of(areaInOtherLocation));
 
         assertThrows(
                 SecurityException.class,
@@ -407,9 +406,10 @@ public class AreaServiceTest {
 
     @Test
     void deleteAreas_Conflict_ReferencedBySeat() {
-        when(areaRepository.findByIdWithEventLocation(existingArea.id))
-                .thenReturn(Optional.of(existingArea));
-        when(seatRepository.countByArea(existingArea)).thenReturn(1L);
+        when(areaRepository.findByIdsWithEventLocation(List.of(existingArea.id)))
+                .thenReturn(List.of(existingArea));
+        when(seatRepository.findUsedAreaIds(List.of(existingArea.id)))
+                .thenReturn(List.of(existingArea.id));
 
         assertThrows(
                 AreaInUseException.class,

--- a/src/test/java/de/felixhertweck/seatreservation/management/service/EntranceServiceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/management/service/EntranceServiceTest.java
@@ -367,9 +367,10 @@ public class EntranceServiceTest {
 
     @Test
     void deleteEntrances_Success() {
-        when(entranceRepository.findByIdWithEventLocation(existingEntrance.id))
-                .thenReturn(Optional.of(existingEntrance));
-        when(seatRepository.countByEntrance(existingEntrance)).thenReturn(0L);
+        when(entranceRepository.findByIdsWithEventLocation(List.of(existingEntrance.id)))
+                .thenReturn(List.of(existingEntrance));
+        when(seatRepository.findUsedEntranceIds(List.of(existingEntrance.id)))
+                .thenReturn(List.of());
 
         entranceService.deleteEntrances(List.of(existingEntrance.id), managerAuth);
 
@@ -378,8 +379,7 @@ public class EntranceServiceTest {
 
     @Test
     void deleteEntrances_NotFound() {
-        when(entranceRepository.findByIdWithEventLocation(any(UUID.class)))
-                .thenReturn(Optional.empty());
+        when(entranceRepository.findByIdsWithEventLocation(List.of(id(999)))).thenReturn(List.of());
 
         assertThrows(
                 EntranceNotFoundException.class,
@@ -388,9 +388,10 @@ public class EntranceServiceTest {
 
     @Test
     void deleteEntrances_Conflict_ReferencedBySeat() {
-        when(entranceRepository.findByIdWithEventLocation(existingEntrance.id))
-                .thenReturn(Optional.of(existingEntrance));
-        when(seatRepository.countByEntrance(existingEntrance)).thenReturn(1L);
+        when(entranceRepository.findByIdsWithEventLocation(List.of(existingEntrance.id)))
+                .thenReturn(List.of(existingEntrance));
+        when(seatRepository.findUsedEntranceIds(List.of(existingEntrance.id)))
+                .thenReturn(List.of(existingEntrance.id));
 
         assertThrows(
                 EntranceInUseException.class,

--- a/src/test/java/de/felixhertweck/seatreservation/management/service/EventServiceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/management/service/EventServiceTest.java
@@ -460,14 +460,13 @@ public class EventServiceTest {
 
         when(eventRepository.findByIdOptional(existingEvent.id))
                 .thenReturn(Optional.of(existingEvent));
-        when(userRepository.findByIdOptional(regularUser.id)).thenReturn(Optional.of(regularUser));
-        // Mocking PanacheQuery for find method when no existing allowance is found
         @SuppressWarnings("unchecked")
-        PanacheQuery<EventUserAllowance> mockQueryNewAllowance = mock(PanacheQuery.class);
-        when(eventUserAllowanceRepository.find(
-                        "user = ?1 and event = ?2", regularUser, existingEvent))
-                .thenReturn(mockQueryNewAllowance);
-        when(mockQueryNewAllowance.firstResultOptional()).thenReturn(Optional.empty());
+        PanacheQuery<User> mockUserQuery = mock(PanacheQuery.class);
+        when(userRepository.find("id in ?1", dto.getUserIds())).thenReturn(mockUserQuery);
+        when(mockUserQuery.list()).thenReturn(List.of(regularUser));
+        // Mocking the batch allowance lookup to report no existing allowance
+        when(eventUserAllowanceRepository.findByEventAndUserIds(existingEvent, dto.getUserIds()))
+                .thenReturn(List.of());
         doAnswer(
                         invocation -> {
                             EventUserAllowance allowance = invocation.getArgument(0);
@@ -492,14 +491,12 @@ public class EventServiceTest {
 
         when(eventRepository.findByIdOptional(existingEvent.id))
                 .thenReturn(Optional.of(existingEvent));
-        when(userRepository.findByIdOptional(regularUser.id)).thenReturn(Optional.of(regularUser));
-        // Mocking PanacheQuery for find method
         @SuppressWarnings("unchecked")
-        PanacheQuery<EventUserAllowance> mockQuery = mock(PanacheQuery.class);
-        when(eventUserAllowanceRepository.find(
-                        "user = ?1 and event = ?2", regularUser, existingEvent))
-                .thenReturn(mockQuery);
-        when(mockQuery.firstResultOptional()).thenReturn(Optional.of(existingAllowance));
+        PanacheQuery<User> mockUserQuery = mock(PanacheQuery.class);
+        when(userRepository.find("id in ?1", dto.getUserIds())).thenReturn(mockUserQuery);
+        when(mockUserQuery.list()).thenReturn(List.of(regularUser));
+        when(eventUserAllowanceRepository.findByEventAndUserIds(existingEvent, dto.getUserIds()))
+                .thenReturn(List.of(existingAllowance));
         doNothing().when(eventUserAllowanceRepository).persist(any(EventUserAllowance.class));
 
         eventReservationAllowanceService.setReservationsAllowedForUser(dto, managerAuth);
@@ -519,13 +516,12 @@ public class EventServiceTest {
 
         when(eventRepository.findByIdOptional(existingEvent.id))
                 .thenReturn(Optional.of(existingEvent));
-        when(userRepository.findByIdOptional(regularUser.id)).thenReturn(Optional.of(regularUser));
         @SuppressWarnings("unchecked")
-        PanacheQuery<EventUserAllowance> mockQuery = mock(PanacheQuery.class);
-        when(eventUserAllowanceRepository.find(
-                        "user = ?1 and event = ?2", regularUser, existingEvent))
-                .thenReturn(mockQuery);
-        when(mockQuery.firstResultOptional()).thenReturn(Optional.empty());
+        PanacheQuery<User> mockUserQuery = mock(PanacheQuery.class);
+        when(userRepository.find("id in ?1", dto.getUserIds())).thenReturn(mockUserQuery);
+        when(mockUserQuery.list()).thenReturn(List.of(regularUser));
+        when(eventUserAllowanceRepository.findByEventAndUserIds(existingEvent, dto.getUserIds()))
+                .thenReturn(List.of());
 
         // Act
         eventReservationAllowanceService.setReservationsAllowedForUser(dto, adminAuth);
@@ -562,7 +558,12 @@ public class EventServiceTest {
 
         when(eventRepository.findByIdOptional(existingEvent.id))
                 .thenReturn(Optional.of(existingEvent));
-        when(userRepository.findByIdOptional(any(UUID.class))).thenReturn(Optional.empty());
+        @SuppressWarnings("unchecked")
+        PanacheQuery<User> mockUserQuery = mock(PanacheQuery.class);
+        when(userRepository.find("id in ?1", dto.getUserIds())).thenReturn(mockUserQuery);
+        when(mockUserQuery.list()).thenReturn(List.of());
+        when(eventUserAllowanceRepository.findByEventAndUserIds(existingEvent, dto.getUserIds()))
+                .thenReturn(List.of());
 
         assertThrows(
                 UserNotFoundException.class,

--- a/src/test/java/de/felixhertweck/seatreservation/management/service/MarkerServiceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/management/service/MarkerServiceTest.java
@@ -286,8 +286,8 @@ public class MarkerServiceTest {
 
     @Test
     void deleteMarkers_Success() {
-        when(markerRepository.findByIdWithEventLocation(existingMarker.id))
-                .thenReturn(Optional.of(existingMarker));
+        when(markerRepository.findByIdsWithEventLocation(List.of(existingMarker.id)))
+                .thenReturn(List.of(existingMarker));
 
         markerService.deleteMarkers(List.of(existingMarker.id), managerAuth);
 
@@ -296,8 +296,7 @@ public class MarkerServiceTest {
 
     @Test
     void deleteMarkers_NotFound() {
-        when(markerRepository.findByIdWithEventLocation(any(UUID.class)))
-                .thenReturn(Optional.empty());
+        when(markerRepository.findByIdsWithEventLocation(List.of(id(999)))).thenReturn(List.of());
 
         assertThrows(
                 MarkerNotFoundException.class,
@@ -309,8 +308,8 @@ public class MarkerServiceTest {
         EventLocationMarker markerInOtherLocation = new EventLocationMarker("X", 1, 1);
         markerInOtherLocation.id = id(20);
         markerInOtherLocation.setEventLocation(otherLocation);
-        when(markerRepository.findByIdWithEventLocation(markerInOtherLocation.id))
-                .thenReturn(Optional.of(markerInOtherLocation));
+        when(markerRepository.findByIdsWithEventLocation(List.of(markerInOtherLocation.id)))
+                .thenReturn(List.of(markerInOtherLocation));
 
         assertThrows(
                 SecurityException.class,

--- a/src/test/java/de/felixhertweck/seatreservation/management/service/ReservationServiceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/management/service/ReservationServiceTest.java
@@ -38,6 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
@@ -237,18 +238,18 @@ public class ReservationServiceTest {
 
         doAnswer(
                         inv -> {
-                            Reservation res = inv.getArgument(0);
-                            res.id = id(99);
+                            List<Reservation> reservations = inv.getArgument(0);
+                            reservations.forEach(res -> res.id = id(99));
                             return null;
                         })
                 .when(reservationRepository)
-                .persist(any(Reservation.class));
+                .persistAll(anyList());
 
         Set<ReservationResponseDTO> created = reservationService.createReservations(dto, adminUser);
 
         assertNotNull(created);
         assertEquals(regularUser.id, created.iterator().next().user().id());
-        verify(reservationRepository).persist(any(Reservation.class));
+        verify(reservationRepository).persistAll(anyList());
         verify(eventUserAllowanceRepository).persist(any(EventUserAllowance.class));
         assertEquals(0, allowance.getReservationsAllowedCount()); // Allowance should be decremented
     }
@@ -268,18 +269,18 @@ public class ReservationServiceTest {
 
         doAnswer(
                         inv -> {
-                            Reservation res = inv.getArgument(0);
-                            res.id = id(99);
+                            List<Reservation> reservations = inv.getArgument(0);
+                            reservations.forEach(res -> res.id = id(99));
                             return null;
                         })
                 .when(reservationRepository)
-                .persist(any(Reservation.class));
+                .persistAll(anyList());
 
         Set<ReservationResponseDTO> created = reservationService.createReservations(dto, adminUser);
 
         assertNotNull(created);
         assertEquals(regularUser.id, created.iterator().next().user().id());
-        verify(reservationRepository).persist(any(Reservation.class));
+        verify(reservationRepository).persistAll(anyList());
         verify(eventUserAllowanceRepository, never())
                 .persist(any(EventUserAllowance.class)); // Verify allowance was not persisted
     }
@@ -299,19 +300,19 @@ public class ReservationServiceTest {
 
         doAnswer(
                         inv -> {
-                            Reservation res = inv.getArgument(0);
-                            res.id = id(99);
+                            List<Reservation> reservations = inv.getArgument(0);
+                            reservations.forEach(res -> res.id = id(99));
                             return null;
                         })
                 .when(reservationRepository)
-                .persist(any(Reservation.class));
+                .persistAll(anyList());
 
         Set<ReservationResponseDTO> created =
                 reservationService.createReservations(dto, managerUser);
 
         assertNotNull(created);
         assertEquals(regularUser.id, created.iterator().next().user().id());
-        verify(reservationRepository).persist(any(Reservation.class));
+        verify(reservationRepository).persistAll(anyList());
         verify(eventUserAllowanceRepository, never())
                 .persist(any(EventUserAllowance.class)); // Verify allowance was not persisted
     }
@@ -338,7 +339,7 @@ public class ReservationServiceTest {
 
         assertNotNull(created);
         assertEquals(regularUser.id, created.iterator().next().user().id());
-        verify(reservationRepository).persist(any(Reservation.class));
+        verify(reservationRepository).persistAll(anyList());
         verify(eventUserAllowanceRepository).persist(any(EventUserAllowance.class));
         assertEquals(0, allowance.getReservationsAllowedCount()); // Allowance should be decremented
     }
@@ -484,8 +485,8 @@ public class ReservationServiceTest {
         allowance.setReservationsAllowedCount(0);
 
         mockReservationFind(List.of(reservation.id), List.of(reservation));
-        when(eventUserAllowanceRepository.findByUserAndEvent(regularUser, event))
-                .thenReturn(Optional.of(allowance));
+        when(eventUserAllowanceRepository.findByEventAndUserIds(event, Set.of(regularUser.id)))
+                .thenReturn(List.of(allowance));
         doNothing().when(eventUserAllowanceRepository).persist(any(EventUserAllowance.class));
 
         reservationService.deleteReservation(List.of(reservation.id), managerUser);
@@ -551,8 +552,8 @@ public class ReservationServiceTest {
 
         mockReservationFind(
                 List.of(reservation.id, reservation2.id), List.of(reservation, reservation2));
-        when(eventUserAllowanceRepository.findByUserAndEvent(regularUser, event))
-                .thenReturn(Optional.of(allowance));
+        when(eventUserAllowanceRepository.findByEventAndUserIds(event, Set.of(regularUser.id)))
+                .thenReturn(List.of(allowance));
         doNothing().when(eventUserAllowanceRepository).persist(any(EventUserAllowance.class));
 
         reservationService.deleteReservation(List.of(reservation.id, reservation2.id), managerUser);
@@ -602,8 +603,8 @@ public class ReservationServiceTest {
         mockReservationFind(
                 List.of(blockedReservation.id, reservedReservation.id),
                 List.of(blockedReservation, reservedReservation));
-        when(eventUserAllowanceRepository.findByUserAndEvent(regularUser, event))
-                .thenReturn(Optional.of(allowance));
+        when(eventUserAllowanceRepository.findByEventAndUserIds(event, Set.of(regularUser.id)))
+                .thenReturn(List.of(allowance));
         doNothing().when(eventUserAllowanceRepository).persist(any(EventUserAllowance.class));
 
         reservationService.deleteReservation(
@@ -622,8 +623,8 @@ public class ReservationServiceTest {
         allowance.setReservationsAllowedCount(5);
 
         mockReservationFind(List.of(reservation.id), List.of(reservation));
-        when(eventUserAllowanceRepository.findByUserAndEvent(regularUser, event))
-                .thenReturn(Optional.of(allowance));
+        when(eventUserAllowanceRepository.findByEventAndUserIds(event, Set.of(regularUser.id)))
+                .thenReturn(List.of(allowance));
         doNothing().when(eventUserAllowanceRepository).persist(any(EventUserAllowance.class));
 
         reservationService.deleteReservation(List.of(reservation.id), managerUser);

--- a/src/test/java/de/felixhertweck/seatreservation/management/service/SeatServiceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/management/service/SeatServiceTest.java
@@ -718,8 +718,8 @@ public class SeatServiceTest {
 
     @Test
     void deleteSeat_Success_AsManager() {
-        when(seatRepository.findByIdOptional(existingSeat.id))
-                .thenReturn(Optional.of(existingSeat));
+        when(seatRepository.findByIdsWithLocation(List.of(existingSeat.id)))
+                .thenReturn(List.of(existingSeat));
         doNothing().when(seatRepository).delete(any(Seat.class));
 
         seatService.deleteSeatForManager(List.of(existingSeat.id), managerAuth);
@@ -729,8 +729,8 @@ public class SeatServiceTest {
 
     @Test
     void deleteSeat_Success_AsAdmin() {
-        when(seatRepository.findByIdOptional(existingSeat.id))
-                .thenReturn(Optional.of(existingSeat));
+        when(seatRepository.findByIdsWithLocation(List.of(existingSeat.id)))
+                .thenReturn(List.of(existingSeat));
         doNothing().when(seatRepository).delete(any(Seat.class));
 
         seatService.deleteSeatForManager(List.of(existingSeat.id), adminAuth);
@@ -740,7 +740,7 @@ public class SeatServiceTest {
 
     @Test
     void deleteSeat_NotFound() {
-        when(seatRepository.findByIdOptional(any(UUID.class))).thenReturn(Optional.empty());
+        when(seatRepository.findByIdsWithLocation(List.of(id(99)))).thenReturn(List.of());
 
         assertThrows(
                 SeatNotFoundException.class,
@@ -756,8 +756,8 @@ public class SeatServiceTest {
         Seat seatInOtherLocation = new Seat("X1", "", otherLocation);
         seatInOtherLocation.id = id(2);
 
-        when(seatRepository.findByIdOptional(seatInOtherLocation.id))
-                .thenReturn(Optional.of(seatInOtherLocation));
+        when(seatRepository.findByIdsWithLocation(List.of(seatInOtherLocation.id)))
+                .thenReturn(List.of(seatInOtherLocation));
 
         assertThrows(
                 SecurityException.class,

--- a/src/test/java/de/felixhertweck/seatreservation/reservation/service/EventLocationServiceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/reservation/service/EventLocationServiceTest.java
@@ -24,7 +24,6 @@ import static de.felixhertweck.seatreservation.testutil.TestIds.id;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import jakarta.inject.Inject;
 
@@ -34,6 +33,7 @@ import static org.mockito.Mockito.when;
 import de.felixhertweck.seatreservation.common.exception.UserNotFoundException;
 import de.felixhertweck.seatreservation.model.entity.*;
 import de.felixhertweck.seatreservation.model.repository.EventUserAllowanceRepository;
+import de.felixhertweck.seatreservation.model.repository.ReservationRepository;
 import de.felixhertweck.seatreservation.model.repository.UserRepository;
 import de.felixhertweck.seatreservation.reservation.dto.UserEventLocationResponseDTO;
 import de.felixhertweck.seatreservation.utils.CodeGenerator;
@@ -50,6 +50,8 @@ class EventLocationServiceTest {
     @InjectMock UserRepository userRepository;
 
     @InjectMock EventUserAllowanceRepository eventUserAllowanceRepository;
+
+    @InjectMock ReservationRepository reservationRepository;
 
     private User user;
     private EventLocation locationA;
@@ -100,12 +102,12 @@ class EventLocationServiceTest {
                         Instant.now(),
                         ReservationStatus.RESERVED,
                         CodeGenerator.generateRandomCode());
-        var reservations = new HashSet<Reservation>();
-        reservations.add(reservation);
-        user.setReservations(reservations);
 
         when(userRepository.findByUsername("testuser")).thenReturn(user);
-        when(eventUserAllowanceRepository.findByUser(user)).thenReturn(List.of(allowance));
+        when(eventUserAllowanceRepository.findByUserWithEventAndLocation(user))
+                .thenReturn(List.of(allowance));
+        when(reservationRepository.findByUserWithEventAndLocation(user))
+                .thenReturn(List.of(reservation));
 
         List<UserEventLocationResponseDTO> result =
                 eventLocationService.getLocationsForCurrentUser("testuser");
@@ -132,12 +134,12 @@ class EventLocationServiceTest {
                         Instant.now(),
                         ReservationStatus.RESERVED,
                         CodeGenerator.generateRandomCode());
-        var reservations = new HashSet<Reservation>();
-        reservations.add(reservation);
-        user.setReservations(reservations);
 
         when(userRepository.findByUsername("testuser")).thenReturn(user);
-        when(eventUserAllowanceRepository.findByUser(user)).thenReturn(List.of(allowance));
+        when(eventUserAllowanceRepository.findByUserWithEventAndLocation(user))
+                .thenReturn(List.of(allowance));
+        when(reservationRepository.findByUserWithEventAndLocation(user))
+                .thenReturn(List.of(reservation));
 
         List<UserEventLocationResponseDTO> result =
                 eventLocationService.getLocationsForCurrentUser("testuser");
@@ -149,8 +151,10 @@ class EventLocationServiceTest {
     @Test
     void getLocationsForCurrentUser_Empty() {
         when(userRepository.findByUsername("testuser")).thenReturn(user);
-        when(eventUserAllowanceRepository.findByUser(user)).thenReturn(Collections.emptyList());
-        user.setReservations(Collections.emptySet());
+        when(eventUserAllowanceRepository.findByUserWithEventAndLocation(user))
+                .thenReturn(Collections.emptyList());
+        when(reservationRepository.findByUserWithEventAndLocation(user))
+                .thenReturn(Collections.emptyList());
 
         List<UserEventLocationResponseDTO> result =
                 eventLocationService.getLocationsForCurrentUser("testuser");
@@ -175,8 +179,10 @@ class EventLocationServiceTest {
         allowance.setReservationsAllowedCount(3);
 
         when(userRepository.findByUsername("testuser")).thenReturn(user);
-        when(eventUserAllowanceRepository.findByUser(user)).thenReturn(List.of(allowance));
-        user.setReservations(Collections.emptySet()); // No reservations
+        when(eventUserAllowanceRepository.findByUserWithEventAndLocation(user))
+                .thenReturn(List.of(allowance));
+        when(reservationRepository.findByUserWithEventAndLocation(user))
+                .thenReturn(Collections.emptyList()); // No reservations
 
         List<UserEventLocationResponseDTO> result =
                 eventLocationService.getLocationsForCurrentUser("testuser");
@@ -197,13 +203,12 @@ class EventLocationServiceTest {
                         Instant.now(),
                         ReservationStatus.RESERVED,
                         CodeGenerator.generateRandomCode());
-        var reservations = new HashSet<Reservation>();
-        reservations.add(reservation);
-        user.setReservations(reservations);
 
         when(userRepository.findByUsername("testuser")).thenReturn(user);
-        when(eventUserAllowanceRepository.findByUser(user))
+        when(eventUserAllowanceRepository.findByUserWithEventAndLocation(user))
                 .thenReturn(Collections.emptyList()); // No allowances
+        when(reservationRepository.findByUserWithEventAndLocation(user))
+                .thenReturn(List.of(reservation));
 
         List<UserEventLocationResponseDTO> result =
                 eventLocationService.getLocationsForCurrentUser("testuser");
@@ -215,8 +220,10 @@ class EventLocationServiceTest {
     @Test
     void getLocationsForCurrentUser_NoAllowanceNoReservation() {
         when(userRepository.findByUsername("testuser")).thenReturn(user);
-        when(eventUserAllowanceRepository.findByUser(user)).thenReturn(Collections.emptyList());
-        user.setReservations(Collections.emptySet());
+        when(eventUserAllowanceRepository.findByUserWithEventAndLocation(user))
+                .thenReturn(Collections.emptyList());
+        when(reservationRepository.findByUserWithEventAndLocation(user))
+                .thenReturn(Collections.emptyList());
 
         List<UserEventLocationResponseDTO> result =
                 eventLocationService.getLocationsForCurrentUser("testuser");
@@ -242,12 +249,12 @@ class EventLocationServiceTest {
                         Instant.now(),
                         ReservationStatus.RESERVED,
                         CodeGenerator.generateRandomCode());
-        var reservations = new HashSet<Reservation>();
-        reservations.add(reservationB);
-        user.setReservations(reservations);
 
         when(userRepository.findByUsername("testuser")).thenReturn(user);
-        when(eventUserAllowanceRepository.findByUser(user)).thenReturn(List.of(allowanceA));
+        when(eventUserAllowanceRepository.findByUserWithEventAndLocation(user))
+                .thenReturn(List.of(allowanceA));
+        when(reservationRepository.findByUserWithEventAndLocation(user))
+                .thenReturn(List.of(reservationB));
 
         List<UserEventLocationResponseDTO> result =
                 eventLocationService.getLocationsForCurrentUser("testuser");
@@ -275,12 +282,12 @@ class EventLocationServiceTest {
                         Instant.now(),
                         ReservationStatus.RESERVED,
                         CodeGenerator.generateRandomCode());
-        var reservations = new HashSet<Reservation>();
-        reservations.add(reservationB);
-        user.setReservations(reservations);
 
         when(userRepository.findByUsername("testuser")).thenReturn(user);
-        when(eventUserAllowanceRepository.findByUser(user)).thenReturn(List.of(allowanceA));
+        when(eventUserAllowanceRepository.findByUserWithEventAndLocation(user))
+                .thenReturn(List.of(allowanceA));
+        when(reservationRepository.findByUserWithEventAndLocation(user))
+                .thenReturn(List.of(reservationB));
 
         List<UserEventLocationResponseDTO> result =
                 eventLocationService.getLocationsForCurrentUser("testuser");
@@ -314,12 +321,12 @@ class EventLocationServiceTest {
                         Instant.now(),
                         ReservationStatus.RESERVED,
                         CodeGenerator.generateRandomCode());
-        var reservations = new HashSet<Reservation>();
-        reservations.add(reservationC);
-        user.setReservations(reservations);
 
         when(userRepository.findByUsername("testuser")).thenReturn(user);
-        when(eventUserAllowanceRepository.findByUser(user)).thenReturn(List.of(allowanceA));
+        when(eventUserAllowanceRepository.findByUserWithEventAndLocation(user))
+                .thenReturn(List.of(allowanceA));
+        when(reservationRepository.findByUserWithEventAndLocation(user))
+                .thenReturn(List.of(reservationC));
 
         List<UserEventLocationResponseDTO> result =
                 eventLocationService.getLocationsForCurrentUser("testuser");
@@ -351,8 +358,10 @@ class EventLocationServiceTest {
         allowance.setReservationsAllowedCount(3);
 
         when(userRepository.findByUsername("testuser")).thenReturn(user);
-        when(eventUserAllowanceRepository.findByUser(user)).thenReturn(List.of(allowance));
-        user.setReservations(Collections.emptySet());
+        when(eventUserAllowanceRepository.findByUserWithEventAndLocation(user))
+                .thenReturn(List.of(allowance));
+        when(reservationRepository.findByUserWithEventAndLocation(user))
+                .thenReturn(Collections.emptyList());
 
         List<UserEventLocationResponseDTO> result =
                 eventLocationService.getLocationsForCurrentUser("testuser");

--- a/src/test/java/de/felixhertweck/seatreservation/reservation/service/EventServiceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/reservation/service/EventServiceTest.java
@@ -28,6 +28,7 @@ import java.util.UUID;
 import jakarta.inject.Inject;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -41,6 +42,7 @@ import de.felixhertweck.seatreservation.model.entity.User;
 import de.felixhertweck.seatreservation.model.repository.EventUserAllowanceRepository;
 import de.felixhertweck.seatreservation.model.repository.ReservationRepository;
 import de.felixhertweck.seatreservation.reservation.dto.UserEventResponseDTO;
+import io.quarkus.hibernate.orm.panache.PanacheQuery;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.BeforeEach;
@@ -95,10 +97,24 @@ class EventServiceTest {
         reservation2.setEvent(event2);
     }
 
+    /**
+     * Stubs the bulk per-event reservation lookup that {@code getEventsForCurrentUser} issues once
+     * for all relevant events (replacing the old per-event lazy {@code event.getReservations()}
+     * load), so tests don't NPE on the unstubbed {@code find(...)} call.
+     */
+    @SuppressWarnings("unchecked")
+    private void mockReservationsByEventQuery(Set<UUID> eventIds, List<Reservation> result) {
+        PanacheQuery<Reservation> query = mock(PanacheQuery.class);
+        when(reservationRepository.find("event.id in ?1", eventIds)).thenReturn(query);
+        when(query.list()).thenReturn(result);
+    }
+
     @Test
     void getEventsForCurrentUser_Success_OnlyAllowances() {
-        when(eventUserAllowanceRepository.findByUser(user)).thenReturn(List.of(allowance1));
-        when(reservationRepository.findByUser(user)).thenReturn(Collections.emptyList());
+        when(eventUserAllowanceRepository.findByUserWithEvent(user))
+                .thenReturn(List.of(allowance1));
+        when(reservationRepository.findByUserWithEvent(user)).thenReturn(Collections.emptyList());
+        mockReservationsByEventQuery(Set.of(event1.id), List.of());
 
         List<UserEventResponseDTO> result = eventService.getEventsForCurrentUser(user);
 
@@ -110,8 +126,10 @@ class EventServiceTest {
 
     @Test
     void getEventsForCurrentUser_Success_OnlyReservations() {
-        when(eventUserAllowanceRepository.findByUser(user)).thenReturn(Collections.emptyList());
-        when(reservationRepository.findByUser(user)).thenReturn(List.of(reservation2));
+        when(eventUserAllowanceRepository.findByUserWithEvent(user))
+                .thenReturn(Collections.emptyList());
+        when(reservationRepository.findByUserWithEvent(user)).thenReturn(List.of(reservation2));
+        mockReservationsByEventQuery(Set.of(event2.id), List.of());
 
         List<UserEventResponseDTO> result = eventService.getEventsForCurrentUser(user);
 
@@ -124,8 +142,10 @@ class EventServiceTest {
 
     @Test
     void getEventsForCurrentUser_Success_AllowancesAndDifferentReservations() {
-        when(eventUserAllowanceRepository.findByUser(user)).thenReturn(List.of(allowance1));
-        when(reservationRepository.findByUser(user)).thenReturn(List.of(reservation2));
+        when(eventUserAllowanceRepository.findByUserWithEvent(user))
+                .thenReturn(List.of(allowance1));
+        when(reservationRepository.findByUserWithEvent(user)).thenReturn(List.of(reservation2));
+        mockReservationsByEventQuery(Set.of(event1.id, event2.id), List.of());
 
         List<UserEventResponseDTO> result = eventService.getEventsForCurrentUser(user);
 
@@ -150,9 +170,11 @@ class EventServiceTest {
 
     @Test
     void getEventsForCurrentUser_Success_AllowancesAndSameEventReservations() {
-        when(eventUserAllowanceRepository.findByUser(user)).thenReturn(List.of(allowance1));
-        when(reservationRepository.findByUser(user))
+        when(eventUserAllowanceRepository.findByUserWithEvent(user))
+                .thenReturn(List.of(allowance1));
+        when(reservationRepository.findByUserWithEvent(user))
                 .thenReturn(List.of(reservation1)); // reservation for event1
+        mockReservationsByEventQuery(Set.of(event1.id), List.of());
 
         List<UserEventResponseDTO> result = eventService.getEventsForCurrentUser(user);
 
@@ -166,8 +188,10 @@ class EventServiceTest {
     @Test
     void getEventsForCurrentUser_MergesPendingSeatStatusesFromCart() {
         UUID pendingSeatId = id(10);
-        when(eventUserAllowanceRepository.findByUser(user)).thenReturn(List.of(allowance1));
-        when(reservationRepository.findByUser(user)).thenReturn(Collections.emptyList());
+        when(eventUserAllowanceRepository.findByUserWithEvent(user))
+                .thenReturn(List.of(allowance1));
+        when(reservationRepository.findByUserWithEvent(user)).thenReturn(Collections.emptyList());
+        mockReservationsByEventQuery(Set.of(event1.id), List.of());
         when(seatCartService.findPendingSeatIds(event1.id, user.id))
                 .thenReturn(Set.of(pendingSeatId));
 
@@ -186,8 +210,10 @@ class EventServiceTest {
 
     @Test
     void getEventsForCurrentUser_NoCartHolds_SeatStatusesUnchanged() {
-        when(eventUserAllowanceRepository.findByUser(user)).thenReturn(List.of(allowance1));
-        when(reservationRepository.findByUser(user)).thenReturn(Collections.emptyList());
+        when(eventUserAllowanceRepository.findByUserWithEvent(user))
+                .thenReturn(List.of(allowance1));
+        when(reservationRepository.findByUserWithEvent(user)).thenReturn(Collections.emptyList());
+        mockReservationsByEventQuery(Set.of(event1.id), List.of());
         when(seatCartService.findPendingSeatIds(event1.id, user.id))
                 .thenReturn(Collections.emptySet());
 
@@ -205,8 +231,10 @@ class EventServiceTest {
         // own cart holds - EventService must pass the current user's ID through so that a seat
         // the user themselves is holding never shows up as PENDING in their own event list (it
         // would otherwise make the seat look blocked/unselectable to the very user holding it).
-        when(eventUserAllowanceRepository.findByUser(user)).thenReturn(List.of(allowance1));
-        when(reservationRepository.findByUser(user)).thenReturn(Collections.emptyList());
+        when(eventUserAllowanceRepository.findByUserWithEvent(user))
+                .thenReturn(List.of(allowance1));
+        when(reservationRepository.findByUserWithEvent(user)).thenReturn(Collections.emptyList());
+        mockReservationsByEventQuery(Set.of(event1.id), List.of());
         when(seatCartService.findPendingSeatIds(event1.id, user.id))
                 .thenReturn(Collections.emptySet());
 
@@ -217,8 +245,9 @@ class EventServiceTest {
 
     @Test
     void getEventsForCurrentUser_Success_NoEvents() {
-        when(eventUserAllowanceRepository.findByUser(user)).thenReturn(Collections.emptyList());
-        when(reservationRepository.findByUser(user)).thenReturn(Collections.emptyList());
+        when(eventUserAllowanceRepository.findByUserWithEvent(user))
+                .thenReturn(Collections.emptyList());
+        when(reservationRepository.findByUserWithEvent(user)).thenReturn(Collections.emptyList());
 
         List<UserEventResponseDTO> result = eventService.getEventsForCurrentUser(user);
 

--- a/src/test/java/de/felixhertweck/seatreservation/supervisor/service/CheckInServiceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/supervisor/service/CheckInServiceTest.java
@@ -33,6 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -131,7 +132,7 @@ class CheckInServiceTest {
         assertEquals(ReservationLiveStatus.CHECKED_IN, reservation1.getLiveStatus());
         assertEquals(ReservationLiveStatus.CHECKED_IN, reservation2.getLiveStatus());
 
-        verify(reservationRepository, times(2)).persist(any(Reservation.class));
+        verify(reservationRepository, times(1)).persistAll(anyList());
     }
 
     @Test
@@ -173,7 +174,7 @@ class CheckInServiceTest {
 
         assertEquals(ReservationLiveStatus.CANCELLED, reservation1.getLiveStatus());
 
-        verify(reservationRepository, times(1)).persist(any(Reservation.class));
+        verify(reservationRepository, times(1)).persistAll(anyList());
     }
 
     @Test
@@ -225,7 +226,7 @@ class CheckInServiceTest {
         assertEquals(ReservationLiveStatus.CHECKED_IN, checkInReservation.getLiveStatus());
         assertEquals(ReservationLiveStatus.CANCELLED, cancelReservation.getLiveStatus());
 
-        verify(reservationRepository, times(2)).persist(any(Reservation.class));
+        verify(reservationRepository, times(2)).persistAll(anyList());
     }
 
     @Test
@@ -370,7 +371,7 @@ class CheckInServiceTest {
 
         assertEquals(ReservationLiveStatus.CANCELLED, reservation1.getLiveStatus());
 
-        verify(reservationRepository, times(1)).persist(any(Reservation.class));
+        verify(reservationRepository, times(1)).persistAll(anyList());
     }
 
     @Test

--- a/src/test/java/de/felixhertweck/seatreservation/userManagment/service/UserServiceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/userManagment/service/UserServiceTest.java
@@ -1467,8 +1467,8 @@ public class UserServiceTest {
                         Set.of());
         dtos.add(duplicateDto);
 
-        when(userRepository.findByUsernameOptional("existinguser"))
-                .thenReturn(Optional.of(new User())); // Simulate existing user
+        when(userRepository.findExistingUsernames(Set.of("existinguser")))
+                .thenReturn(List.of("existinguser")); // Simulate existing user
         when(emailService.createEmailVerification(any(User.class)))
                 .thenReturn(
                         new EmailVerification(


### PR DESCRIPTION
Replace per-item repository lookups/lazy-collection loads in loops with single batched queries (id-in / join-fetch) across EmailService, EventService/EventLocationService, allowance and admin delete paths, and switch remaining per-item persist() calls to persistAll().