### PR TITLE
🛡️ Sentinel: [HIGH] Fix CSV Injection bypass

### DIFF
--- a/src/main/java/de/felixhertweck/seatreservation/utils/ReservationExporter.java
+++ b/src/main/java/de/felixhertweck/seatreservation/utils/ReservationExporter.java
@@ -61,12 +61,17 @@ public class ReservationExporter {
         String escaped = field;
 
         // Check for CSV injection patterns
-        char firstChar = escaped.charAt(0);
-        if (firstChar == '='
-                || firstChar == '+'
-                || firstChar == '-'
-                || firstChar == '@'
-                || firstChar == '\t') {
+        int index = 0;
+        while (index < escaped.length() && isSpreadsheetTrimmable(escaped.charAt(index))) {
+            index++;
+        }
+        if (index < escaped.length()) {
+            char firstNonWs = escaped.charAt(index);
+            if (firstNonWs == '=' || firstNonWs == '+' || firstNonWs == '-' || firstNonWs == '@') {
+                escaped = "'" + escaped;
+            }
+        }
+        if (!escaped.startsWith("'") && escaped.charAt(0) == '\t') {
             escaped = "'" + escaped;
         }
 
@@ -79,6 +84,17 @@ public class ReservationExporter {
             escaped = "\"" + escaped + "\"";
         }
         return escaped;
+    }
+
+    /**
+     * Whether a character is whitespace that spreadsheet applications (Excel, LibreOffice) trim or
+     * ignore when deciding if a cell value starts with a formula trigger. This is broader than
+     * {@link Character#isWhitespace(char)}, which excludes non-breaking space variants (e.g.
+     * U+00A0, U+2007, U+202F) that would otherwise let a CSV injection payload slip past the
+     * leading-whitespace check below.
+     */
+    private static boolean isSpreadsheetTrimmable(char c) {
+        return Character.isWhitespace(c) || Character.isSpaceChar(c);
     }
 
     private static final String TEMPLATE_PATH_BLOCKED = "/export-template/blocked.pdf";

--- a/src/test/java/de/felixhertweck/seatreservation/utils/ReservationExporterTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/utils/ReservationExporterTest.java
@@ -152,6 +152,65 @@ class ReservationExporterTest {
     }
 
     @Test
+    void exportReservationsToCsv_fieldStartingWithFormulaChar_isEscapedWithLeadingApostrophe()
+            throws IOException {
+        Reservation reservation =
+                createReservation(
+                        id(1),
+                        "A1",
+                        "1",
+                        "=cmd|'/C calc'!A0",
+                        "Mustermann",
+                        ReservationStatus.RESERVED);
+        byte[] csvBytes =
+                ReservationExporter.exportReservationsToCsv(List.of(reservation)).toByteArray();
+        String csv = new String(csvBytes);
+        assertTrue(csv.contains("'=cmd|'/C calc'!A0"), csv);
+    }
+
+    @Test
+    void exportReservationsToCsv_fieldWithLeadingNonBreakingSpace_isEscapedWithLeadingApostrophe()
+            throws IOException {
+        // U+00A0 (NO-BREAK SPACE) is trimmed by Excel/LibreOffice before evaluating a leading
+        // formula-trigger character, so it must be treated like ordinary whitespace here.
+        Reservation reservation =
+                createReservation(
+                        id(1),
+                        "A1",
+                        "1",
+                        " =cmd|'/C calc'!A0",
+                        "Mustermann",
+                        ReservationStatus.RESERVED);
+        byte[] csvBytes =
+                ReservationExporter.exportReservationsToCsv(List.of(reservation)).toByteArray();
+        String csv = new String(csvBytes);
+        assertTrue(csv.contains("' =cmd|'/C calc'!A0"), csv);
+    }
+
+    @Test
+    void exportReservationsToCsv_fieldWithoutFormulaTrigger_isNotEscaped() throws IOException {
+        Reservation reservation =
+                createReservation(
+                        id(1), "A1", "1", "Max", "Mustermann", ReservationStatus.RESERVED);
+        byte[] csvBytes =
+                ReservationExporter.exportReservationsToCsv(List.of(reservation)).toByteArray();
+        String csv = new String(csvBytes);
+        assertTrue(csv.contains(",Max,"), csv);
+        assertTrue(!csv.contains("'Max"), csv);
+    }
+
+    @Test
+    void exportReservationsToCsv_fieldWithComma_isQuoted() throws IOException {
+        Reservation reservation =
+                createReservation(
+                        id(1), "A1", "1", "Max,Junior", "Mustermann", ReservationStatus.RESERVED);
+        byte[] csvBytes =
+                ReservationExporter.exportReservationsToCsv(List.of(reservation)).toByteArray();
+        String csv = new String(csvBytes);
+        assertTrue(csv.contains("\"Max,Junior\""), csv);
+    }
+
+    @Test
     void exportReservationsToPdf_withBlockedReservation_createsValidPdf() throws IOException {
         Reservation r1 = createReservation(id(1), "C1", "3", null, null, ReservationStatus.BLOCKED);
         byte[] pdfBytes =


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: CSV Injection (Formula Injection) bypass. The existing protection only checked the first character of a field. Attackers could bypass this by prepending whitespace characters (like spaces or newlines) before the malicious formula (e.g., ` \n=cmd`), which spreadsheet software like Excel will still execute.
🎯 Impact: If an attacker provides a malicious payload starting with whitespace in a field that gets exported to CSV, they could execute arbitrary code or exfiltrate data when a manager opens the CSV in Excel.
🔧 Fix: Updated the `escapeCsvField` method to iterate past leading whitespace characters before checking for formula injection characters (`=`, `+`, `-`, `@`).
✅ Verification: Run `./mvnw test` to verify no regressions in CSV generation.

---
*PR created automatically by Jules for task [9807536044797927539](https://jules.google.com/task/9807536044797927539) started by @FelixHertweck*