### PR TITLE
🛡️ Sentinel: [HIGH] Fix self-deletion vulnerability

### DIFF
--- a/src/main/java/de/felixhertweck/seatreservation/userManagment/resource/UserResource.java
+++ b/src/main/java/de/felixhertweck/seatreservation/userManagment/resource/UserResource.java
@@ -173,6 +173,14 @@ public class UserResource {
         LOG.debugf(
                 "Received DELETE request to /api/users/admin/%s for user deletion.",
                 ids != null ? ids : Collections.emptyList());
+
+        if (ids != null && ids.contains(userSecurityContext.getAuthenticatedUser().id())) {
+            LOG.warnf(
+                    "User %s attempted to delete themselves.",
+                    userSecurityContext.getAuthenticatedUser().id());
+            throw new SecurityException("You cannot delete your own user account.");
+        }
+
         userService.deleteUser(ids);
         LOG.debugf(
                 "User with ID %s deleted successfully by admin.",


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Administrative users could mistakenly or maliciously delete their own account via the batch user deletion endpoint (`/api/users/admin?ids=...`).
🎯 Impact: This could result in self-lockout or denial of service by breaking administrative access.
🔧 Fix: Added a safeguard inside `UserResource.deleteUser()` that inspects the provided array of IDs. If the current authenticated user's ID is included, a `SecurityException` is thrown before calling the underlying `userService.deleteUser` logic.
✅ Verification: The codebase successfully compiles, passing checkstyle and formatting checks via spotless. Unit tests confirmed that a `SecurityException` is caught and correctly mapped to a 403 Forbidden status by the global exception mapper.

---
*PR created automatically by Jules for task [11281861985562042252](https://jules.google.com/task/11281861985562042252) started by @FelixHertweck*