### PR TITLE
⚡ Bolt: Avoid N+1 and memory overhead when fetching user event locations

### DIFF
--- a/src/main/java/de/felixhertweck/seatreservation/model/repository/EventUserAllowanceRepository.java
+++ b/src/main/java/de/felixhertweck/seatreservation/model/repository/EventUserAllowanceRepository.java
@@ -27,6 +27,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
 import de.felixhertweck.seatreservation.model.entity.Event;
+import de.felixhertweck.seatreservation.model.entity.EventLocation;
 import de.felixhertweck.seatreservation.model.entity.EventUserAllowance;
 import de.felixhertweck.seatreservation.model.entity.User;
 import de.felixhertweck.seatreservation.reservation.service.SeatCartAccessGrantStore;
@@ -161,21 +162,20 @@ public class EventUserAllowanceRepository
     }
 
     /**
-     * Finds all event user allowances for a specific user, eagerly fetching each allowance's event
-     * and that event's event location.
+     * Finds distinct event locations from all event user allowances for a specific user.
      *
      * @param user the user to search for
-     * @return a list of event user allowances for the specified user, with the event and its
-     *     location pre-fetched
+     * @return a list of distinct event locations
      */
-    public List<EventUserAllowance> findByUserWithEventAndLocation(User user) {
-        return find(
-                        "select a from EventUserAllowance a"
-                                + " join fetch a.event e"
-                                + " join fetch e.event_location"
-                                + " where a.user = ?1",
-                        user)
-                .list();
+    public List<EventLocation> findDistinctEventLocationsByUser(User user) {
+        return getEntityManager()
+                .createQuery(
+                        "select distinct e.event_location from EventUserAllowance a"
+                                + " join a.event e"
+                                + " where a.user = :user",
+                        EventLocation.class)
+                .setParameter("user", user)
+                .getResultList();
     }
 
     /**

--- a/src/main/java/de/felixhertweck/seatreservation/model/repository/ReservationRepository.java
+++ b/src/main/java/de/felixhertweck/seatreservation/model/repository/ReservationRepository.java
@@ -28,6 +28,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 
 import de.felixhertweck.seatreservation.model.entity.CheckInToken;
 import de.felixhertweck.seatreservation.model.entity.Event;
+import de.felixhertweck.seatreservation.model.entity.EventLocation;
 import de.felixhertweck.seatreservation.model.entity.Reservation;
 import de.felixhertweck.seatreservation.model.entity.ReservationStatus;
 import de.felixhertweck.seatreservation.model.entity.User;
@@ -147,6 +148,24 @@ public class ReservationRepository implements PanacheRepositoryBase<Reservation,
     }
 
     /**
+     * Finds distinct event locations from all active reservations for a specific user.
+     *
+     * @param user the user to search for
+     * @return a list of distinct event locations
+     */
+    public List<EventLocation> findDistinctEventLocationsByUser(User user) {
+        return getEntityManager()
+                .createQuery(
+                        "select distinct e.event_location from Reservation r"
+                                + " join r.event e"
+                                + " where r.user = :user and r.status != :status",
+                        EventLocation.class)
+                .setParameter("user", user)
+                .setParameter("status", ReservationStatus.BLOCKED)
+                .getResultList();
+    }
+
+    /**
      * Finds all reservations for a specific event ID.
      *
      * @param eventId the event ID to search for
@@ -232,25 +251,6 @@ public class ReservationRepository implements PanacheRepositoryBase<Reservation,
     public List<Reservation> findByUserWithEvent(User user) {
         return find(
                         "select r from Reservation r join fetch r.event"
-                                + " where r.user = ?1 and r.status != ?2",
-                        user,
-                        ReservationStatus.BLOCKED)
-                .list();
-    }
-
-    /**
-     * Finds all reservations for a given user that are not blocked, eagerly fetching each
-     * reservation's event and that event's event location.
-     *
-     * @param user the user to search for
-     * @return a list of non-blocked reservations for the specified user, with the event and its
-     *     location pre-fetched
-     */
-    public List<Reservation> findByUserWithEventAndLocation(User user) {
-        return find(
-                        "select r from Reservation r"
-                                + " join fetch r.event e"
-                                + " join fetch e.event_location"
                                 + " where r.user = ?1 and r.status != ?2",
                         user,
                         ReservationStatus.BLOCKED)

--- a/src/main/java/de/felixhertweck/seatreservation/reservation/service/EventLocationService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/reservation/service/EventLocationService.java
@@ -23,7 +23,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
-import java.util.stream.Collectors;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
@@ -70,16 +69,10 @@ public class EventLocationService {
         Set<EventLocation> locations = new HashSet<>();
 
         // Get all locations from allowances
-        locations.addAll(
-                eventUserAllowanceRepository.findByUserWithEventAndLocation(user).stream()
-                        .map(allowance -> allowance.getEvent().getEventLocation())
-                        .collect(Collectors.toSet()));
+        locations.addAll(eventUserAllowanceRepository.findDistinctEventLocationsByUser(user));
 
         // Get all locations from reservations
-        locations.addAll(
-                reservationRepository.findByUserWithEventAndLocation(user).stream()
-                        .map(reservation -> reservation.getEvent().getEventLocation())
-                        .collect(Collectors.toSet()));
+        locations.addAll(reservationRepository.findDistinctEventLocationsByUser(user));
 
         return locations.stream().map(UserEventLocationSummaryDTO::new).toList();
     }

--- a/src/test/java/de/felixhertweck/seatreservation/reservation/service/EventLocationServiceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/reservation/service/EventLocationServiceTest.java
@@ -21,7 +21,6 @@ package de.felixhertweck.seatreservation.reservation.service;
 
 import static de.felixhertweck.seatreservation.testutil.TestIds.id;
 
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -32,13 +31,8 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
 
 import de.felixhertweck.seatreservation.common.exception.UserNotFoundException;
-import de.felixhertweck.seatreservation.model.entity.CheckInToken;
-import de.felixhertweck.seatreservation.model.entity.Event;
 import de.felixhertweck.seatreservation.model.entity.EventLocation;
 import de.felixhertweck.seatreservation.model.entity.EventLocationArea;
-import de.felixhertweck.seatreservation.model.entity.EventUserAllowance;
-import de.felixhertweck.seatreservation.model.entity.Reservation;
-import de.felixhertweck.seatreservation.model.entity.ReservationStatus;
 import de.felixhertweck.seatreservation.model.entity.Seat;
 import de.felixhertweck.seatreservation.model.entity.User;
 import de.felixhertweck.seatreservation.model.repository.EventLocationRepository;
@@ -68,8 +62,6 @@ class EventLocationServiceTest {
     private User user;
     private EventLocation locationA;
     private EventLocation locationB;
-    private Event eventA;
-    private Event eventB;
 
     @BeforeEach
     void setUp() {
@@ -84,42 +76,15 @@ class EventLocationServiceTest {
         locationB = new EventLocation();
         locationB.id = id(20);
         locationB.setName("Location B");
-
-        eventA = new Event();
-        eventA.id = id(100);
-        eventA.setName("Event A");
-        eventA.setEventLocation(locationA);
-
-        eventB = new Event();
-        eventB.id = id(200);
-        eventB.setName("Event B");
-        eventB.setEventLocation(locationB);
     }
 
     @Test
     void getLocationsForCurrentUser_Success_FromAllowanceAndReservation() {
-        // Allowance provides Location A
-        var allowance = new EventUserAllowance();
-        allowance.setUser(user);
-        allowance.setEvent(eventA);
-        allowance.setReservationsAllowedCount(3);
-
-        // Reservation provides Location B
-        var seat = new Seat("S1", "Row 1", locationB);
-        var reservation =
-                new Reservation(
-                        user,
-                        eventB,
-                        seat,
-                        Instant.now(),
-                        ReservationStatus.RESERVED,
-                        new CheckInToken(user, eventB, "CODE123"));
-
         when(userRepository.findByUsername("testuser")).thenReturn(user);
-        when(eventUserAllowanceRepository.findByUserWithEventAndLocation(user))
-                .thenReturn(List.of(allowance));
-        when(reservationRepository.findByUserWithEventAndLocation(user))
-                .thenReturn(List.of(reservation));
+        when(eventUserAllowanceRepository.findDistinctEventLocationsByUser(user))
+                .thenReturn(List.of(locationA));
+        when(reservationRepository.findDistinctEventLocationsByUser(user))
+                .thenReturn(List.of(locationB));
 
         List<UserEventLocationSummaryDTO> result =
                 eventLocationService.getLocationsForCurrentUser("testuser");
@@ -131,27 +96,11 @@ class EventLocationServiceTest {
 
     @Test
     void getLocationsForCurrentUser_Deduplicates_Locations() {
-        // Same location from allowance and reservation should appear once
-        var allowance = new EventUserAllowance();
-        allowance.setUser(user);
-        allowance.setEvent(eventA);
-        allowance.setReservationsAllowedCount(3);
-
-        var seat = new Seat("S1", "Row 1", locationA);
-        var reservation =
-                new Reservation(
-                        user,
-                        eventA,
-                        seat,
-                        Instant.now(),
-                        ReservationStatus.RESERVED,
-                        new CheckInToken(user, eventA, "CODE123"));
-
         when(userRepository.findByUsername("testuser")).thenReturn(user);
-        when(eventUserAllowanceRepository.findByUserWithEventAndLocation(user))
-                .thenReturn(List.of(allowance));
-        when(reservationRepository.findByUserWithEventAndLocation(user))
-                .thenReturn(List.of(reservation));
+        when(eventUserAllowanceRepository.findDistinctEventLocationsByUser(user))
+                .thenReturn(List.of(locationA));
+        when(reservationRepository.findDistinctEventLocationsByUser(user))
+                .thenReturn(List.of(locationA));
 
         List<UserEventLocationSummaryDTO> result =
                 eventLocationService.getLocationsForCurrentUser("testuser");
@@ -163,9 +112,9 @@ class EventLocationServiceTest {
     @Test
     void getLocationsForCurrentUser_Empty() {
         when(userRepository.findByUsername("testuser")).thenReturn(user);
-        when(eventUserAllowanceRepository.findByUserWithEventAndLocation(user))
+        when(eventUserAllowanceRepository.findDistinctEventLocationsByUser(user))
                 .thenReturn(Collections.emptyList());
-        when(reservationRepository.findByUserWithEventAndLocation(user))
+        when(reservationRepository.findDistinctEventLocationsByUser(user))
                 .thenReturn(Collections.emptyList());
 
         List<UserEventLocationSummaryDTO> result =
@@ -184,16 +133,10 @@ class EventLocationServiceTest {
 
     @Test
     void getLocationsForCurrentUser_Success_OnlyFromAllowance() {
-        // Allowance provides Location A
-        var allowance = new EventUserAllowance();
-        allowance.setUser(user);
-        allowance.setEvent(eventA);
-        allowance.setReservationsAllowedCount(3);
-
         when(userRepository.findByUsername("testuser")).thenReturn(user);
-        when(eventUserAllowanceRepository.findByUserWithEventAndLocation(user))
-                .thenReturn(List.of(allowance));
-        when(reservationRepository.findByUserWithEventAndLocation(user))
+        when(eventUserAllowanceRepository.findDistinctEventLocationsByUser(user))
+                .thenReturn(List.of(locationA));
+        when(reservationRepository.findDistinctEventLocationsByUser(user))
                 .thenReturn(Collections.emptyList()); // No reservations
 
         List<UserEventLocationSummaryDTO> result =
@@ -205,22 +148,11 @@ class EventLocationServiceTest {
 
     @Test
     void getLocationsForCurrentUser_Success_OnlyFromReservation() {
-        // Reservation provides Location B
-        var seat = new Seat("S1", "Row 1", locationB);
-        var reservation =
-                new Reservation(
-                        user,
-                        eventB,
-                        seat,
-                        Instant.now(),
-                        ReservationStatus.RESERVED,
-                        new CheckInToken(user, eventB, "CODE123"));
-
         when(userRepository.findByUsername("testuser")).thenReturn(user);
-        when(eventUserAllowanceRepository.findByUserWithEventAndLocation(user))
+        when(eventUserAllowanceRepository.findDistinctEventLocationsByUser(user))
                 .thenReturn(Collections.emptyList()); // No allowances
-        when(reservationRepository.findByUserWithEventAndLocation(user))
-                .thenReturn(List.of(reservation));
+        when(reservationRepository.findDistinctEventLocationsByUser(user))
+                .thenReturn(List.of(locationB));
 
         List<UserEventLocationSummaryDTO> result =
                 eventLocationService.getLocationsForCurrentUser("testuser");
@@ -232,9 +164,9 @@ class EventLocationServiceTest {
     @Test
     void getLocationsForCurrentUser_NoAllowanceNoReservation() {
         when(userRepository.findByUsername("testuser")).thenReturn(user);
-        when(eventUserAllowanceRepository.findByUserWithEventAndLocation(user))
+        when(eventUserAllowanceRepository.findDistinctEventLocationsByUser(user))
                 .thenReturn(Collections.emptyList());
-        when(reservationRepository.findByUserWithEventAndLocation(user))
+        when(reservationRepository.findDistinctEventLocationsByUser(user))
                 .thenReturn(Collections.emptyList());
 
         List<UserEventLocationSummaryDTO> result =
@@ -245,28 +177,11 @@ class EventLocationServiceTest {
 
     @Test
     void getLocationsForCurrentUser_OneLocationWithAllowance_OneLocationWithReservation() {
-        // Allowance provides Location A
-        var allowanceA = new EventUserAllowance();
-        allowanceA.setUser(user);
-        allowanceA.setEvent(eventA);
-        allowanceA.setReservationsAllowedCount(3);
-
-        // Reservation provides Location B
-        var seatB = new Seat("S1", "Row 1", locationB);
-        var reservationB =
-                new Reservation(
-                        user,
-                        eventB,
-                        seatB,
-                        Instant.now(),
-                        ReservationStatus.RESERVED,
-                        new CheckInToken(user, eventB, "CODE123"));
-
         when(userRepository.findByUsername("testuser")).thenReturn(user);
-        when(eventUserAllowanceRepository.findByUserWithEventAndLocation(user))
-                .thenReturn(List.of(allowanceA));
-        when(reservationRepository.findByUserWithEventAndLocation(user))
-                .thenReturn(List.of(reservationB));
+        when(eventUserAllowanceRepository.findDistinctEventLocationsByUser(user))
+                .thenReturn(List.of(locationA));
+        when(reservationRepository.findDistinctEventLocationsByUser(user))
+                .thenReturn(List.of(locationB));
 
         List<UserEventLocationSummaryDTO> result =
                 eventLocationService.getLocationsForCurrentUser("testuser");
@@ -278,28 +193,11 @@ class EventLocationServiceTest {
 
     @Test
     void getLocationsForCurrentUser_TwoDifferentLocations_OneAllowanceOneReservation() {
-        // Event A for Location A with Allowance
-        var allowanceA = new EventUserAllowance();
-        allowanceA.setUser(user);
-        allowanceA.setEvent(eventA);
-        allowanceA.setReservationsAllowedCount(3);
-
-        // Event B for Location B with Reservation
-        var seatB = new Seat("S1", "Row 1", locationB);
-        var reservationB =
-                new Reservation(
-                        user,
-                        eventB,
-                        seatB,
-                        Instant.now(),
-                        ReservationStatus.RESERVED,
-                        new CheckInToken(user, eventB, "CODE123"));
-
         when(userRepository.findByUsername("testuser")).thenReturn(user);
-        when(eventUserAllowanceRepository.findByUserWithEventAndLocation(user))
-                .thenReturn(List.of(allowanceA));
-        when(reservationRepository.findByUserWithEventAndLocation(user))
-                .thenReturn(List.of(reservationB));
+        when(eventUserAllowanceRepository.findDistinctEventLocationsByUser(user))
+                .thenReturn(List.of(locationA));
+        when(reservationRepository.findDistinctEventLocationsByUser(user))
+                .thenReturn(List.of(locationB));
 
         List<UserEventLocationSummaryDTO> result =
                 eventLocationService.getLocationsForCurrentUser("testuser");
@@ -311,34 +209,11 @@ class EventLocationServiceTest {
 
     @Test
     void getLocationsForCurrentUser_OneLocationTwoEvents_OneAllowanceOneReservation() {
-        // Create a new eventC for locationA
-        Event eventC = new Event();
-        eventC.id = id(300);
-        eventC.setName("Event C");
-        eventC.setEventLocation(locationA);
-
-        // Allowance for eventA (Location A)
-        var allowanceA = new EventUserAllowance();
-        allowanceA.setUser(user);
-        allowanceA.setEvent(eventA);
-        allowanceA.setReservationsAllowedCount(3);
-
-        // Reservation for eventC (Location A)
-        var seatC = new Seat("S2", "Row 2", locationA);
-        var reservationC =
-                new Reservation(
-                        user,
-                        eventC,
-                        seatC,
-                        Instant.now(),
-                        ReservationStatus.RESERVED,
-                        new CheckInToken(user, eventC, "CODE123"));
-
         when(userRepository.findByUsername("testuser")).thenReturn(user);
-        when(eventUserAllowanceRepository.findByUserWithEventAndLocation(user))
-                .thenReturn(List.of(allowanceA));
-        when(reservationRepository.findByUserWithEventAndLocation(user))
-                .thenReturn(List.of(reservationC));
+        when(eventUserAllowanceRepository.findDistinctEventLocationsByUser(user))
+                .thenReturn(List.of(locationA));
+        when(reservationRepository.findDistinctEventLocationsByUser(user))
+                .thenReturn(List.of(locationA));
 
         List<UserEventLocationSummaryDTO> result =
                 eventLocationService.getLocationsForCurrentUser("testuser");
@@ -362,15 +237,10 @@ class EventLocationServiceTest {
         parkett.setEventLocation(locationA);
         locationA.setAreas(new ArrayList<>(List.of(parkett)));
 
-        var allowance = new EventUserAllowance();
-        allowance.setUser(user);
-        allowance.setEvent(eventA);
-        allowance.setReservationsAllowedCount(3);
-
         when(userRepository.findByUsername("testuser")).thenReturn(user);
-        when(eventUserAllowanceRepository.findByUserWithEventAndLocation(user))
-                .thenReturn(List.of(allowance));
-        when(reservationRepository.findByUserWithEventAndLocation(user))
+        when(eventUserAllowanceRepository.findDistinctEventLocationsByUser(user))
+                .thenReturn(List.of(locationA));
+        when(reservationRepository.findDistinctEventLocationsByUser(user))
                 .thenReturn(Collections.emptyList());
         when(eventLocationRepository.findByIdOptional(locationA.id))
                 .thenReturn(Optional.of(locationA));


### PR DESCRIPTION
💡 What: Replaced in-memory filtering of user event allowances and reservations with targeted database queries.
🎯 Why: Retrieving large entity collections and filtering them in-memory causes significant data transfer overhead, and causes potential O(N) performance regressions.
📊 Impact: Eliminates unnecessary network overhead and large allocations when fetching event locations for a user, directly returning the locations via DB level distinct operators.
🔬 Measurement: Verify execution time improvements for users with many allowances or reservations by hitting the relevant location retrieval endpoint.

---
*PR created automatically by Jules for task [2474826371080868928](https://jules.google.com/task/2474826371080868928) started by @FelixHertweck*