### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix sensitive information leakage in error responses

### DIFF
--- a/src/main/java/de/felixhertweck/seatreservation/GlobalExceptionHandler.java
+++ b/src/main/java/de/felixhertweck/seatreservation/GlobalExceptionHandler.java
@@ -156,7 +156,10 @@ public class GlobalExceptionHandler implements ExceptionMapper<Exception> {
                                 cooldownException.getMessage(), cooldownException.getRetryAfter());
                 return Response.status(status).entity(errorResponseCooldown).build();
             }
-            default -> status = Response.Status.INTERNAL_SERVER_ERROR;
+            default -> {
+                status = Response.Status.INTERNAL_SERVER_ERROR;
+                errorResponse = new ErrorResponseDTO("An unexpected error occurred");
+            }
         }
 
         LOG.warnf(

--- a/src/test/java/de/felixhertweck/seatreservation/GlobalExceptionHandlerTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/GlobalExceptionHandlerTest.java
@@ -24,7 +24,6 @@ import jakarta.ws.rs.core.NewCookie;
 import jakarta.ws.rs.core.Response;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
@@ -226,7 +225,7 @@ class GlobalExceptionHandlerTest {
         assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
         assertTrue(response.getEntity() instanceof ErrorResponseDTO);
         ErrorResponseDTO errorResponse = (ErrorResponseDTO) response.getEntity();
-        assertEquals("Generic error", errorResponse.getMessage());
+        assertEquals("An unexpected error occurred", errorResponse.getMessage());
     }
 
     @Test
@@ -237,7 +236,7 @@ class GlobalExceptionHandlerTest {
         assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
         assertTrue(response.getEntity() instanceof ErrorResponseDTO);
         ErrorResponseDTO errorResponse = (ErrorResponseDTO) response.getEntity();
-        assertEquals("Null pointer", errorResponse.getMessage());
+        assertEquals("An unexpected error occurred", errorResponse.getMessage());
     }
 
     @Test
@@ -248,7 +247,7 @@ class GlobalExceptionHandlerTest {
         assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
         assertTrue(response.getEntity() instanceof ErrorResponseDTO);
         ErrorResponseDTO errorResponse = (ErrorResponseDTO) response.getEntity();
-        assertNull(errorResponse.getMessage());
+        assertEquals("An unexpected error occurred", errorResponse.getMessage());
     }
 
     @Test

--- a/src/test/java/de/felixhertweck/seatreservation/userManagment/resource/EmailConfirmationResourceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/userManagment/resource/EmailConfirmationResourceTest.java
@@ -165,7 +165,7 @@ class EmailConfirmationResourceTest {
                 .post("/api/user/verify-email-code")
                 .then()
                 .statusCode(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode())
-                .body(containsString("Database error"));
+                .body(containsString("An unexpected error occurred"));
 
         verify(userService, times(1)).verifyEmailWithCode("123456");
     }


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Unhandled exceptions (HTTP 500) expose internal error messages in the API response.
🎯 Impact: Attackers could gain insights into the system's internal workings, database structure, or other sensitive details from exception messages.
🔧 Fix: Updated `GlobalExceptionHandler` to mask original exception messages for unhandled exceptions with a generic "An unexpected error occurred" message.
✅ Verification: Verified via unit tests that internal server errors now return "An unexpected error occurred" instead of the original exception message.

---
*PR created automatically by Jules for task [15109104158306429669](https://jules.google.com/task/15109104158306429669) started by @FelixHertweck*