### PR TITLE
fix(backend): respect emailVerified when admin creates a user

### DIFF
--- a/src/main/java/de/felixhertweck/seatreservation/importer/CSVToDto.java
+++ b/src/main/java/de/felixhertweck/seatreservation/importer/CSVToDto.java
@@ -143,6 +143,7 @@ public class CSVToDto {
                         username,
                         email.isBlank() ? null : email,
                         Boolean.FALSE,
+                        Boolean.FALSE,
                         password,
                         firstname,
                         lastname,

--- a/src/main/java/de/felixhertweck/seatreservation/userManagment/dto/AdminUserCreationDto.java
+++ b/src/main/java/de/felixhertweck/seatreservation/userManagment/dto/AdminUserCreationDto.java
@@ -56,6 +56,9 @@ public class AdminUserCreationDto {
     @NotNull(message = "sendEmailVerification cannot be null")
     private final Boolean sendEmailVerification;
 
+    @NotNull(message = "emailVerified cannot be null")
+    private final Boolean emailVerified;
+
     @NotNull(message = "roles cannot be null")
     @NotEmpty(message = "roles cannot be empty")
     private Set<String> roles;
@@ -73,6 +76,10 @@ public class AdminUserCreationDto {
 
     public Boolean getSendEmailVerification() {
         return sendEmailVerification;
+    }
+
+    public Boolean getEmailVerified() {
+        return emailVerified;
     }
 
     public String getPassword() {
@@ -99,6 +106,7 @@ public class AdminUserCreationDto {
             String username,
             String email,
             Boolean sendEmailVerification,
+            Boolean emailVerified,
             String password,
             String firstname,
             String lastname,
@@ -107,6 +115,7 @@ public class AdminUserCreationDto {
         this.username = username;
         this.email = email;
         this.sendEmailVerification = sendEmailVerification;
+        this.emailVerified = emailVerified;
         this.password = password;
         this.firstname = firstname;
         this.lastname = lastname;

--- a/src/main/java/de/felixhertweck/seatreservation/userManagment/resource/UserResource.java
+++ b/src/main/java/de/felixhertweck/seatreservation/userManagment/resource/UserResource.java
@@ -121,7 +121,10 @@ public class UserResource {
                 userService.createUser(
                         new UserCreationDTO(userCreationDTO),
                         userCreationDTO.getRoles(),
-                        userCreationDTO.getSendEmailVerification());
+                        userCreationDTO.getSendEmailVerification(),
+                        false,
+                        userCreationDTO.getEmailVerified(),
+                        null);
         LOG.debugf("User %s created successfully by admin.", createdUser.username());
         return createdUser;
     }

--- a/src/main/java/de/felixhertweck/seatreservation/userManagment/service/UserService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/userManagment/service/UserService.java
@@ -109,6 +109,7 @@ public class UserService {
                             adminUser.getRoles(),
                             false,
                             false,
+                            Boolean.TRUE.equals(adminUser.getEmailVerified()),
                             knownExistingUsernames);
             importedUsers.add(user);
         }
@@ -151,7 +152,8 @@ public class UserService {
             boolean sendEmailVerification,
             boolean allowNoPassword)
             throws InvalidUserException, DuplicateUserException {
-        return createUser(userCreationDTO, roles, sendEmailVerification, allowNoPassword, null);
+        return createUser(
+                userCreationDTO, roles, sendEmailVerification, allowNoPassword, false, null);
     }
 
     /**
@@ -163,6 +165,9 @@ public class UserService {
      * @param allowNoPassword when {@code true}, the user may be created without a password (e.g. a
      *     passkey-only account); the stored password hash is {@code null} and password login is
      *     unavailable for this user until a password is set
+     * @param markEmailAsVerified when {@code true}, the new user's email is marked as verified
+     *     immediately (e.g. an admin creating a pre-verified account); {@code
+     *     sendEmailVerification} is ignored in that case since there is nothing left to verify
      * @param knownExistingUsernames when non-{@code null}, the duplicate-username check is done
      *     against this in-memory set instead of a per-call database query; used by {@link
      *     #importUsers} to check all usernames of a batch in a single upfront query. The newly
@@ -176,6 +181,7 @@ public class UserService {
             Set<String> roles,
             boolean sendEmailVerification,
             boolean allowNoPassword,
+            boolean markEmailAsVerified,
             Set<String> knownExistingUsernames)
             throws InvalidUserException, DuplicateUserException {
         if (userCreationDTO == null) {
@@ -244,7 +250,7 @@ public class UserService {
                 new User(
                         userCreationDTO.getUsername(),
                         email,
-                        false,
+                        markEmailAsVerified,
                         false,
                         passwordHash,
                         salt,
@@ -267,7 +273,7 @@ public class UserService {
             knownExistingUsernames.add(user.getUsername());
         }
 
-        if (sendEmailVerification) {
+        if (sendEmailVerification && !markEmailAsVerified) {
             if (user.getEmail() == null || user.getEmail().trim().isEmpty()) {
                 LOG.errorf(
                         "Email verification requested for user %s, but no email address is set.",

--- a/src/test/java/de/felixhertweck/seatreservation/userManagment/resource/UserResourceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/userManagment/resource/UserResourceTest.java
@@ -66,6 +66,7 @@ public class UserResourceTest {
                         "testuser1",
                         "test1@example.com",
                         false,
+                        false,
                         "password",
                         "John",
                         "Doe",
@@ -75,6 +76,7 @@ public class UserResourceTest {
                 new AdminUserCreationDto(
                         "testuser2",
                         "test2@example.com",
+                        false,
                         false,
                         "password",
                         "Jane",
@@ -100,6 +102,7 @@ public class UserResourceTest {
                         "testuser1",
                         "test1@example.com",
                         false,
+                        false,
                         "password",
                         "John",
                         "Doe",
@@ -121,6 +124,7 @@ public class UserResourceTest {
                 new AdminUserCreationDto(
                         "testuser1",
                         "test1@example.com",
+                        false,
                         false,
                         "password",
                         "John",
@@ -146,6 +150,7 @@ public class UserResourceTest {
                         "",
                         "test1@example.com",
                         false,
+                        false,
                         "password",
                         "John",
                         "Doe",
@@ -169,6 +174,7 @@ public class UserResourceTest {
                         "existinguser",
                         "existing@example.com",
                         false,
+                        false,
                         "password",
                         "John",
                         "Doe",
@@ -178,6 +184,7 @@ public class UserResourceTest {
                 new AdminUserCreationDto(
                         "existinguser",
                         "existing2@example.com",
+                        false,
                         false,
                         "password",
                         "Jane",
@@ -190,6 +197,7 @@ public class UserResourceTest {
                         new AdminUserCreationDto(
                                 "existinguser",
                                 "existing@example.com",
+                                false,
                                 false,
                                 "password",
                                 "John",

--- a/src/test/java/de/felixhertweck/seatreservation/userManagment/service/UserServiceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/userManagment/service/UserServiceTest.java
@@ -307,6 +307,26 @@ public class UserServiceTest {
     }
 
     @Test
+    void createUser_Success_MarkEmailAsVerified_SkipsVerificationEmail() throws IOException {
+        UserCreationDTO dto =
+                new UserCreationDTO(
+                        "testuser", "test@example.com", "password", "John", "Doe", null);
+        when(userRepository.findByUsernameOptional(anyString())).thenReturn(Optional.empty());
+        when(userRepository.isPersistent(any(User.class))).thenReturn(true);
+
+        UserDTO createdUser =
+                userService.createUser(dto, Set.of(Roles.USER), true, false, true, null);
+
+        assertNotNull(createdUser);
+        assertEquals("testuser", createdUser.username());
+        assertTrue(createdUser.emailVerified());
+        verify(userRepository, times(1)).persist(any(User.class));
+        verify(emailService, never()).createEmailVerification(any(User.class));
+        verify(emailService, never())
+                .sendEmailConfirmation(any(User.class), any(EmailVerification.class));
+    }
+
+    @Test
     void createUser_InternalServerErrorException_EmailSendFailure() throws IOException {
         UserCreationDTO dto =
                 new UserCreationDTO(

--- a/src/test/java/de/felixhertweck/seatreservation/userManagment/service/UserServiceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/userManagment/service/UserServiceTest.java
@@ -1656,6 +1656,7 @@ public class UserServiceTest {
                         "user1",
                         "user1@example.com",
                         false,
+                        false,
                         "pass1",
                         "First1",
                         "Last1",
@@ -1665,6 +1666,7 @@ public class UserServiceTest {
                 new AdminUserCreationDto(
                         "user2",
                         "user2@example.com",
+                        false,
                         false,
                         "pass2",
                         "First2",
@@ -1724,6 +1726,7 @@ public class UserServiceTest {
                         "",
                         "invalid@example.com",
                         false,
+                        false,
                         "pass",
                         "Invalid",
                         "User",
@@ -1744,6 +1747,7 @@ public class UserServiceTest {
                 new AdminUserCreationDto(
                         "existinguser",
                         "existing@example.com",
+                        false,
                         false,
                         "pass",
                         "Existing",
@@ -1784,6 +1788,7 @@ public class UserServiceTest {
                 new AdminUserCreationDto(
                         "user1",
                         "user1@example.com",
+                        false,
                         false,
                         "pass1",
                         "First1",

--- a/webapp/api/schemas.gen.ts
+++ b/webapp/api/schemas.gen.ts
@@ -8,6 +8,7 @@ export const AdminUserCreationDtoSchema = {
         'firstname',
         'lastname',
         'sendEmailVerification',
+        'emailVerified',
         'roles',
         'tags'
     ],
@@ -29,6 +30,9 @@ export const AdminUserCreationDtoSchema = {
             type: 'string'
         },
         sendEmailVerification: {
+            type: 'boolean'
+        },
+        emailVerified: {
             type: 'boolean'
         },
         roles: {

--- a/webapp/api/types.gen.ts
+++ b/webapp/api/types.gen.ts
@@ -11,6 +11,7 @@ export type AdminUserCreationDto = {
     firstname: string;
     lastname: string;
     sendEmailVerification: boolean;
+    emailVerified: boolean;
     roles: Array<string>;
     tags: Array<string>;
 };

--- a/webapp/docs/openapi.json
+++ b/webapp/docs/openapi.json
@@ -4,7 +4,7 @@
     "schemas" : {
       "AdminUserCreationDto" : {
         "type" : "object",
-        "required" : [ "username", "password", "firstname", "lastname", "sendEmailVerification", "roles", "tags" ],
+        "required" : [ "username", "password", "firstname", "lastname", "sendEmailVerification", "emailVerified", "roles", "tags" ],
         "properties" : {
           "username" : {
             "type" : "string",
@@ -23,6 +23,9 @@
             "type" : "string"
           },
           "sendEmailVerification" : {
+            "type" : "boolean"
+          },
+          "emailVerified" : {
             "type" : "boolean"
           },
           "roles" : {


### PR DESCRIPTION
Admin-created users were always saved as unverified because AdminUserCreationDto had no emailVerified field and UserService hardcoded it to false, even though the frontend already sent the flag.