### PR TITLE
⚡ Bolt: Optimize event location retrieval query

### DIFF
--- a/src/main/java/de/felixhertweck/seatreservation/model/repository/EventLocationRepository.java
+++ b/src/main/java/de/felixhertweck/seatreservation/model/repository/EventLocationRepository.java
@@ -24,6 +24,7 @@ import java.util.UUID;
 import jakarta.enterprise.context.ApplicationScoped;
 
 import de.felixhertweck.seatreservation.model.entity.EventLocation;
+import de.felixhertweck.seatreservation.model.entity.ReservationStatus;
 import de.felixhertweck.seatreservation.model.entity.User;
 import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
 
@@ -37,5 +38,24 @@ public class EventLocationRepository implements PanacheRepositoryBase<EventLocat
      */
     public List<EventLocation> findByManager(User manager) {
         return find("manager", manager).list();
+    }
+
+    /**
+     * Finds all distinct event locations where the user has event allowances or active
+     * reservations.
+     *
+     * @param user the user to search for
+     * @return a list of event locations the user is allowed to access
+     */
+    public List<EventLocation> findByUserAllowancesOrReservations(User user) {
+        return find(
+                        "select distinct el from EventLocation el where el.id in (  select"
+                            + " e1.eventLocation.id from EventUserAllowance a join a.event e1 where"
+                            + " a.user = ?1) or el.id in (  select e2.eventLocation.id from"
+                            + " Reservation r join r.event e2 where r.user = ?1 and r.status != ?2"
+                            + ")",
+                        user,
+                        ReservationStatus.BLOCKED)
+                .list();
     }
 }

--- a/src/main/java/de/felixhertweck/seatreservation/model/repository/EventLocationRepository.java
+++ b/src/main/java/de/felixhertweck/seatreservation/model/repository/EventLocationRepository.java
@@ -50,8 +50,8 @@ public class EventLocationRepository implements PanacheRepositoryBase<EventLocat
     public List<EventLocation> findByUserAllowancesOrReservations(User user) {
         return find(
                         "select distinct el from EventLocation el where el.id in (  select"
-                            + " e1.event_location.id from EventUserAllowance a join a.event e1"
-                            + " where a.user = ?1) or el.id in (  select e2.event_location.id from"
+                            + " e1.eventLocation.id from EventUserAllowance a join a.event e1 where"
+                            + " a.user = ?1) or el.id in (  select e2.eventLocation.id from"
                             + " Reservation r join r.event e2 where r.user = ?1 and r.status != ?2"
                             + ")",
                         user,

--- a/src/main/java/de/felixhertweck/seatreservation/model/repository/EventLocationRepository.java
+++ b/src/main/java/de/felixhertweck/seatreservation/model/repository/EventLocationRepository.java
@@ -50,8 +50,8 @@ public class EventLocationRepository implements PanacheRepositoryBase<EventLocat
     public List<EventLocation> findByUserAllowancesOrReservations(User user) {
         return find(
                         "select distinct el from EventLocation el where el.id in (  select"
-                            + " e1.eventLocation.id from EventUserAllowance a join a.event e1 where"
-                            + " a.user = ?1) or el.id in (  select e2.eventLocation.id from"
+                            + " e1.event_location.id from EventUserAllowance a join a.event e1"
+                            + " where a.user = ?1) or el.id in (  select e2.event_location.id from"
                             + " Reservation r join r.event e2 where r.user = ?1 and r.status != ?2"
                             + ")",
                         user,

--- a/src/main/java/de/felixhertweck/seatreservation/reservation/service/EventLocationService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/reservation/service/EventLocationService.java
@@ -19,16 +19,14 @@
  */
 package de.felixhertweck.seatreservation.reservation.service;
 
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
 import de.felixhertweck.seatreservation.common.exception.UserNotFoundException;
 import de.felixhertweck.seatreservation.model.entity.EventLocation;
 import de.felixhertweck.seatreservation.model.entity.User;
+import de.felixhertweck.seatreservation.model.repository.EventLocationRepository;
 import de.felixhertweck.seatreservation.model.repository.EventUserAllowanceRepository;
 import de.felixhertweck.seatreservation.model.repository.ReservationRepository;
 import de.felixhertweck.seatreservation.model.repository.UserRepository;
@@ -42,6 +40,7 @@ public class EventLocationService {
     @Inject UserRepository userRepository;
     @Inject EventUserAllowanceRepository eventUserAllowanceRepository;
     @Inject ReservationRepository reservationRepository;
+    @Inject EventLocationRepository eventLocationRepository;
 
     /**
      * Retrieves all event locations for which the specified user has event allowances or active
@@ -62,19 +61,8 @@ public class EventLocationService {
         }
         LOG.debugf("User %s found. Retrieving event allowances.", username);
 
-        Set<EventLocation> locations = new HashSet<>();
-
-        // Get all locations from allowances
-        locations.addAll(
-                eventUserAllowanceRepository.findByUserWithEventAndLocation(user).stream()
-                        .map(allowance -> allowance.getEvent().getEventLocation())
-                        .collect(Collectors.toSet()));
-
-        // Get all locations from reservations
-        locations.addAll(
-                reservationRepository.findByUserWithEventAndLocation(user).stream()
-                        .map(reservation -> reservation.getEvent().getEventLocation())
-                        .collect(Collectors.toSet()));
+        List<EventLocation> locations =
+                eventLocationRepository.findByUserAllowancesOrReservations(user);
 
         return locations.stream().map(UserEventLocationResponseDTO::new).toList();
     }


### PR DESCRIPTION
💡 What: Moved the filtering and projection of event locations from in-memory Streams to a targeted Panache HQL query.
🎯 Why: The original implementation in EventLocationService fetched all allowances and reservations for a user, transferring significant data to application memory to extract only the EventLocations via Java Streams.
📊 Impact: Avoids transferring O(N) reservation and allowance records to memory and reduces memory pressure by letting the database handle uniqueness filtering.
🔬 Measurement: Run application with many reservations per user and measure memory footprint and response time on the locations API compared to previous versions.

---
*PR created automatically by Jules for task [8121985179103286825](https://jules.google.com/task/8121985179103286825) started by @FelixHertweck*