### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Information Disclosure in Error Messages

### DIFF
--- a/src/main/java/de/felixhertweck/seatreservation/GlobalExceptionHandler.java
+++ b/src/main/java/de/felixhertweck/seatreservation/GlobalExceptionHandler.java
@@ -82,9 +82,9 @@ public class GlobalExceptionHandler implements ExceptionMapper<Exception> {
      */
     @Override
     public Response toResponse(Exception exception) {
-        ErrorResponseDTO errorResponse = new ErrorResponseDTO(exception.getMessage());
         Response.Status status;
         List<NewCookie> cookies = new ArrayList<>();
+        String errorMessage = exception.getMessage();
 
         switch (exception) {
             case EventBookingClosedException ignored -> status = Response.Status.BAD_REQUEST;
@@ -139,11 +139,14 @@ public class GlobalExceptionHandler implements ExceptionMapper<Exception> {
             }
             default -> {
                 status = Response.Status.INTERNAL_SERVER_ERROR;
+                errorMessage = "An unexpected error occurred";
             }
         }
 
         LOG.warnf(
                 "Exception occurred (handled by GlobalExceptionHandler): %s", exception.toString());
+
+        ErrorResponseDTO errorResponse = new ErrorResponseDTO(errorMessage);
 
         return Response.status(status)
                 .entity(errorResponse)

--- a/src/test/java/de/felixhertweck/seatreservation/GlobalExceptionHandlerTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/GlobalExceptionHandlerTest.java
@@ -24,7 +24,6 @@ import jakarta.ws.rs.core.NewCookie;
 import jakarta.ws.rs.core.Response;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
@@ -226,7 +225,7 @@ class GlobalExceptionHandlerTest {
         assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
         assertTrue(response.getEntity() instanceof ErrorResponseDTO);
         ErrorResponseDTO errorResponse = (ErrorResponseDTO) response.getEntity();
-        assertEquals("Generic error", errorResponse.getMessage());
+        assertEquals("An unexpected error occurred", errorResponse.getMessage());
     }
 
     @Test
@@ -237,7 +236,7 @@ class GlobalExceptionHandlerTest {
         assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
         assertTrue(response.getEntity() instanceof ErrorResponseDTO);
         ErrorResponseDTO errorResponse = (ErrorResponseDTO) response.getEntity();
-        assertEquals("Null pointer", errorResponse.getMessage());
+        assertEquals("An unexpected error occurred", errorResponse.getMessage());
     }
 
     @Test
@@ -248,7 +247,7 @@ class GlobalExceptionHandlerTest {
         assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
         assertTrue(response.getEntity() instanceof ErrorResponseDTO);
         ErrorResponseDTO errorResponse = (ErrorResponseDTO) response.getEntity();
-        assertNull(errorResponse.getMessage());
+        assertEquals("An unexpected error occurred", errorResponse.getMessage());
     }
 
     @Test

--- a/src/test/java/de/felixhertweck/seatreservation/userManagment/resource/EmailConfirmationResourceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/userManagment/resource/EmailConfirmationResourceTest.java
@@ -165,7 +165,7 @@ class EmailConfirmationResourceTest {
                 .post("/api/user/verify-email-code")
                 .then()
                 .statusCode(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode())
-                .body(containsString("Database error"));
+                .body(containsString("An unexpected error occurred"));
 
         verify(userService, times(1)).verifyEmailWithCode("123456");
     }


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Unhandled exceptions that result in a 500 Internal Server Error leak their exact exception message directly to the client via `GlobalExceptionHandler.java`. This can expose sensitive system details, internal paths, or stack traces depending on the exception thrown.
🎯 **Impact:** An attacker could potentially gain insights into the backend architecture, database schema, or environment details which can be leveraged for further attacks.
🔧 **Fix:** Modified the `GlobalExceptionHandler` to return a generic "An unexpected error occurred" message whenever an unhandled exception triggers an `INTERNAL_SERVER_ERROR`. The actual exception message is still logged on the server.
✅ **Verification:** Verified that tests pass and a generic `RuntimeException` now results in a 500 status with the generic error message.

---
*PR created automatically by Jules for task [5368946908455212305](https://jules.google.com/task/5368946908455212305) started by @FelixHertweck*