### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Error Message Information Leakage

### DIFF
--- a/src/main/java/de/felixhertweck/seatreservation/GlobalExceptionHandler.java
+++ b/src/main/java/de/felixhertweck/seatreservation/GlobalExceptionHandler.java
@@ -156,7 +156,10 @@ public class GlobalExceptionHandler implements ExceptionMapper<Exception> {
                                 cooldownException.getMessage(), cooldownException.getRetryAfter());
                 return Response.status(status).entity(errorResponseCooldown).build();
             }
-            default -> status = Response.Status.INTERNAL_SERVER_ERROR;
+            default -> {
+                status = Response.Status.INTERNAL_SERVER_ERROR;
+                errorResponse = new ErrorResponseDTO("An unexpected error occurred");
+            }
         }
 
         LOG.warnf(

--- a/src/test/java/de/felixhertweck/seatreservation/GlobalExceptionHandlerTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/GlobalExceptionHandlerTest.java
@@ -24,7 +24,6 @@ import jakarta.ws.rs.core.NewCookie;
 import jakarta.ws.rs.core.Response;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
@@ -226,7 +225,7 @@ class GlobalExceptionHandlerTest {
         assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
         assertTrue(response.getEntity() instanceof ErrorResponseDTO);
         ErrorResponseDTO errorResponse = (ErrorResponseDTO) response.getEntity();
-        assertEquals("Generic error", errorResponse.getMessage());
+        assertEquals("An unexpected error occurred", errorResponse.getMessage());
     }
 
     @Test
@@ -237,7 +236,7 @@ class GlobalExceptionHandlerTest {
         assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
         assertTrue(response.getEntity() instanceof ErrorResponseDTO);
         ErrorResponseDTO errorResponse = (ErrorResponseDTO) response.getEntity();
-        assertEquals("Null pointer", errorResponse.getMessage());
+        assertEquals("An unexpected error occurred", errorResponse.getMessage());
     }
 
     @Test
@@ -248,7 +247,7 @@ class GlobalExceptionHandlerTest {
         assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
         assertTrue(response.getEntity() instanceof ErrorResponseDTO);
         ErrorResponseDTO errorResponse = (ErrorResponseDTO) response.getEntity();
-        assertNull(errorResponse.getMessage());
+        assertEquals("An unexpected error occurred", errorResponse.getMessage());
     }
 
     @Test

--- a/src/test/java/de/felixhertweck/seatreservation/userManagment/resource/EmailConfirmationResourceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/userManagment/resource/EmailConfirmationResourceTest.java
@@ -165,7 +165,7 @@ class EmailConfirmationResourceTest {
                 .post("/api/user/verify-email-code")
                 .then()
                 .statusCode(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode())
-                .body(containsString("Database error"));
+                .body(containsString("An unexpected error occurred"));
 
         verify(userService, times(1)).verifyEmailWithCode("123456");
     }


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Unhandled exceptions (HTTP 500) expose internal exception messages to the client, potentially leaking sensitive system information.
🎯 Impact: Attackers could gain insights into internal system workings, stack traces, or other sensitive details through unhandled error messages.
🔧 Fix: Updated the `GlobalExceptionHandler` to mask original exception messages with a generic "An unexpected error occurred" for unhandled exceptions.
✅ Verification: Run `mvn test` to verify the `GlobalExceptionHandlerTest` confirms the generic error message is returned for 500 responses.

---
*PR created automatically by Jules for task [15592682507517563220](https://jules.google.com/task/15592682507517563220) started by @FelixHertweck*