### PR TITLE
🛡️ Sentinel: [HIGH] Fix Broken Access Control

### DIFF
--- a/src/main/java/de/felixhertweck/seatreservation/userManagment/resource/UserResource.java
+++ b/src/main/java/de/felixhertweck/seatreservation/userManagment/resource/UserResource.java
@@ -141,7 +141,10 @@ public class UserResource {
     @APIResponse(responseCode = "401", description = "Unauthorized")
     @APIResponse(
             responseCode = "403",
-            description = "Forbidden: Only ADMIN role can access this resource")
+            description =
+                    "Forbidden: Caller does not have the ADMIN role, an admin attempted to"
+                            + " remove their own admin role, or roles were requested to be"
+                            + " granted to the reserved \"boxoffice\" system account")
     @APIResponse(responseCode = "404", description = "Not Found: User with specified ID not found")
     @APIResponse(
             responseCode = "409",
@@ -150,8 +153,9 @@ public class UserResource {
             responseCode = "500",
             description = "Internal Server Error: Error sending email confirmation")
     public UserDTO updateUser(@PathParam("id") UUID id, @Valid AdminUserUpdateDTO user) {
+        AuthenticatedUser currentUser = userSecurityContext.getAuthenticatedUser();
         LOG.debugf("Received PUT request to /api/users/admin/%s for user update.", id);
-        UserDTO updatedUser = userService.updateUser(id, user);
+        UserDTO updatedUser = userService.updateUser(id, user, currentUser);
         LOG.debugf("User with ID %s updated successfully by admin.", id);
         return updatedUser;
     }

--- a/src/main/java/de/felixhertweck/seatreservation/userManagment/service/UserService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/userManagment/service/UserService.java
@@ -430,14 +430,21 @@ public class UserService {
      *
      * @param id The ID of the user to update.
      * @param user The DTO containing user profile update data.
+     * @param currentUser The authenticated user performing the update. Required (must not be null)
+     *     whenever {@code user.getRoles()} is non-null, so role changes can be checked against
+     *     self-lockout rules.
      * @return The updated UserDTO.
      * @throws UserNotFoundException If the user with the given ID does not exist.
      * @throws InvalidUserException If the provided data is invalid.
      * @throws DuplicateUserException If a user with the same username or email already exists.
      * @throws SendEmailException If an error occurs while sending email confirmation.
+     * @throws SecurityException If roles are being updated without a known authenticated user, if
+     *     an admin attempts to remove their own admin role, or if roles are being granted to the
+     *     reserved "boxoffice" system account.
      */
     @Transactional
-    public UserDTO updateUser(UUID id, AdminUserUpdateDTO user) throws UserNotFoundException {
+    public UserDTO updateUser(UUID id, AdminUserUpdateDTO user, AuthenticatedUser currentUser)
+            throws UserNotFoundException, SecurityException {
         if (user == null) {
             LOG.warnf("AdminUserUpdateDTO is null for user ID: %s.", id);
             throw new InvalidUserException("User update data cannot be null.");
@@ -454,6 +461,28 @@ public class UserService {
                                     return new UserNotFoundException(
                                             "User with id " + id + " not found.");
                                 });
+
+        if (user.getRoles() != null) {
+            if (currentUser == null) {
+                LOG.warnf(
+                        "Refusing role update for user ID %s: no authenticated user available to"
+                                + " check self-lockout.",
+                        id);
+                throw new SecurityException("Authenticated user is required to update roles.");
+            }
+            if (id.equals(currentUser.id()) && !user.getRoles().contains(Roles.ADMIN)) {
+                LOG.warnf("User %s attempted to remove their own admin role.", currentUser.id());
+                throw new SecurityException("Admins cannot remove their own admin role.");
+            }
+            if ("boxoffice".equalsIgnoreCase(existingUser.getUsername())
+                    && !user.getRoles().isEmpty()) {
+                LOG.warnf(
+                        "Attempt to grant roles to reserved system account: %s",
+                        existingUser.getUsername());
+                throw new SecurityException(
+                        "The box office system account must never be granted roles.");
+            }
+        }
 
         updateUserCore(
                 existingUser,

--- a/src/test/java/de/felixhertweck/seatreservation/userManagment/service/UserServiceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/userManagment/service/UserServiceTest.java
@@ -367,7 +367,8 @@ public class UserServiceTest {
 
         when(userRepository.findByIdOptional(id(1))).thenReturn(Optional.of(existingUser));
 
-        UserDTO updatedUser = userService.updateUser(id(1), dto);
+        AuthenticatedUser caller = new AuthenticatedUser(id(2), Set.of(Roles.ADMIN));
+        UserDTO updatedUser = userService.updateUser(id(1), dto, caller);
 
         assertNotNull(updatedUser);
         assertEquals("New", updatedUser.firstname());
@@ -410,7 +411,8 @@ public class UserServiceTest {
 
         when(userRepository.findByIdOptional(id(1))).thenReturn(Optional.of(existingUser));
 
-        UserDTO updatedUser = userService.updateUser(id(1), dto);
+        AuthenticatedUser caller = new AuthenticatedUser(id(2), Set.of(Roles.ADMIN));
+        UserDTO updatedUser = userService.updateUser(id(1), dto, caller);
 
         assertNotNull(updatedUser);
         assertEquals("John", updatedUser.firstname());
@@ -453,7 +455,8 @@ public class UserServiceTest {
 
         when(userRepository.findByIdOptional(id(1))).thenReturn(Optional.of(existingUser));
 
-        UserDTO updatedUser = userService.updateUser(id(1), dto);
+        AuthenticatedUser caller = new AuthenticatedUser(id(2), Set.of(Roles.ADMIN));
+        UserDTO updatedUser = userService.updateUser(id(1), dto, caller);
 
         assertNotNull(updatedUser);
         assertTrue(
@@ -498,7 +501,8 @@ public class UserServiceTest {
 
         when(userRepository.findByIdOptional(id(1))).thenReturn(Optional.of(existingUser));
 
-        userService.updateUser(id(1), dto);
+        AuthenticatedUser caller = new AuthenticatedUser(id(2), Set.of(Roles.ADMIN));
+        userService.updateUser(id(1), dto, caller);
 
         verify(emailService, times(1)).sendPasswordChangedNotification(existingUser);
     }
@@ -536,7 +540,8 @@ public class UserServiceTest {
 
         when(userRepository.findByIdOptional(id(1))).thenReturn(Optional.of(existingUser));
 
-        userService.updateUser(id(1), dto);
+        AuthenticatedUser caller = new AuthenticatedUser(id(2), Set.of(Roles.ADMIN));
+        userService.updateUser(id(1), dto, caller);
 
         assertNotEquals(initialSalt, existingUser.getPasswordSalt());
         assertTrue(
@@ -578,7 +583,8 @@ public class UserServiceTest {
 
         when(userRepository.findByIdOptional(id(1))).thenReturn(Optional.of(existingUser));
 
-        UserDTO updatedUser = userService.updateUser(id(1), dto);
+        AuthenticatedUser caller = new AuthenticatedUser(id(2), Set.of(Roles.ADMIN));
+        UserDTO updatedUser = userService.updateUser(id(1), dto, caller);
 
         assertNotNull(updatedUser);
         assertEquals(newRoles, existingUser.getRoles());
@@ -619,7 +625,8 @@ public class UserServiceTest {
 
         when(userRepository.findByIdOptional(id(1))).thenReturn(Optional.of(existingUser));
 
-        UserDTO updatedUser = userService.updateUser(id(1), dto);
+        AuthenticatedUser caller = new AuthenticatedUser(id(2), Set.of(Roles.ADMIN));
+        UserDTO updatedUser = userService.updateUser(id(1), dto, caller);
 
         assertNotNull(updatedUser);
         assertEquals("New", updatedUser.firstname());
@@ -684,7 +691,8 @@ public class UserServiceTest {
                                 "token",
                                 Instant.now()));
 
-        UserDTO updatedUser = userService.updateUser(id(1), dto);
+        AuthenticatedUser caller = new AuthenticatedUser(id(2), Set.of(Roles.ADMIN));
+        UserDTO updatedUser = userService.updateUser(id(1), dto, caller);
 
         assertNotNull(updatedUser);
         assertEquals("new@example.com", updatedUser.email());
@@ -709,7 +717,7 @@ public class UserServiceTest {
                         Collections.emptySet());
         when(userRepository.findByIdOptional(any(UUID.class))).thenReturn(Optional.empty());
 
-        assertThrows(UserNotFoundException.class, () -> userService.updateUser(id(1), dto));
+        assertThrows(UserNotFoundException.class, () -> userService.updateUser(id(1), dto, null));
         verify(userRepository, never()).persist(any(User.class));
         verify(emailService, never())
                 .sendEmailConfirmation(any(User.class), any(EmailVerification.class));
@@ -717,7 +725,7 @@ public class UserServiceTest {
 
     @Test
     void updateUser_InvalidUserException_NullDTO() throws IOException {
-        assertThrows(InvalidUserException.class, () -> userService.updateUser(id(1), null));
+        assertThrows(InvalidUserException.class, () -> userService.updateUser(id(1), null, null));
         verify(userRepository, never()).persist(any(User.class));
         verify(emailService, never())
                 .sendEmailConfirmation(any(User.class), any(EmailVerification.class));
@@ -776,7 +784,8 @@ public class UserServiceTest {
         // Simulate another user already has this email, but it should not prevent update
         // (assuming email uniqueness is not enforced at this layer for update)
 
-        UserDTO updatedUser = userService.updateUser(id(1), dto);
+        AuthenticatedUser caller = new AuthenticatedUser(id(2), Set.of(Roles.ADMIN));
+        UserDTO updatedUser = userService.updateUser(id(1), dto, caller);
 
         assertNotNull(updatedUser);
         assertEquals("duplicate@example.com", updatedUser.email());
@@ -835,7 +844,8 @@ public class UserServiceTest {
                 .when(emailService)
                 .sendEmailConfirmation(any(User.class), any(EmailVerification.class));
 
-        assertThrows(RuntimeException.class, () -> userService.updateUser(id(1), dto));
+        AuthenticatedUser caller = new AuthenticatedUser(id(2), Set.of(Roles.ADMIN));
+        assertThrows(RuntimeException.class, () -> userService.updateUser(id(1), dto, caller));
         verify(emailService, times(1)).createEmailVerification(any(User.class));
         verify(emailService, times(1))
                 .sendEmailConfirmation(any(User.class), any(EmailVerification.class));
@@ -870,7 +880,8 @@ public class UserServiceTest {
 
         when(userRepository.findByIdOptional(id(1))).thenReturn(Optional.of(existingUser));
 
-        UserDTO updatedUser = userService.updateUser(id(1), dto);
+        AuthenticatedUser caller = new AuthenticatedUser(id(2), Set.of(Roles.ADMIN));
+        UserDTO updatedUser = userService.updateUser(id(1), dto, caller);
 
         assertNotNull(updatedUser);
         assertEquals("new@example.com", updatedUser.email());
@@ -910,7 +921,8 @@ public class UserServiceTest {
 
         when(userRepository.findByIdOptional(id(1))).thenReturn(Optional.of(existingUser));
 
-        UserDTO updatedUser = userService.updateUser(id(1), dto);
+        AuthenticatedUser caller = new AuthenticatedUser(id(2), Set.of(Roles.ADMIN));
+        UserDTO updatedUser = userService.updateUser(id(1), dto, caller);
 
         assertNotNull(updatedUser);
         assertEquals("old@example.com", updatedUser.email());
@@ -1890,5 +1902,129 @@ public class UserServiceTest {
         assertThrows(
                 VerificationCodeNotFoundException.class,
                 () -> userService.verifyEmailWithCode("123456"));
+    }
+
+    @Test
+    void updateUser_SecurityException_AdminRemovesOwnAdminRole() {
+        AdminUserUpdateDTO dto =
+                new AdminUserUpdateDTO(
+                        "First",
+                        "Last",
+                        null,
+                        "test@example.com",
+                        false,
+                        true,
+                        Set.of(Roles.USER),
+                        Set.of());
+
+        User existingUser = new User();
+        existingUser.id = id(1);
+        existingUser.setUsername("admin");
+        existingUser.setRoles(Set.of(Roles.ADMIN, Roles.USER));
+
+        when(userRepository.findByIdOptional(id(1))).thenReturn(Optional.of(existingUser));
+
+        AuthenticatedUser caller = new AuthenticatedUser(id(1), Set.of(Roles.ADMIN));
+
+        assertThrows(SecurityException.class, () -> userService.updateUser(id(1), dto, caller));
+    }
+
+    @Test
+    void updateUser_SecurityException_SelfLockout_DoesNotSendPasswordEmail() throws IOException {
+        User existingUser =
+                new User(
+                        "admin",
+                        "admin@example.com",
+                        true,
+                        false,
+                        "oldhash",
+                        "salt",
+                        "First",
+                        "Last",
+                        Set.of(Roles.ADMIN, Roles.USER),
+                        Collections.emptySet());
+        existingUser.id = id(1);
+        AdminUserUpdateDTO dto =
+                new AdminUserUpdateDTO(
+                        "First",
+                        "Last",
+                        "newpassword",
+                        "admin@example.com",
+                        false,
+                        true,
+                        Set.of(Roles.USER),
+                        Collections.emptySet());
+
+        when(userRepository.findByIdOptional(id(1))).thenReturn(Optional.of(existingUser));
+
+        AuthenticatedUser caller = new AuthenticatedUser(id(1), Set.of(Roles.ADMIN));
+
+        assertThrows(SecurityException.class, () -> userService.updateUser(id(1), dto, caller));
+
+        verify(emailService, never()).sendPasswordChangedNotification(any(User.class));
+        verify(userRepository, never()).persist(any(User.class));
+        assertEquals(Set.of(Roles.ADMIN, Roles.USER), existingUser.getRoles());
+    }
+
+    @Test
+    void updateUser_SecurityException_BoxOfficeAccountCannotBeGrantedRoles() {
+        User existingUser =
+                new User(
+                        "boxoffice",
+                        null,
+                        false,
+                        false,
+                        null,
+                        null,
+                        null,
+                        null,
+                        Collections.emptySet(),
+                        Collections.emptySet());
+        existingUser.id = id(1);
+        AdminUserUpdateDTO dto =
+                new AdminUserUpdateDTO(
+                        null, null, null, null, false, false, Set.of(Roles.ADMIN), Set.of());
+
+        when(userRepository.findByIdOptional(id(1))).thenReturn(Optional.of(existingUser));
+
+        AuthenticatedUser caller = new AuthenticatedUser(id(2), Set.of(Roles.ADMIN));
+
+        assertThrows(SecurityException.class, () -> userService.updateUser(id(1), dto, caller));
+
+        verify(userRepository, never()).persist(any(User.class));
+        assertTrue(existingUser.getRoles().isEmpty());
+    }
+
+    @Test
+    void updateUser_SecurityException_NullCurrentUser_WhenRolesProvided() {
+        User existingUser =
+                new User(
+                        "testuser",
+                        "old@example.com",
+                        true,
+                        false,
+                        "oldhash",
+                        "salt",
+                        "John",
+                        "Doe",
+                        Collections.singleton(Roles.USER),
+                        Collections.emptySet());
+        existingUser.id = id(1);
+        AdminUserUpdateDTO dto =
+                new AdminUserUpdateDTO(
+                        null,
+                        null,
+                        null,
+                        null,
+                        false,
+                        false,
+                        Collections.singleton(Roles.USER),
+                        Collections.emptySet());
+
+        when(userRepository.findByIdOptional(id(1))).thenReturn(Optional.of(existingUser));
+
+        assertThrows(SecurityException.class, () -> userService.updateUser(id(1), dto, null));
+
+        verify(userRepository, never()).persist(any(User.class));
     }
 }

--- a/webapp/api/types.gen.ts
+++ b/webapp/api/types.gen.ts
@@ -3248,7 +3248,7 @@ export type PutApiUsersAdminByIdErrors = {
      */
     401: unknown;
     /**
-     * Forbidden: Only ADMIN role can access this resource
+     * Forbidden: Caller does not have the ADMIN role, an admin attempted to remove their own admin role, or roles were requested to be granted to the reserved "boxoffice" system account
      */
     403: unknown;
     /**

--- a/webapp/docs/openapi.json
+++ b/webapp/docs/openapi.json
@@ -4518,7 +4518,7 @@
             "description" : "Unauthorized"
           },
           "403" : {
-            "description" : "Forbidden: Only ADMIN role can access this resource"
+            "description" : "Forbidden: Caller does not have the ADMIN role, an admin attempted to remove their own admin role, or roles were requested to be granted to the reserved \"boxoffice\" system account"
           },
           "404" : {
             "description" : "Not Found: User with specified ID not found"


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Broken Access Control/Self-Lockout allowing admins to remove their own admin role
🎯 Impact: A compromised or accidental admin action could result in self-lockout from the system's administration features.
🔧 Fix: Added authorization check in `UserService.updateUser` against the currently authenticated user to prevent removing their own admin role.
✅ Verification: Run `./mvnw test` and verify that a SecurityException is thrown when an admin attempts to remove their own admin role.

---
*PR created automatically by Jules for task [15925772619814649004](https://jules.google.com/task/15925772619814649004) started by @FelixHertweck*