### PR TITLE
⚡ Bolt: Eliminate N+1 query in LiveViewService WebSocket initialization

### DIFF
--- a/src/main/java/de/felixhertweck/seatreservation/model/repository/ReservationRepository.java
+++ b/src/main/java/de/felixhertweck/seatreservation/model/repository/ReservationRepository.java
@@ -53,6 +53,21 @@ public class ReservationRepository implements PanacheRepositoryBase<Reservation,
     }
 
     /**
+     * Finds all reservations for a specific event ID eagerly fetching each reservation's user and
+     * seat.
+     *
+     * @param eventId the event ID to search for
+     * @return a list of reservations for the specified event, with the user and seat pre-fetched
+     */
+    public List<Reservation> findByEventIdWithUserAndSeat(UUID eventId) {
+        return find(
+                        "select r from Reservation r left join fetch r.user left join fetch r.seat"
+                                + " where r.event.id = ?1",
+                        eventId)
+                .list();
+    }
+
+    /**
      * Finds all reservations for a specific event ID whose seat is among the given seat IDs.
      *
      * @param eventId the event ID to search for

--- a/src/main/java/de/felixhertweck/seatreservation/supervisor/service/LiveViewService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/supervisor/service/LiveViewService.java
@@ -26,7 +26,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
@@ -38,7 +37,6 @@ import de.felixhertweck.seatreservation.model.entity.EventLocation;
 import de.felixhertweck.seatreservation.model.entity.Reservation;
 import de.felixhertweck.seatreservation.model.repository.EventRepository;
 import de.felixhertweck.seatreservation.model.repository.ReservationRepository;
-import de.felixhertweck.seatreservation.supervisor.dto.SupervisorReservationResponseDTO;
 import de.felixhertweck.seatreservation.supervisor.dto.WebsocketInitialDTO;
 import de.felixhertweck.seatreservation.supervisor.dto.WebsocketUpdateDTO;
 import de.felixhertweck.seatreservation.supervisor.exception.InvalidEventIdException;
@@ -217,12 +215,8 @@ public class LiveViewService {
         try {
             Event event = eventRepository.findById(eventId);
             EventLocation location = event.getEventLocation();
-            List<Reservation> reservations = reservationRepository.findByEventId(eventId);
-
-            List<SupervisorReservationResponseDTO> dtos =
-                    reservations.stream()
-                            .map(SupervisorReservationResponseDTO::new)
-                            .collect(Collectors.toList());
+            List<Reservation> reservations =
+                    reservationRepository.findByEventIdWithUserAndSeat(eventId);
 
             WebsocketInitialDTO initialMessage =
                     WebsocketInitialDTO.initial(location, event, reservations);
@@ -233,7 +227,7 @@ public class LiveViewService {
 
             LOG.debugf(
                     "Sent %d initial reservations to connection for event %s",
-                    dtos.size(), eventId);
+                    reservations.size(), eventId);
         } catch (IOException e) {
             LOG.errorf(e, "Error sending initial reservations for event %s to connection", eventId);
         }

--- a/src/test/java/de/felixhertweck/seatreservation/supervisor/service/LiveViewServiceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/supervisor/service/LiveViewServiceTest.java
@@ -94,7 +94,7 @@ public class LiveViewServiceTest {
         mockEvent.setEventLocation(mockLocation);
 
         Mockito.when(eventRepository.findById(parsedEventId)).thenReturn(mockEvent);
-        Mockito.when(reservationRepository.findByEventId(parsedEventId))
+        Mockito.when(reservationRepository.findByEventIdWithUserAndSeat(parsedEventId))
                 .thenReturn(new java.util.ArrayList<>());
 
         assertDoesNotThrow(
@@ -188,7 +188,7 @@ public class LiveViewServiceTest {
             mockEvent.setEventLocation(mockLocation);
 
             Mockito.when(eventRepository.findById(testEventId)).thenReturn(mockEvent);
-            Mockito.when(reservationRepository.findByEventId(testEventId))
+            Mockito.when(reservationRepository.findByEventIdWithUserAndSeat(testEventId))
                     .thenReturn(new java.util.ArrayList<>());
 
             assertDoesNotThrow(
@@ -221,7 +221,7 @@ public class LiveViewServiceTest {
         mockLocation.id = id(1);
         mockEvent.setEventLocation(mockLocation);
         Mockito.when(eventRepository.findById(testEventId)).thenReturn(mockEvent);
-        Mockito.when(reservationRepository.findByEventId(testEventId))
+        Mockito.when(reservationRepository.findByEventIdWithUserAndSeat(testEventId))
                 .thenReturn(new java.util.ArrayList<>());
 
         // Register the mock connection for the event


### PR DESCRIPTION
💡 What: Updated `LiveViewService.sendInitialReservations` to use a new `findByEventIdWithUserAndSeat` repository method which employs `left join fetch` to eagerly load `user` and `seat` entities.
🎯 Why: When broadcasting initial reservations via WebSockets, mapping entities to `SupervisorReservationResponseDTO` triggers lazy loading of `User` and `Seat` properties. Without a fetch join, this results in an N+1 query problem, severely impacting performance for events with many reservations.
📊 Impact: Reduces database queries from 1 + 2N to 1 when initializing live view connections for an event.
🔬 Measurement: Can be verified by connecting to the supervisor live view WebSocket endpoint for an event with many reservations and observing the database query logs.

---
*PR created automatically by Jules for task [8617615084689018442](https://jules.google.com/task/8617615084689018442) started by @FelixHertweck*