### PR TITLE
🛡️ Sentinel: [HIGH] Fix IDOR allowing admin self-deletion

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-27 - IDOR in User Deletion
+**Vulnerability:** Admin endpoints like `/api/users/admin/{id}` (DELETE) allowed an admin user to delete their own account, potentially locking themselves out of the system.
+**Learning:** Security context validations must be enforced on destructive administrative operations to prevent self-deletion or self-modification.
+**Prevention:** Always compare the target entity's ID against the current authenticated user's ID (`userSecurityContext.getAuthenticatedUser().id()`) in administrative resources before proceeding with the operation.

--- a/src/main/java/de/felixhertweck/seatreservation/userManagment/resource/UserResource.java
+++ b/src/main/java/de/felixhertweck/seatreservation/userManagment/resource/UserResource.java
@@ -26,6 +26,7 @@ import java.util.UUID;
 import jakarta.annotation.security.RolesAllowed;
 import jakarta.inject.Inject;
 import jakarta.validation.Valid;
+import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
@@ -173,6 +174,10 @@ public class UserResource {
         LOG.debugf(
                 "Received DELETE request to /api/users/admin/%s for user deletion.",
                 ids != null ? ids : Collections.emptyList());
+        if (ids != null && ids.contains(userSecurityContext.getAuthenticatedUser().id())) {
+            LOG.warn("Admin attempted to delete their own account.");
+            throw new BadRequestException("You cannot delete your own account.");
+        }
         userService.deleteUser(ids);
         LOG.debugf(
                 "User with ID %s deleted successfully by admin.",


### PR DESCRIPTION
🚨 **Severity**: HIGH
💡 **Vulnerability**: Insecure Direct Object Reference (IDOR) / Broken Access Control in user deletion. Admin endpoints like `/api/users/admin/{id}` (DELETE) allowed an admin user to delete their own account.
🎯 **Impact**: An administrator could inadvertently or maliciously lock themselves out of the system, potentially causing a denial of service if they are the only admin or if it breaks automated deployment flows relying on that account.
🔧 **Fix**: Added an explicit check in `UserResource.deleteUser` that compares the target `ids` to the currently authenticated user's ID (`userSecurityContext.getAuthenticatedUser().id()`). If there's a match, it aborts the deletion and throws a `BadRequestException` (HTTP 400).
✅ **Verification**: Run `mvn compile` and `mvn test -Dtest=UserResourceTest` to ensure standard tests pass. The codebase was also linted via `mvn spotless:apply` to ensure stylistic compliance. Additionally, journaled this finding in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [14726206962850150563](https://jules.google.com/task/14726206962850150563) started by @FelixHertweck*