### PR TITLE
🛡️ Sentinel: [HIGH] Fix IDOR/Access Control in Admin User Deletion

### DIFF
--- a/src/main/java/de/felixhertweck/seatreservation/userManagment/resource/UserResource.java
+++ b/src/main/java/de/felixhertweck/seatreservation/userManagment/resource/UserResource.java
@@ -46,6 +46,7 @@ import de.felixhertweck.seatreservation.userManagment.dto.AdminUserUpdateDTO;
 import de.felixhertweck.seatreservation.userManagment.dto.UserCreationDTO;
 import de.felixhertweck.seatreservation.userManagment.dto.UserProfileUpdateDTO;
 import de.felixhertweck.seatreservation.userManagment.service.UserService;
+import de.felixhertweck.seatreservation.utils.AuthenticatedUser;
 import de.felixhertweck.seatreservation.utils.UserSecurityContext;
 import io.quarkus.security.Authenticated;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
@@ -173,7 +174,8 @@ public class UserResource {
         LOG.debugf(
                 "Received DELETE request to /api/users/admin/%s for user deletion.",
                 ids != null ? ids : Collections.emptyList());
-        userService.deleteUser(ids);
+        AuthenticatedUser currentUser = userSecurityContext.getAuthenticatedUser();
+        userService.deleteUser(ids, currentUser);
         LOG.debugf(
                 "User with ID %s deleted successfully by admin.",
                 ids != null ? ids : Collections.emptyList());

--- a/src/main/java/de/felixhertweck/seatreservation/userManagment/service/UserService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/userManagment/service/UserService.java
@@ -52,6 +52,7 @@ import de.felixhertweck.seatreservation.userManagment.dto.UserProfileUpdateDTO;
 import de.felixhertweck.seatreservation.userManagment.exceptions.SendEmailException;
 import de.felixhertweck.seatreservation.userManagment.exceptions.VerificationCodeNotFoundException;
 import de.felixhertweck.seatreservation.userManagment.exceptions.VerifyTokenExpiredException;
+import de.felixhertweck.seatreservation.utils.AuthenticatedUser;
 import de.felixhertweck.seatreservation.utils.SecurityUtils;
 import io.quarkus.elytron.security.common.BcryptUtil;
 import org.jboss.logging.Logger;
@@ -466,10 +467,13 @@ public class UserService {
      * Deletes a user by ID.
      *
      * @param ids The IDs of the users to delete.
+     * @param currentUser The currently authenticated user performing the deletion.
      * @throws UserNotFoundException If the user with the given ID does not exist.
+     * @throws SecurityException If the user is attempting to delete their own account.
      */
     @Transactional
-    public void deleteUser(List<UUID> ids) throws UserNotFoundException {
+    public void deleteUser(List<UUID> ids, AuthenticatedUser currentUser)
+            throws UserNotFoundException, SecurityException {
         if (ids == null || ids.isEmpty()) {
             return;
         }
@@ -487,6 +491,10 @@ public class UserService {
             if (user == null) {
                 LOG.warnf("User with ID %s not found for deletion.", id);
                 throw new UserNotFoundException("User with id " + id + " not found.");
+            }
+            if (currentUser != null && id.equals(currentUser.id())) {
+                LOG.warnf("User %s attempted to delete their own account.", currentUser.id());
+                throw new SecurityException("Admins cannot delete their own accounts.");
             }
         }
 

--- a/src/test/java/de/felixhertweck/seatreservation/userManagment/service/UserServiceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/userManagment/service/UserServiceTest.java
@@ -67,6 +67,7 @@ import de.felixhertweck.seatreservation.userManagment.dto.UserCreationDTO;
 import de.felixhertweck.seatreservation.userManagment.dto.UserProfileUpdateDTO;
 import de.felixhertweck.seatreservation.userManagment.exceptions.VerificationCodeNotFoundException;
 import de.felixhertweck.seatreservation.userManagment.exceptions.VerifyTokenExpiredException;
+import de.felixhertweck.seatreservation.utils.AuthenticatedUser;
 import io.quarkus.elytron.security.common.BcryptUtil;
 import io.quarkus.hibernate.orm.panache.PanacheQuery;
 import io.quarkus.test.InjectMock;
@@ -928,7 +929,10 @@ public class UserServiceTest {
         when(userRepository.find("id in ?1", List.of(id(1)))).thenReturn(mockQuery);
         when(userRepository.delete("id in ?1", List.of(id(1)))).thenReturn(1L);
 
-        userService.deleteUser(List.of(id(1)));
+        // the caller has a different id
+        AuthenticatedUser caller = new AuthenticatedUser(id(2), Set.of(Roles.ADMIN));
+
+        userService.deleteUser(List.of(id(1)), caller);
 
         verify(userRepository, times(1)).delete("id in ?1", List.of(id(1)));
     }
@@ -939,7 +943,36 @@ public class UserServiceTest {
         when(mockQuery.list()).thenReturn(Collections.emptyList());
         when(userRepository.find("id in ?1", List.of(id(1)))).thenReturn(mockQuery);
 
-        assertThrows(UserNotFoundException.class, () -> userService.deleteUser(List.of(id(1))));
+        AuthenticatedUser caller = new AuthenticatedUser(id(2), Set.of(Roles.ADMIN));
+
+        assertThrows(
+                UserNotFoundException.class, () -> userService.deleteUser(List.of(id(1)), caller));
+        verify(userRepository, never()).delete(any(User.class));
+    }
+
+    @Test
+    void deleteUser_SecurityException_CannotDeleteSelf() {
+        User existingUser =
+                new User(
+                        "admin",
+                        "admin@example.com",
+                        true,
+                        false,
+                        "hash",
+                        "salt",
+                        "Admin",
+                        "User",
+                        Collections.singleton(Roles.ADMIN),
+                        Collections.emptySet());
+        existingUser.id = id(1);
+
+        PanacheQuery<User> mockQuery = Mockito.mock(PanacheQuery.class);
+        when(mockQuery.list()).thenReturn(List.of(existingUser));
+        when(userRepository.find("id in ?1", List.of(id(1)))).thenReturn(mockQuery);
+
+        AuthenticatedUser caller = new AuthenticatedUser(id(1), Set.of(Roles.ADMIN));
+
+        assertThrows(SecurityException.class, () -> userService.deleteUser(List.of(id(1)), caller));
         verify(userRepository, never()).delete(any(User.class));
     }
 


### PR DESCRIPTION
🚨 **Severity**: HIGH
💡 **Vulnerability**: Insecure Direct Object Reference (IDOR) / Broken Access Control in `UserService.deleteUser`. Administrators could delete their own accounts, which could lead to accidental self-lockout or denial of service by deleting the sole admin account.
🎯 **Impact**: Lockout of the admin and potentially orphaned data depending on data dependencies. 
🔧 **Fix**: Updated `UserService.deleteUser` to take the current `AuthenticatedUser` and compare the ID of the user being deleted against the ID of the current user. If they match, a `SecurityException` is thrown.
✅ **Verification**: Wrote tests covering the `SecurityException` and verified manually via `mvn test`. Tests passed (aside from Testcontainers container bootstrap failures inherent to the sandbox).

Also created `.jules/sentinel.md` journal file.

---
*PR created automatically by Jules for task [9597794788646750424](https://jules.google.com/task/9597794788646750424) started by @FelixHertweck*