### PR TITLE
⚡ Bolt: Fix N+1 query in reservation retrieval

### DIFF
--- a/src/main/java/de/felixhertweck/seatreservation/model/repository/ReservationRepository.java
+++ b/src/main/java/de/felixhertweck/seatreservation/model/repository/ReservationRepository.java
@@ -43,6 +43,28 @@ public class ReservationRepository implements PanacheRepositoryBase<Reservation,
     }
 
     /**
+     * Finds all reservations for a given user that are not blocked, eagerly fetching each
+     * reservation's event and seat with location details.
+     *
+     * @param user the user to search for
+     * @return a list of non-blocked reservations for the specified user, with the event, seat, and
+     *     location details pre-fetched
+     */
+    public List<Reservation> findByUserWithDetails(User user) {
+        return find(
+                        "select r from Reservation r"
+                                + " left join fetch r.event"
+                                + " left join fetch r.seat s"
+                                + " left join fetch s.location"
+                                + " left join fetch s.entrance"
+                                + " left join fetch s.area"
+                                + " where r.user = ?1 and r.status != ?2",
+                        user,
+                        ReservationStatus.BLOCKED)
+                .list();
+    }
+
+    /**
      * Finds all reservations for a specific event ID.
      *
      * @param eventId the event ID to search for

--- a/src/main/java/de/felixhertweck/seatreservation/reservation/service/ReservationService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/reservation/service/ReservationService.java
@@ -77,7 +77,7 @@ public class ReservationService {
      */
     public List<UserReservationResponseDTO> findReservationsByUser(User currentUser) {
         LOG.debugf("Attempting to find reservations for user ID: %s", currentUser.id);
-        List<Reservation> reservations = reservationRepository.findByUser(currentUser);
+        List<Reservation> reservations = reservationRepository.findByUserWithDetails(currentUser);
         LOG.debugf("Found %d reservations for user ID: %s", reservations.size(), currentUser.id);
         return reservations.stream().map(UserReservationResponseDTO::new).toList();
     }

--- a/src/main/java/de/felixhertweck/seatreservation/supervisor/service/CheckInService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/supervisor/service/CheckInService.java
@@ -321,7 +321,7 @@ public class CheckInService {
             throw new ReservationNotFoundException("User with specified username not found.");
         }
 
-        List<Reservation> reservations = reservationRepository.findByUser(user);
+        List<Reservation> reservations = reservationRepository.findByUserWithDetails(user);
         if (reservations.isEmpty()) {
             LOG.warnf("No reservations found for user %s.", username);
             throw new ReservationNotFoundException(

--- a/src/test/java/de/felixhertweck/seatreservation/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/reservation/service/ReservationServiceTest.java
@@ -163,7 +163,8 @@ class ReservationServiceTest {
 
     @Test
     void findReservationsByUser_Success() {
-        when(reservationRepository.findByUser(currentUser)).thenReturn(List.of(reservation));
+        when(reservationRepository.findByUserWithDetails(any(User.class)))
+                .thenReturn(List.of(reservation));
 
         List<UserReservationResponseDTO> result =
                 reservationService.findReservationsByUser(currentUser);
@@ -175,7 +176,8 @@ class ReservationServiceTest {
 
     @Test
     void findReservationsByUser_Success_NoReservations() {
-        when(reservationRepository.findByUser(currentUser)).thenReturn(Collections.emptyList());
+        when(reservationRepository.findByUserWithDetails(any(User.class)))
+                .thenReturn(Collections.emptyList());
 
         List<UserReservationResponseDTO> result =
                 reservationService.findReservationsByUser(currentUser);


### PR DESCRIPTION
💡 What: Replaced `findByUser` with a new `findByUserWithDetails` repository method using HQL `LEFT JOIN FETCH` to eagerly load related entities (`Event`, `Seat`, `EventLocation`, `EventLocationEntrance`, `EventLocationArea`).
🎯 Why: The original query fetched reservations lazily. Since mapping them to `UserReservationResponseDTO` or `SupervisorReservationResponseDTO` requires seat location details, it triggered an N+1 query problem, slowing down responses significantly for users with many reservations.
📊 Impact: Eliminates N+1 queries when users view their reservations or supervisors look up reservations by username, significantly improving response times.
🔬 Measurement: Check the database logs; queries executed during reservation retrieval drop from O(N) queries to O(1) batched query.

---
*PR created automatically by Jules for task [260168335701343642](https://jules.google.com/task/260168335701343642) started by @FelixHertweck*