### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix exception information leak

### DIFF
--- a/src/main/java/de/felixhertweck/seatreservation/GlobalExceptionHandler.java
+++ b/src/main/java/de/felixhertweck/seatreservation/GlobalExceptionHandler.java
@@ -28,12 +28,14 @@ import jakarta.ws.rs.ext.ExceptionMapper;
 import jakarta.ws.rs.ext.Provider;
 
 import de.felixhertweck.seatreservation.common.dto.ErrorResponseDTO;
+import de.felixhertweck.seatreservation.common.exception.AccessDeniedException;
 import de.felixhertweck.seatreservation.common.exception.DuplicateUserException;
 import de.felixhertweck.seatreservation.common.exception.EventNotFoundException;
 import de.felixhertweck.seatreservation.common.exception.InvalidUserException;
 import de.felixhertweck.seatreservation.common.exception.RegistrationDisabledException;
 import de.felixhertweck.seatreservation.common.exception.ReservationNotFoundException;
 import de.felixhertweck.seatreservation.common.exception.UserNotFoundException;
+import de.felixhertweck.seatreservation.common.exception.ValidationException;
 import de.felixhertweck.seatreservation.management.exception.AreaInUseException;
 import de.felixhertweck.seatreservation.management.exception.AreaNotFoundException;
 import de.felixhertweck.seatreservation.management.exception.EntranceInUseException;
@@ -136,9 +138,20 @@ public class GlobalExceptionHandler implements ExceptionMapper<Exception> {
                     status = Response.Status.BAD_REQUEST;
             case PasswordResetTokenExpiredException ignored -> status = Response.Status.GONE;
             case UserNotFoundException ignored -> status = Response.Status.NOT_FOUND;
-            case IllegalArgumentException ignored -> status = Response.Status.BAD_REQUEST;
-            case SecurityException ignored -> status = Response.Status.FORBIDDEN;
-            case IllegalStateException ignored -> status = Response.Status.BAD_REQUEST;
+            case ValidationException ignored -> status = Response.Status.BAD_REQUEST;
+            case AccessDeniedException ignored -> status = Response.Status.FORBIDDEN;
+            case IllegalArgumentException ignored -> {
+                status = Response.Status.BAD_REQUEST;
+                errorResponse = new ErrorResponseDTO("Bad Request");
+            }
+            case SecurityException ignored -> {
+                status = Response.Status.FORBIDDEN;
+                errorResponse = new ErrorResponseDTO("Forbidden");
+            }
+            case IllegalStateException ignored -> {
+                status = Response.Status.BAD_REQUEST;
+                errorResponse = new ErrorResponseDTO("Bad Request");
+            }
             case AccountLockedException accountLockedException -> {
                 status = Response.Status.TOO_MANY_REQUESTS;
                 LoginLockedDTO errorResponseLogin =

--- a/src/main/java/de/felixhertweck/seatreservation/common/exception/AccessDeniedException.java
+++ b/src/main/java/de/felixhertweck/seatreservation/common/exception/AccessDeniedException.java
@@ -1,0 +1,33 @@
+/*
+ * #%L
+ * seat-reservation
+ * %%
+ * Copyright (C) 2025 Felix Hertweck
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package de.felixhertweck.seatreservation.common.exception;
+
+/**
+ * Signals that an authenticated user is not authorized to perform the requested operation. The
+ * message is developer-authored and safe to return to the client as-is, unlike the message of a
+ * generic {@link SecurityException}, which may wrap internal details and is therefore masked by
+ * {@code GlobalExceptionHandler}.
+ */
+public class AccessDeniedException extends RuntimeException {
+
+    public AccessDeniedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/de/felixhertweck/seatreservation/common/exception/ValidationException.java
+++ b/src/main/java/de/felixhertweck/seatreservation/common/exception/ValidationException.java
@@ -1,0 +1,37 @@
+/*
+ * #%L
+ * seat-reservation
+ * %%
+ * Copyright (C) 2025 Felix Hertweck
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package de.felixhertweck.seatreservation.common.exception;
+
+/**
+ * Signals that a request failed a business-rule or input validation check. The message is
+ * developer-authored and safe to return to the client as-is, unlike the message of a generic {@link
+ * IllegalArgumentException} or {@link IllegalStateException}, which may wrap internal details and
+ * is therefore masked by {@code GlobalExceptionHandler}.
+ */
+public class ValidationException extends RuntimeException {
+
+    public ValidationException(String message) {
+        super(message);
+    }
+
+    public ValidationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/de/felixhertweck/seatreservation/email/service/EmailService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/email/service/EmailService.java
@@ -25,6 +25,7 @@ import java.util.List;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
+import de.felixhertweck.seatreservation.common.exception.AccessDeniedException;
 import de.felixhertweck.seatreservation.common.exception.EventNotFoundException;
 import de.felixhertweck.seatreservation.email.service.notifications.EmailConfirmationNotification;
 import de.felixhertweck.seatreservation.email.service.notifications.PasswordChangedNotification;
@@ -386,10 +387,10 @@ public class EmailService {
      * @param event the event for which the reservations are to be exported
      * @throws IOException if CSV export fails
      * @throws EventNotFoundException if the event is not found
-     * @throws SecurityException if there are security issues during CSV export
+     * @throws AccessDeniedException if there are security issues during CSV export
      */
     public void sendEventReservationsCsvToManager(User manager, Event event)
-            throws EventNotFoundException, SecurityException, IOException {
+            throws EventNotFoundException, AccessDeniedException, IOException {
         if (!EmailSender.isValidAddress(manager.getEmail())) {
             LOG.warn("No valid email addresses provided to send CSV export.");
             return;

--- a/src/main/java/de/felixhertweck/seatreservation/email/service/NotificationService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/email/service/NotificationService.java
@@ -35,6 +35,7 @@ import jakarta.enterprise.context.control.ActivateRequestContext;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
 
+import de.felixhertweck.seatreservation.common.exception.AccessDeniedException;
 import de.felixhertweck.seatreservation.common.exception.EventNotFoundException;
 import de.felixhertweck.seatreservation.management.service.EventService;
 import de.felixhertweck.seatreservation.management.service.ReservationService;
@@ -347,7 +348,7 @@ public class NotificationService {
                 } else {
                     LOG.warnf("No manager found for event: %s (ID: %s)", event.getName(), event.id);
                 }
-            } catch (EventNotFoundException | SecurityException | IOException e) {
+            } catch (EventNotFoundException | AccessDeniedException | IOException e) {
                 LOG.errorf(
                         e,
                         "Unexpected error during CSV generation or email preparation for event %s",
@@ -392,7 +393,7 @@ public class NotificationService {
      */
     @ActivateRequestContext
     public void sendReservationsCsvToManager(User manager, Event event)
-            throws EventNotFoundException, SecurityException, IOException {
+            throws EventNotFoundException, AccessDeniedException, IOException {
         emailService.sendEventReservationsCsvToManager(manager, event);
     }
 }

--- a/src/main/java/de/felixhertweck/seatreservation/management/resource/AreaResource.java
+++ b/src/main/java/de/felixhertweck/seatreservation/management/resource/AreaResource.java
@@ -36,6 +36,7 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 
+import de.felixhertweck.seatreservation.common.exception.ValidationException;
 import de.felixhertweck.seatreservation.management.dto.AreaRequestDTO;
 import de.felixhertweck.seatreservation.management.dto.AreaResponseDTO;
 import de.felixhertweck.seatreservation.management.service.AreaService;
@@ -96,7 +97,7 @@ public class AreaResource {
         LOG.debugf(
                 "Received GET request to /api/manager/areas?eventLocationId=%s", eventLocationId);
         if (eventLocationId == null) {
-            throw new IllegalArgumentException("eventLocationId query parameter is required");
+            throw new ValidationException("eventLocationId query parameter is required");
         }
         AuthenticatedUser currentUser = userSecurityContext.getAuthenticatedUser();
         return areaService.findAreasByLocation(eventLocationId, currentUser);

--- a/src/main/java/de/felixhertweck/seatreservation/management/resource/EntranceResource.java
+++ b/src/main/java/de/felixhertweck/seatreservation/management/resource/EntranceResource.java
@@ -36,6 +36,7 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 
+import de.felixhertweck.seatreservation.common.exception.ValidationException;
 import de.felixhertweck.seatreservation.management.dto.EntranceRequestDTO;
 import de.felixhertweck.seatreservation.management.dto.EntranceResponseDTO;
 import de.felixhertweck.seatreservation.management.service.EntranceService;
@@ -97,7 +98,7 @@ public class EntranceResource {
                 "Received GET request to /api/manager/entrances?eventLocationId=%s",
                 eventLocationId);
         if (eventLocationId == null) {
-            throw new IllegalArgumentException("eventLocationId query parameter is required");
+            throw new ValidationException("eventLocationId query parameter is required");
         }
         AuthenticatedUser currentUser = userSecurityContext.getAuthenticatedUser();
         return entranceService.findEntrancesByLocation(eventLocationId, currentUser);

--- a/src/main/java/de/felixhertweck/seatreservation/management/resource/MarkerResource.java
+++ b/src/main/java/de/felixhertweck/seatreservation/management/resource/MarkerResource.java
@@ -37,6 +37,7 @@ import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 
 import de.felixhertweck.seatreservation.common.dto.EventLocationMakerDTO;
+import de.felixhertweck.seatreservation.common.exception.ValidationException;
 import de.felixhertweck.seatreservation.management.dto.MakerRequestDTO;
 import de.felixhertweck.seatreservation.management.service.MarkerService;
 import de.felixhertweck.seatreservation.model.entity.Roles;
@@ -96,7 +97,7 @@ public class MarkerResource {
         LOG.debugf(
                 "Received GET request to /api/manager/markers?eventLocationId=%s", eventLocationId);
         if (eventLocationId == null) {
-            throw new IllegalArgumentException("eventLocationId query parameter is required");
+            throw new ValidationException("eventLocationId query parameter is required");
         }
         AuthenticatedUser currentUser = userSecurityContext.getAuthenticatedUser();
         return markerService.findMarkersByLocation(eventLocationId, currentUser);

--- a/src/main/java/de/felixhertweck/seatreservation/management/resource/SeatResource.java
+++ b/src/main/java/de/felixhertweck/seatreservation/management/resource/SeatResource.java
@@ -37,6 +37,7 @@ import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 
 import de.felixhertweck.seatreservation.common.dto.SeatDTO;
+import de.felixhertweck.seatreservation.common.exception.ValidationException;
 import de.felixhertweck.seatreservation.management.dto.SeatRequestDTO;
 import de.felixhertweck.seatreservation.management.service.SeatService;
 import de.felixhertweck.seatreservation.model.entity.Roles;
@@ -104,7 +105,7 @@ public class SeatResource {
         LOG.debugf(
                 "Received GET request to /api/manager/seats?eventLocationId=%s", eventLocationId);
         if (eventLocationId == null) {
-            throw new IllegalArgumentException("eventLocationId query parameter is required");
+            throw new ValidationException("eventLocationId query parameter is required");
         }
         AuthenticatedUser currentUser = userSecurityContext.getAuthenticatedUser();
         List<SeatDTO> result =

--- a/src/main/java/de/felixhertweck/seatreservation/management/service/AreaService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/management/service/AreaService.java
@@ -31,6 +31,7 @@ import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
 
 import de.felixhertweck.seatreservation.common.dto.CoordinateDTO;
+import de.felixhertweck.seatreservation.common.exception.ValidationException;
 import de.felixhertweck.seatreservation.management.dto.AreaRequestDTO;
 import de.felixhertweck.seatreservation.management.dto.AreaResponseDTO;
 import de.felixhertweck.seatreservation.management.exception.AreaInUseException;
@@ -92,7 +93,7 @@ public class AreaService {
                 eventLocationAccessService.findOwnedEventLocation(
                         dto.getEventLocationId(), manager);
         if (dto.getName() == null || dto.getName().trim().isEmpty()) {
-            throw new IllegalArgumentException("Area name cannot be empty");
+            throw new ValidationException("Area name cannot be empty");
         }
 
         EventLocationArea area = new EventLocationArea(dto.getName().trim());
@@ -130,7 +131,7 @@ public class AreaService {
                 eventLocationAccessService.findOwnedEventLocation(
                         dto.getEventLocationId(), manager);
         if (dto.getName() == null || dto.getName().trim().isEmpty()) {
-            throw new IllegalArgumentException("Area name cannot be empty");
+            throw new ValidationException("Area name cannot be empty");
         }
 
         // Seats may only reference an area of their own event location (see
@@ -177,7 +178,7 @@ public class AreaService {
     @Transactional
     public void deleteAreas(List<UUID> ids, AuthenticatedUser manager) {
         if (ids == null || ids.isEmpty()) {
-            throw new IllegalArgumentException("No area IDs provided for deletion");
+            throw new ValidationException("No area IDs provided for deletion");
         }
 
         Map<UUID, EventLocationArea> areaMap =

--- a/src/main/java/de/felixhertweck/seatreservation/management/service/EntranceService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/management/service/EntranceService.java
@@ -29,6 +29,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
 
+import de.felixhertweck.seatreservation.common.exception.ValidationException;
 import de.felixhertweck.seatreservation.management.dto.EntranceRequestDTO;
 import de.felixhertweck.seatreservation.management.dto.EntranceResponseDTO;
 import de.felixhertweck.seatreservation.management.exception.EntranceInUseException;
@@ -90,7 +91,7 @@ public class EntranceService {
                 eventLocationAccessService.findOwnedEventLocation(
                         dto.getEventLocationId(), manager);
         if (dto.getName() == null || dto.getName().trim().isEmpty()) {
-            throw new IllegalArgumentException("Entrance name cannot be empty");
+            throw new ValidationException("Entrance name cannot be empty");
         }
 
         EventLocationEntrance entrance = new EventLocationEntrance(dto.getName().trim());
@@ -123,7 +124,7 @@ public class EntranceService {
                 eventLocationAccessService.findOwnedEventLocation(
                         dto.getEventLocationId(), manager);
         if (dto.getName() == null || dto.getName().trim().isEmpty()) {
-            throw new IllegalArgumentException("Entrance name cannot be empty");
+            throw new ValidationException("Entrance name cannot be empty");
         }
 
         // Seats may only reference an entrance of their own event location (see
@@ -165,7 +166,7 @@ public class EntranceService {
     @Transactional
     public void deleteEntrances(List<UUID> ids, AuthenticatedUser manager) {
         if (ids == null || ids.isEmpty()) {
-            throw new IllegalArgumentException("No entrance IDs provided for deletion");
+            throw new ValidationException("No entrance IDs provided for deletion");
         }
 
         Map<UUID, EventLocationEntrance> entranceMap =

--- a/src/main/java/de/felixhertweck/seatreservation/management/service/EventAccessService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/management/service/EventAccessService.java
@@ -23,6 +23,7 @@ import java.util.UUID;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
+import de.felixhertweck.seatreservation.common.exception.AccessDeniedException;
 import de.felixhertweck.seatreservation.common.exception.EventNotFoundException;
 import de.felixhertweck.seatreservation.model.entity.Event;
 import de.felixhertweck.seatreservation.model.repository.EventRepository;
@@ -51,7 +52,7 @@ public class EventAccessService {
      * @param user the user attempting to access the event
      * @return the event entity
      * @throws EventNotFoundException if no such event exists
-     * @throws SecurityException if the user neither is an ADMIN nor manages the event
+     * @throws AccessDeniedException if the user neither is an ADMIN nor manages the event
      */
     public Event findOwnedEvent(UUID eventId, AuthenticatedUser user) {
         Event event =
@@ -70,14 +71,14 @@ public class EventAccessService {
      *
      * @param event the event to check
      * @param user the user attempting to access the event
-     * @throws SecurityException if the user neither is an ADMIN nor manages the event
+     * @throws AccessDeniedException if the user neither is an ADMIN nor manages the event
      */
     public void requireAccess(Event event, AuthenticatedUser user) {
         if (!isManager(event, user)) {
             LOG.warnf(
                     "User %s is not authorized to manage event %s",
                     user == null ? null : user.id(), event == null ? null : event.getId());
-            throw new SecurityException("User is not a manager of this event");
+            throw new AccessDeniedException("User is not a manager of this event");
         }
     }
 

--- a/src/main/java/de/felixhertweck/seatreservation/management/service/EventLocationAccessService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/management/service/EventLocationAccessService.java
@@ -23,6 +23,8 @@ import java.util.UUID;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
+import de.felixhertweck.seatreservation.common.exception.AccessDeniedException;
+import de.felixhertweck.seatreservation.common.exception.ValidationException;
 import de.felixhertweck.seatreservation.management.exception.EventLocationNotFoundException;
 import de.felixhertweck.seatreservation.model.entity.EventLocation;
 import de.felixhertweck.seatreservation.model.repository.EventLocationRepository;
@@ -47,13 +49,13 @@ public class EventLocationAccessService {
      * @param eventLocationId the event location ID to find, must not be null
      * @param user the user attempting to access the event location
      * @return the event location entity
-     * @throws IllegalArgumentException if the ID is null
+     * @throws ValidationException if the ID is null
      * @throws EventLocationNotFoundException if no such event location exists
-     * @throws SecurityException if the user neither is an ADMIN nor manages the location
+     * @throws AccessDeniedException if the user neither is an ADMIN nor manages the location
      */
     public EventLocation findOwnedEventLocation(UUID eventLocationId, AuthenticatedUser user) {
         if (eventLocationId == null) {
-            throw new IllegalArgumentException("EventLocation ID must not be null");
+            throw new ValidationException("EventLocation ID must not be null");
         }
         EventLocation eventLocation =
                 eventLocationRepository
@@ -73,7 +75,7 @@ public class EventLocationAccessService {
      *
      * @param eventLocation the event location to check
      * @param user the user attempting to access the event location
-     * @throws SecurityException if the user neither is an ADMIN nor manages the location
+     * @throws AccessDeniedException if the user neither is an ADMIN nor manages the location
      */
     public void requireAccess(EventLocation eventLocation, AuthenticatedUser user) {
         if (eventLocation == null
@@ -85,7 +87,7 @@ public class EventLocationAccessService {
                     "User %s is not authorized to manage event location %s",
                     user == null ? null : user.id(),
                     eventLocation == null ? null : eventLocation.getId());
-            throw new SecurityException("Manager does not own this EventLocation");
+            throw new AccessDeniedException("Manager does not own this EventLocation");
         }
     }
 }

--- a/src/main/java/de/felixhertweck/seatreservation/management/service/EventLocationService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/management/service/EventLocationService.java
@@ -33,6 +33,8 @@ import jakarta.transaction.Transactional;
 
 import de.felixhertweck.seatreservation.common.dto.CoordinateDTO;
 import de.felixhertweck.seatreservation.common.events.EventUpdatedEvent;
+import de.felixhertweck.seatreservation.common.exception.AccessDeniedException;
+import de.felixhertweck.seatreservation.common.exception.ValidationException;
 import de.felixhertweck.seatreservation.management.dto.EventLocationRequestDTO;
 import de.felixhertweck.seatreservation.management.dto.EventLocationResponseDTO;
 import de.felixhertweck.seatreservation.management.dto.EventLocationUpdateDTO;
@@ -118,8 +120,7 @@ public class EventLocationService {
      */
     @Transactional
     public EventLocationResponseDTO createEventLocation(
-            EventLocationRequestDTO dto, AuthenticatedUser manager)
-            throws IllegalArgumentException {
+            EventLocationRequestDTO dto, AuthenticatedUser manager) throws ValidationException {
         LOG.debugf(
                 "Attempting to create event location with name: %s, address: %s for manager ID: %s",
                 dto.getName(), dto.getAddress(), manager.id());
@@ -128,7 +129,7 @@ public class EventLocationService {
                 || dto.getAddress() == null
                 || dto.getAddress().trim().isEmpty()) {
             LOG.warnf("Invalid EventLocation data provided by manager ID: %s", manager.id());
-            throw new IllegalArgumentException("Invalid EventLocation data provided.");
+            throw new ValidationException("Invalid EventLocation data provided.");
         }
 
         EventLocation location =
@@ -186,13 +187,13 @@ public class EventLocationService {
      * @param id The ID of the EventLocation to be updated.
      * @param dto The DTO containing the updated details of the EventLocation.
      * @return A DTO representing the updated EventLocation.
-     * @throws IllegalArgumentException If the EventLocation with the specified ID is not found.
-     * @throws SecurityException If the user is not authorized to update the EventLocation.
+     * @throws ValidationException If the EventLocation with the specified ID is not found.
+     * @throws AccessDeniedException If the user is not authorized to update the EventLocation.
      */
     @Transactional
     public EventLocationResponseDTO updateEventLocation(
             UUID id, EventLocationUpdateDTO dto, AuthenticatedUser manager)
-            throws IllegalArgumentException, SecurityException {
+            throws ValidationException, AccessDeniedException {
         LOG.debugf(
                 "Attempting to update event location with ID: %s for manager ID: %s",
                 id, manager.id());
@@ -385,15 +386,15 @@ public class EventLocationService {
      * the manager of the EventLocation or has the ADMIN role.
      *
      * @param ids The IDs of the EventLocations to be deleted.
-     * @throws IllegalArgumentException If the EventLocation with the specified ID is not found.
-     * @throws SecurityException If the user is not authorized to delete the EventLocation.
+     * @throws ValidationException If the EventLocation with the specified ID is not found.
+     * @throws AccessDeniedException If the user is not authorized to delete the EventLocation.
      */
     @Transactional
     public void deleteEventLocation(List<UUID> ids, AuthenticatedUser manager)
-            throws IllegalArgumentException, SecurityException {
+            throws ValidationException, AccessDeniedException {
         if (ids == null || ids.isEmpty()) {
             LOG.warnf("No event locations to delete for manager ID: %s", manager.id());
-            throw new IllegalArgumentException("No event location IDs provided for deletion.");
+            throw new ValidationException("No event location IDs provided for deletion.");
         }
 
         LOG.debugf(

--- a/src/main/java/de/felixhertweck/seatreservation/management/service/EventReservationAllowanceService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/management/service/EventReservationAllowanceService.java
@@ -29,8 +29,10 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
 
+import de.felixhertweck.seatreservation.common.exception.AccessDeniedException;
 import de.felixhertweck.seatreservation.common.exception.EventNotFoundException;
 import de.felixhertweck.seatreservation.common.exception.UserNotFoundException;
+import de.felixhertweck.seatreservation.common.exception.ValidationException;
 import de.felixhertweck.seatreservation.management.dto.EventUserAllowanceUpdateDto;
 import de.felixhertweck.seatreservation.management.dto.EventUserAllowancesCreateDto;
 import de.felixhertweck.seatreservation.management.dto.EventUserAllowancesDto;
@@ -129,13 +131,13 @@ public class EventReservationAllowanceService {
      * @param manager The user attempting to update the allowance.
      * @throws EventNotFoundException If the event or allowance with the specified IDs are not
      *     found.
-     * @throws SecurityException If the user is not authorized to update this allowance.
+     * @throws AccessDeniedException If the user is not authorized to update this allowance.
      * @return A DTO representing the updated reservation allowance.
      */
     @Transactional
     public EventUserAllowancesDto updateReservationAllowance(
             EventUserAllowanceUpdateDto dto, User manager)
-            throws EventNotFoundException, SecurityException {
+            throws EventNotFoundException, AccessDeniedException {
         LOG.debugf(
                 "Attempting to update reservation allowance with ID: %s for user ID: %s, event ID:"
                         + " %s by manager: %s (ID: %s)",
@@ -174,7 +176,7 @@ public class EventReservationAllowanceService {
      * @param manager The user attempting to retrieve the allowance.
      * @throws EventNotFoundException If the reservation allowance with the specified ID is not
      *     found.
-     * @throws SecurityException If the user is not authorized to view this allowance.
+     * @throws AccessDeniedException If the user is not authorized to view this allowance.
      * @return A DTO representing the reservation allowance.
      */
     public EventUserAllowancesDto getReservationAllowanceById(UUID id, User manager) {
@@ -206,11 +208,11 @@ public class EventReservationAllowanceService {
      * events managed by the current user are returned.
      *
      * @param currentUser The currently authenticated user.
-     * @throws SecurityException If the user is not authorized to view the allowances.
+     * @throws AccessDeniedException If the user is not authorized to view the allowances.
      * @return A list of DTOs representing the reservation allowances for the current user.
      */
     public List<EventUserAllowancesDto> getReservationAllowances(AuthenticatedUser currentUser)
-            throws SecurityException {
+            throws AccessDeniedException {
         LOG.debugf(
                 "Attempting to retrieve all reservation allowances for user ID: %s",
                 currentUser.id());
@@ -239,13 +241,13 @@ public class EventReservationAllowanceService {
      *
      * @param eventId The ID of the event for which to retrieve allowances.
      * @param currentUser The currently authenticated user.
-     * @throws SecurityException If the user is not authorized to view the allowances for this
+     * @throws AccessDeniedException If the user is not authorized to view the allowances for this
      *     event.
      * @throws EventNotFoundException If the event with the specified ID is not found.
      * @return A list of DTOs representing the reservation allowances for the specified event.
      */
     public List<EventUserAllowancesDto> getReservationAllowancesByEventId(
-            UUID eventId, User currentUser) throws SecurityException, EventNotFoundException {
+            UUID eventId, User currentUser) throws AccessDeniedException, EventNotFoundException {
         LOG.debugf(
                 "Attempting to retrieve reservation allowances for event ID: %s by user ID: %s (ID:"
                         + " %s)",
@@ -270,18 +272,17 @@ public class EventReservationAllowanceService {
      * @param currentUser The currently authenticated user.
      * @throws EventNotFoundException If the reservation allowance with the specified ID is not
      *     found.
-     * @throws SecurityException If the user is not authorized to delete this allowance.
-     * @throws IllegalArgumentException If no IDs are provided.
+     * @throws AccessDeniedException If the user is not authorized to delete this allowance.
+     * @throws ValidationException If no IDs are provided.
      */
     @Transactional
     public void deleteReservationAllowance(List<UUID> ids, User currentUser)
-            throws EventNotFoundException, SecurityException, IllegalArgumentException {
+            throws EventNotFoundException, AccessDeniedException, ValidationException {
         if (ids == null || ids.isEmpty()) {
             LOG.warnf(
                     "No reservation allowances to delete for user ID: %s (ID: %s)",
                     currentUser.id, currentUser.getId());
-            throw new IllegalArgumentException(
-                    "No reservation allowance IDs provided for deletion.");
+            throw new ValidationException("No reservation allowance IDs provided for deletion.");
         }
 
         Map<UUID, EventUserAllowance> allowanceMap =

--- a/src/main/java/de/felixhertweck/seatreservation/management/service/EventService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/management/service/EventService.java
@@ -32,7 +32,9 @@ import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
 
 import de.felixhertweck.seatreservation.common.events.EventUpdatedEvent;
+import de.felixhertweck.seatreservation.common.exception.AccessDeniedException;
 import de.felixhertweck.seatreservation.common.exception.EventNotFoundException;
+import de.felixhertweck.seatreservation.common.exception.ValidationException;
 import de.felixhertweck.seatreservation.email.service.NotificationService;
 import de.felixhertweck.seatreservation.management.dto.EventRequestDTO;
 import de.felixhertweck.seatreservation.management.dto.EventResponseDTO;
@@ -75,12 +77,12 @@ public class EventService {
      *
      * @param dto The DTO containing the details of the Event to be created.
      * @param manager The currently authenticated user.
-     * @throws IllegalArgumentException If the EventLocation or any supervisor user is not found.
+     * @throws ValidationException If the EventLocation or any supervisor user is not found.
      * @return A DTO representing the newly created Event.
      */
     @Transactional
     public EventResponseDTO createEvent(EventRequestDTO dto, User manager)
-            throws IllegalArgumentException {
+            throws ValidationException {
         LOG.debugf(
                 "Attempting to create event with name: %s for manager: %s (ID: %s)",
                 dto.getName(), manager.id, manager.getId());
@@ -93,7 +95,7 @@ public class EventService {
                                             "EventLocation with id %s not found for event"
                                                     + " creation.",
                                             dto.getEventLocationId());
-                                    return new IllegalArgumentException(
+                                    return new ValidationException(
                                             "EventLocation with id "
                                                     + dto.getEventLocationId()
                                                     + " not found");
@@ -147,11 +149,11 @@ public class EventService {
      * @param dto The DTO containing the updated details of the Event.
      * @return A DTO representing the updated Event.
      * @throws EventNotFoundException If the Event with the specified ID is not found.
-     * @throws SecurityException If the user is not authorized to update the Event.
+     * @throws AccessDeniedException If the user is not authorized to update the Event.
      */
     @Transactional
     public EventResponseDTO updateEvent(UUID id, EventRequestDTO dto, User manager)
-            throws EventNotFoundException, IllegalArgumentException {
+            throws EventNotFoundException, ValidationException {
         LOG.debugf(
                 "Attempting to update event with ID: %s for manager: %s (ID: %s)",
                 id, manager.id, manager.getId());
@@ -180,7 +182,7 @@ public class EventService {
                                     LOG.warnf(
                                             "EventLocation with id %s not found for event update.",
                                             dto.getEventLocationId());
-                                    return new IllegalArgumentException(
+                                    return new ValidationException(
                                             "EventLocation with id "
                                                     + dto.getEventLocationId()
                                                     + " not found");
@@ -266,9 +268,10 @@ public class EventService {
     /** Adds a manager to an event. */
     @Transactional
     public EventResponseDTO addManager(UUID eventId, UUID newManagerId, User currentUser)
-            throws EventNotFoundException, SecurityException, IllegalArgumentException {
+            throws EventNotFoundException, AccessDeniedException, ValidationException {
         if (currentUser == null) {
-            throw new SecurityException("User is not authorized to add a manager to this event");
+            throw new AccessDeniedException(
+                    "User is not authorized to add a manager to this event");
         }
         Event event = getEventById(eventId);
         eventAccessService.requireAccess(event, AuthenticatedUser.of(currentUser));
@@ -286,9 +289,9 @@ public class EventService {
     /** Removes a manager from an event. */
     @Transactional
     public EventResponseDTO removeManager(UUID eventId, UUID managerToRemoveId, User currentUser)
-            throws EventNotFoundException, SecurityException, IllegalArgumentException {
+            throws EventNotFoundException, AccessDeniedException, ValidationException {
         if (currentUser == null) {
-            throw new SecurityException(
+            throw new AccessDeniedException(
                     "User is not authorized to remove a manager from this event");
         }
         Event event = getEventById(eventId);
@@ -297,24 +300,24 @@ public class EventService {
             LOG.warnf(
                     "User ID %s attempted to remove themselves from event ID %s",
                     currentUser.id, eventId);
-            throw new IllegalArgumentException("Manager cannot remove themselves from the event");
+            throw new ValidationException("Manager cannot remove themselves from the event");
         }
         if (event.getCreatedBy() != null
                 && managerToRemoveId.equals(event.getCreatedBy().getId())) {
             LOG.warnf(
                     "Attempted to remove primary creator %s from event ID %s",
                     managerToRemoveId, eventId);
-            throw new IllegalArgumentException("The event creator cannot be removed as manager");
+            throw new ValidationException("The event creator cannot be removed as manager");
         }
         if (event.getManagers().size() <= 1) {
-            throw new IllegalArgumentException("An event must have at least one manager");
+            throw new ValidationException("An event must have at least one manager");
         }
         User managerToRemove =
                 userRepository
                         .findByIdOptional(managerToRemoveId)
                         .orElseThrow(
                                 () ->
-                                        new IllegalArgumentException(
+                                        new ValidationException(
                                                 "User with id "
                                                         + managerToRemoveId
                                                         + " not found"));
@@ -329,10 +332,9 @@ public class EventService {
      *
      * @param supervisorIds Set of supervisor user IDs
      * @return Set of User entities
-     * @throws IllegalArgumentException if any supervisor ID is invalid
+     * @throws ValidationException if any supervisor ID is invalid
      */
-    private Set<User> getSupervisorsFromIds(Set<UUID> supervisorIds)
-            throws IllegalArgumentException {
+    private Set<User> getSupervisorsFromIds(Set<UUID> supervisorIds) throws ValidationException {
         Set<User> supervisors = new HashSet<>();
         if (supervisorIds == null || supervisorIds.isEmpty()) {
             // empty set when no supervisors are provided
@@ -347,8 +349,7 @@ public class EventService {
             for (UUID supervisorId : supervisorIds) {
                 if (!foundIds.contains(supervisorId)) {
                     LOG.warnf("User with id %s not found for event creation.", supervisorId);
-                    throw new IllegalArgumentException(
-                            "User with id " + supervisorId + " not found");
+                    throw new ValidationException("User with id " + supervisorId + " not found");
                 }
             }
         }
@@ -428,17 +429,17 @@ public class EventService {
      * @param ids The IDs of the Events to be deleted.
      * @param currentUser The currently authenticated user.
      * @throws EventNotFoundException If the Event with the specified ID is not found.
-     * @throws SecurityException If the user is not authorized to delete the Event.
-     * @throws IllegalArgumentException If no IDs are provided.
+     * @throws AccessDeniedException If the user is not authorized to delete the Event.
+     * @throws ValidationException If no IDs are provided.
      */
     @Transactional
     public void deleteEvent(List<UUID> ids, User currentUser)
-            throws EventNotFoundException, SecurityException, IllegalArgumentException {
+            throws EventNotFoundException, AccessDeniedException, ValidationException {
         if (ids == null || ids.isEmpty()) {
             LOG.warnf(
                     "No events to delete for user ID: %s (ID: %s)",
                     currentUser.id, currentUser.getId());
-            throw new IllegalArgumentException("No event IDs provided for deletion.");
+            throw new ValidationException("No event IDs provided for deletion.");
         }
 
         LOG.debugf(
@@ -505,10 +506,10 @@ public class EventService {
      * @param manager The currently authenticated user.
      * @return A DTO representing the retrieved Event.
      * @throws EventNotFoundException If the Event with the specified ID is not found.
-     * @throws SecurityException If the user is not authorized to view the Event.
+     * @throws AccessDeniedException If the user is not authorized to view the Event.
      */
     public EventResponseDTO getEventByIdForManager(UUID id, User manager)
-            throws EventNotFoundException, SecurityException {
+            throws EventNotFoundException, AccessDeniedException {
         LOG.debugf(
                 "Attempting to retrieve event with ID: %s for manager: %s (ID: %s)",
                 id, manager.id, manager.getId());
@@ -536,26 +537,24 @@ public class EventService {
      * Validates event timing constraints.
      *
      * @param dto The event request DTO containing the timing information
-     * @throws IllegalArgumentException if timing constraints are violated
+     * @throws ValidationException if timing constraints are violated
      */
     private void validateEventTiming(EventRequestDTO dto) {
         if (!dto.getStartTime().isBefore(dto.getEndTime())) {
-            throw new IllegalArgumentException("Start time must be before end time");
+            throw new ValidationException("Start time must be before end time");
         }
 
         if (!dto.getBookingDeadline().isBefore(dto.getEndTime())) {
-            throw new IllegalArgumentException("Booking deadline must be before end time");
+            throw new ValidationException("Booking deadline must be before end time");
         }
 
         if (!dto.getBookingStartTime().isBefore(dto.getBookingDeadline())) {
-            throw new IllegalArgumentException(
-                    "Booking start time must be before booking deadline");
+            throw new ValidationException("Booking start time must be before booking deadline");
         }
 
         if (dto.getReminderSendDate() != null
                 && !dto.getReminderSendDate().isBefore(dto.getStartTime())) {
-            throw new IllegalArgumentException(
-                    "Reminder send date must be before event start time");
+            throw new ValidationException("Reminder send date must be before event start time");
         }
     }
 }

--- a/src/main/java/de/felixhertweck/seatreservation/management/service/MarkerService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/management/service/MarkerService.java
@@ -30,6 +30,7 @@ import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
 
 import de.felixhertweck.seatreservation.common.dto.EventLocationMakerDTO;
+import de.felixhertweck.seatreservation.common.exception.ValidationException;
 import de.felixhertweck.seatreservation.management.dto.MakerRequestDTO;
 import de.felixhertweck.seatreservation.management.exception.MarkerNotFoundException;
 import de.felixhertweck.seatreservation.model.entity.EventLocation;
@@ -86,7 +87,7 @@ public class MarkerService {
                 eventLocationAccessService.findOwnedEventLocation(
                         dto.getEventLocationId(), manager);
         if (dto.getLabel() == null || dto.getLabel().trim().isEmpty()) {
-            throw new IllegalArgumentException("Marker label cannot be empty");
+            throw new ValidationException("Marker label cannot be empty");
         }
 
         EventLocationMarker marker =
@@ -121,7 +122,7 @@ public class MarkerService {
                 eventLocationAccessService.findOwnedEventLocation(
                         dto.getEventLocationId(), manager);
         if (dto.getLabel() == null || dto.getLabel().trim().isEmpty()) {
-            throw new IllegalArgumentException("Marker label cannot be empty");
+            throw new ValidationException("Marker label cannot be empty");
         }
 
         marker.setLabel(dto.getLabel());
@@ -150,7 +151,7 @@ public class MarkerService {
     @Transactional
     public void deleteMarkers(List<UUID> ids, AuthenticatedUser manager) {
         if (ids == null || ids.isEmpty()) {
-            throw new IllegalArgumentException("No marker IDs provided for deletion");
+            throw new ValidationException("No marker IDs provided for deletion");
         }
 
         Map<UUID, EventLocationMarker> markerMap =

--- a/src/main/java/de/felixhertweck/seatreservation/management/service/ReservationService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/management/service/ReservationService.java
@@ -36,9 +36,11 @@ import jakarta.inject.Inject;
 import jakarta.persistence.PersistenceException;
 import jakarta.transaction.Transactional;
 
+import de.felixhertweck.seatreservation.common.exception.AccessDeniedException;
 import de.felixhertweck.seatreservation.common.exception.EventNotFoundException;
 import de.felixhertweck.seatreservation.common.exception.ReservationNotFoundException;
 import de.felixhertweck.seatreservation.common.exception.UserNotFoundException;
+import de.felixhertweck.seatreservation.common.exception.ValidationException;
 import de.felixhertweck.seatreservation.email.service.EmailService;
 import de.felixhertweck.seatreservation.management.dto.ReservationConfirmationEmailDTO;
 import de.felixhertweck.seatreservation.management.dto.ReservationRequestDTO;
@@ -88,11 +90,11 @@ public class ReservationService {
      *
      * @param id The ID of the reservation to retrieve.
      * @return The Reservation entity.
-     * @throws SecurityException If the current user does not have the necessary permissions.
+     * @throws AccessDeniedException If the current user does not have the necessary permissions.
      * @throws UserNotFoundException If the current user cannot be found.
      */
     public ReservationResponseDTO findReservationById(UUID id, User currentUser)
-            throws SecurityException, UserNotFoundException {
+            throws AccessDeniedException, UserNotFoundException {
         LOG.debugf(
                 "Attempting to retrieve reservation with ID: %s for user ID: %s (ID: %s)",
                 id, currentUser.id, currentUser.getId());
@@ -121,19 +123,20 @@ public class ReservationService {
         LOG.warnf(
                 "user ID: %s (ID: %s) is not allowed to access reservation with ID %s.",
                 currentUser.id, currentUser.getId(), id);
-        throw new SecurityException("You are not allowed to access this reservation.");
+        throw new AccessDeniedException("You are not allowed to access this reservation.");
     }
 
     /**
      * Retrieves reservations for a specific event by its ID. Access is restricted based on user
      * roles: - ADMIN: Returns reservations for any event. - MANAGER: Returns reservations only for
-     * events the manager is allowed to manage. - Other roles: Throws SecurityException.
+     * events the manager is allowed to manage. - Other roles: Throws AccessDeniedException.
      *
      * @param eventId The ID of the event for which to retrieve reservations
      * @param currentUser The user attempting to retrieve the reservations
      * @return A list of DTOs representing the reservations for the specified event
-     * @throws SecurityException If the user is not authorized to access this event's reservations
-     * @throws IllegalArgumentException If the event is not found
+     * @throws AccessDeniedException If the user is not authorized to access this event's
+     *     reservations
+     * @throws ValidationException If the event is not found
      */
     public List<ReservationResponseDTO> findReservationsByEventId(UUID eventId, User currentUser) {
         LOG.debugf(
@@ -148,7 +151,7 @@ public class ReservationService {
                                             "Event with ID %s not found for retrieving reservations"
                                                     + " by user: %s (ID: %s)",
                                             eventId, currentUser.id, currentUser.getId());
-                                    return new IllegalArgumentException(
+                                    return new ValidationException(
                                             "Event with id " + eventId + " not found");
                                 });
 
@@ -157,7 +160,7 @@ public class ReservationService {
                     "user ID: %s (ID: %s) is not allowed to access event ID %s for retrieving"
                             + " reservations.",
                     currentUser.id, currentUser.getId(), eventId);
-            throw new SecurityException("You are not allowed to access this event.");
+            throw new AccessDeniedException("You are not allowed to access this event.");
         }
 
         List<ReservationResponseDTO> result =
@@ -178,13 +181,13 @@ public class ReservationService {
      * @param dto The ReservationCreationDTO containing reservation details.
      * @return The created Reservation entity.
      * @throws UserNotFoundException If the target user or current user cannot be found.
-     * @throws SecurityException If the current user does not have the necessary permissions.
-     * @throws IllegalArgumentException If the user has no reservation allowance for the event.
+     * @throws AccessDeniedException If the current user does not have the necessary permissions.
+     * @throws ValidationException If the user has no reservation allowance for the event.
      */
     @Transactional
     public Set<ReservationResponseDTO> createReservations(
             ReservationRequestDTO dto, User managerUser)
-            throws SecurityException, UserNotFoundException, IllegalArgumentException {
+            throws AccessDeniedException, UserNotFoundException, ValidationException {
         LOG.debugf(
                 "Attempting to create reservation for seat ID: %s, user ID: %s, event ID: %s by"
                         + " user: %s (ID: %s)",
@@ -214,7 +217,7 @@ public class ReservationService {
                                     LOG.warnf(
                                             "Event with ID %s not found for reservation creation.",
                                             dto.getEventId());
-                                    return new IllegalArgumentException(
+                                    return new ValidationException(
                                             "Event with id " + dto.getEventId() + " not found");
                                 });
 
@@ -222,7 +225,7 @@ public class ReservationService {
             LOG.warnf(
                     "user ID: %s (ID: %s) is not allowed to access this reservation for creation.",
                     targetUser.id, targetUser.getId());
-            throw new SecurityException("You are not allowed to access this reservation.");
+            throw new AccessDeniedException("You are not allowed to access this reservation.");
         }
 
         List<Reservation> existingReservations = new ArrayList<>();
@@ -242,7 +245,7 @@ public class ReservationService {
                                                 "User ID %s has no reservation allowance for event"
                                                         + " ID %s.",
                                                 targetUser.getId(), event.getId());
-                                        return new IllegalArgumentException(
+                                        return new ValidationException(
                                                 "User has no reservation allowance for this"
                                                         + " event.");
                                     });
@@ -254,7 +257,7 @@ public class ReservationService {
             if (seat == null) {
                 LOG.errorf(
                         "Seat with ID %s not found for event ID %s.", dtoSeatId, dto.getEventId());
-                throw new IllegalArgumentException("Seat with id " + dtoSeatId + " not found");
+                throw new ValidationException("Seat with id " + dtoSeatId + " not found");
             }
 
             if (!dto.isDeductAllowance()) {
@@ -266,7 +269,7 @@ public class ReservationService {
                     LOG.warnf(
                             "No more reservations allowed for user ID %s and event ID %s.",
                             targetUser.getId(), event.getId());
-                    throw new IllegalArgumentException(
+                    throw new ValidationException(
                             "No more reservations allowed for this user and event.");
                 }
                 allowance.setReservationsAllowedCount(allowance.getReservationsAllowedCount() - 1);
@@ -322,18 +325,18 @@ public class ReservationService {
      * event the manager is allowed to manage. - Other roles: Throws ForbiddenException.
      *
      * @param ids The IDs of the reservation to delete.
-     * @throws SecurityException If the current user does not have the necessary permissions.
+     * @throws AccessDeniedException If the current user does not have the necessary permissions.
      * @throws UserNotFoundException If the current user cannot be found.
-     * @throws IllegalArgumentException If no IDs are provided.
+     * @throws ValidationException If no IDs are provided.
      */
     @Transactional
     public void deleteReservation(List<UUID> ids, User managerUser)
-            throws SecurityException, UserNotFoundException, IllegalArgumentException {
+            throws AccessDeniedException, UserNotFoundException, ValidationException {
         if (ids == null || ids.isEmpty()) {
             LOG.warnf(
                     "No reservation IDs provided for deletion by user ID: %s (ID: %s)",
                     managerUser.id, managerUser.getId());
-            throw new IllegalArgumentException("No reservation IDs provided for deletion.");
+            throw new ValidationException("No reservation IDs provided for deletion.");
         }
 
         LOG.debugf(
@@ -362,7 +365,7 @@ public class ReservationService {
                 LOG.warnf(
                         "user ID: %s (ID: %s) is not allowed to delete reservation with ID %s.",
                         managerUser.id, managerUser.getId(), id);
-                throw new SecurityException("You are not allowed to delete this reservation.");
+                throw new AccessDeniedException("You are not allowed to delete this reservation.");
             }
 
             reservationRepository.delete(reservation);
@@ -446,19 +449,19 @@ public class ReservationService {
     /**
      * Blocks seats for an event. Access is restricted based on user roles: - ADMIN: Allows blocking
      * seats for any event. - MANAGER: Allows blocking seats only for events the manager is allowed
-     * to manage. - Other roles: Throws SecurityException.
+     * to manage. - Other roles: Throws AccessDeniedException.
      *
      * @param eventId The ID of the event for which to block seats.
      * @param seatIds The IDs of the seats to block.
      * @param currentUser The user performing the action.
-     * @throws IllegalArgumentException If the event or any seat is not found.
-     * @throws SecurityException If the current user does not have the necessary permissions.
-     * @throws IllegalStateException If any of the specified seats are already reserved or blocked.
+     * @throws ValidationException If the event or any seat is not found, or if any of the specified
+     *     seats are already reserved or blocked.
+     * @throws AccessDeniedException If the current user does not have the necessary permissions.
      */
     @Transactional
     public Set<ReservationResponseDTO> blockSeats(
             UUID eventId, List<UUID> seatIds, User currentUser)
-            throws IllegalArgumentException, SecurityException, IllegalStateException {
+            throws ValidationException, AccessDeniedException {
         LOG.debugf(
                 "Attempting to block seats for event ID: %s, seat IDs: %s by user ID: %s (ID: %s)",
                 eventId, seatIds, currentUser.id, currentUser.getId());
@@ -470,7 +473,7 @@ public class ReservationService {
                                     LOG.warnf(
                                             "Event with ID %s not found for blocking seats.",
                                             eventId);
-                                    return new IllegalArgumentException(
+                                    return new ValidationException(
                                             "Event with id " + eventId + " not found");
                                 });
 
@@ -478,7 +481,7 @@ public class ReservationService {
             LOG.warnf(
                     "user ID: %s (ID: %s) is not allowed to block seats for event ID %s.",
                     currentUser.id, currentUser.getId(), eventId);
-            throw new SecurityException("You are not allowed to block seats for this event.");
+            throw new AccessDeniedException("You are not allowed to block seats for this event.");
         }
 
         Map<UUID, Seat> seatMap =
@@ -492,7 +495,7 @@ public class ReservationService {
                 LOG.warnf(
                         "Seat with ID %s not found for blocking seats in event ID %s.",
                         seatId, eventId);
-                throw new IllegalArgumentException("Seat with id " + seatId + " not found");
+                throw new ValidationException("Seat with id " + seatId + " not found");
             }
             seats.add(seat);
         }
@@ -504,7 +507,7 @@ public class ReservationService {
             LOG.warnf(
                     "Seat with ID %s is already reserved or blocked for event ID %s.",
                     conflictingSeatId, eventId);
-            throw new IllegalStateException(
+            throw new ValidationException(
                     "Seat with id " + conflictingSeatId + " is already reserved or blocked.");
         }
 
@@ -539,11 +542,11 @@ public class ReservationService {
      * @param currentUser The user attempting the export
      * @return A byte array containing the CSV export data
      * @throws EventNotFoundException If the event is not found
-     * @throws SecurityException If the user is not authorized to export this event
+     * @throws AccessDeniedException If the user is not authorized to export this event
      * @throws IOException If an I/O error occurs during export
      */
     public byte[] exportReservationsToCsv(UUID eventId, User currentUser)
-            throws EventNotFoundException, SecurityException, IOException {
+            throws EventNotFoundException, AccessDeniedException, IOException {
         LOG.debugf(
                 "Attempting to export reservations for event ID %s by user ID: %s (ID: %s)",
                 eventId, currentUser.id, currentUser.getId());
@@ -567,11 +570,11 @@ public class ReservationService {
      * @param currentUser The user attempting the export
      * @return A byte array containing the PDF export data
      * @throws EventNotFoundException If the event is not found
-     * @throws SecurityException If the user is not authorized to export this event
+     * @throws AccessDeniedException If the user is not authorized to export this event
      * @throws IOException If an I/O error occurs during export
      */
     public byte[] exportReservationsToPdf(UUID eventId, User currentUser)
-            throws EventNotFoundException, SecurityException, IOException {
+            throws EventNotFoundException, AccessDeniedException, IOException {
         LOG.debugf(
                 "Attempting to export reservations for event ID %s by user ID: %s (ID: %s)",
                 eventId, currentUser.id, currentUser.getId());
@@ -605,7 +608,7 @@ public class ReservationService {
      * @param currentUser The user attempting the export
      * @return The Event entity
      * @throws EventNotFoundException If the event is not found
-     * @throws SecurityException If the user is not authorized to export this event
+     * @throws AccessDeniedException If the user is not authorized to export this event
      */
     private Event getSortedReservations(UUID eventId, User currentUser) {
         Event event =
@@ -624,7 +627,7 @@ public class ReservationService {
                     "user ID: %s (ID: %s) is not authorized to export reservations for event ID"
                             + " %s.",
                     currentUser.id, currentUser.getId(), eventId);
-            throw new SecurityException(
+            throw new AccessDeniedException(
                     "User is not authorized to export this event's reservations");
         }
 
@@ -683,7 +686,7 @@ public class ReservationService {
                                                 "Event with id " + eventId + " not found"));
 
         if (!eventAccessService.isManager(event, AuthenticatedUser.of(currentUser))) {
-            throw new SecurityException("You are not allowed to access this event.");
+            throw new AccessDeniedException("You are not allowed to access this event.");
         }
 
         User user =
@@ -695,7 +698,7 @@ public class ReservationService {
                                                 "User with id " + userId + " not found"));
 
         if (BoxOfficeService.BOXOFFICE_USERNAME.equalsIgnoreCase(user.getUsername())) {
-            throw new IllegalArgumentException(
+            throw new ValidationException(
                     "Box office guest reservations share a single account and do not support"
                             + " per-guest confirmation emails.");
         }
@@ -747,7 +750,7 @@ public class ReservationService {
         boolean sent =
                 emailService.sendReservationConfirmation(target.user(), target.reservations());
         if (!sent) {
-            throw new IllegalStateException(
+            throw new ValidationException(
                     "User "
                             + userId
                             + " has no valid email address to resend the confirmation"

--- a/src/main/java/de/felixhertweck/seatreservation/management/service/SeatService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/management/service/SeatService.java
@@ -30,6 +30,8 @@ import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
 
 import de.felixhertweck.seatreservation.common.dto.SeatDTO;
+import de.felixhertweck.seatreservation.common.exception.AccessDeniedException;
+import de.felixhertweck.seatreservation.common.exception.ValidationException;
 import de.felixhertweck.seatreservation.management.dto.SeatRequestDTO;
 import de.felixhertweck.seatreservation.management.exception.SeatNotFoundException;
 import de.felixhertweck.seatreservation.model.entity.EventLocation;
@@ -63,12 +65,12 @@ public class SeatService {
      * @param dto the seat request DTO containing seat details
      * @param manager the manager attempting to create the seat
      * @return the created seat DTO
-     * @throws IllegalArgumentException if the event location is not found or seat data is invalid
-     * @throws SecurityException if the manager does not own the event location
+     * @throws ValidationException if the event location is not found or seat data is invalid
+     * @throws AccessDeniedException if the manager does not own the event location
      */
     @Transactional
     public SeatDTO createSeatManager(SeatRequestDTO dto, AuthenticatedUser manager)
-            throws IllegalArgumentException, SecurityException {
+            throws ValidationException, AccessDeniedException {
         LOG.debugf(
                 "Attempting to create seat with number: %s for event location ID: %s by manager"
                         + " ID: %s",
@@ -81,13 +83,13 @@ public class SeatService {
             LOG.warnf(
                     "Invalid seat data: seat number is empty for event location ID %s.",
                     eventLocation.getId());
-            throw new IllegalArgumentException("Seat number cannot be empty");
+            throw new ValidationException("Seat number cannot be empty");
         }
         if (dto.getSeatRow() == null || dto.getSeatRow().trim().isEmpty()) {
             LOG.warnf(
                     "Invalid seat data: seat row is empty for event location ID %s.",
                     eventLocation.getId());
-            throw new IllegalArgumentException("Seat row cannot be empty");
+            throw new ValidationException("Seat row cannot be empty");
         }
 
         Seat seat =
@@ -140,10 +142,10 @@ public class SeatService {
      * @param manager the manager attempting to access the seat
      * @return the seat DTO
      * @throws SeatNotFoundException if the seat is not found
-     * @throws SecurityException if the manager does not have permission to access the seat
+     * @throws AccessDeniedException if the manager does not have permission to access the seat
      */
     public SeatDTO findSeatByIdForManager(UUID id, AuthenticatedUser manager)
-            throws SeatNotFoundException, SecurityException {
+            throws SeatNotFoundException, AccessDeniedException {
         LOG.debugf("Attempting to retrieve seat with ID: %s for manager ID: %s", id, manager.id());
         Seat seat = findSeatEntityById(id, manager); // This already checks for ownership
         LOG.debugf("Successfully retrieved seat with ID %s for manager ID: %s", id, manager.id());
@@ -158,12 +160,12 @@ public class SeatService {
      * @param manager the manager attempting to update the seat
      * @return the updated seat DTO
      * @throws SeatNotFoundException if the seat is not found
-     * @throws SecurityException if the manager does not own the seat or the new event location
-     * @throws IllegalArgumentException if the event location is not found or seat data is invalid
+     * @throws AccessDeniedException if the manager does not own the seat or the new event location
+     * @throws ValidationException if the event location is not found or seat data is invalid
      */
     @Transactional
     public SeatDTO updateSeatForManager(UUID id, SeatRequestDTO dto, AuthenticatedUser manager)
-            throws SeatNotFoundException, SecurityException, IllegalArgumentException {
+            throws SeatNotFoundException, AccessDeniedException, ValidationException {
         LOG.debugf("Attempting to update seat with ID: %s for manager ID: %s", id, manager.id());
         Seat seat = findSeatEntityById(id, manager);
         UUID oldLocationId = seat.getLocation().getId();
@@ -174,11 +176,11 @@ public class SeatService {
 
         if (dto.getSeatNumber() == null || dto.getSeatNumber().trim().isEmpty()) {
             LOG.warnf("Invalid seat data: seat number is empty for seat ID %s.", id);
-            throw new IllegalArgumentException("Seat number cannot be empty");
+            throw new ValidationException("Seat number cannot be empty");
         }
         if (dto.getSeatRow() == null || dto.getSeatRow().trim().isEmpty()) {
             LOG.warnf("Invalid seat data: seat row is empty for seat ID %s.", id);
-            throw new IllegalArgumentException("Seat row cannot be empty");
+            throw new ValidationException("Seat row cannot be empty");
         }
 
         LOG.debugf(
@@ -230,7 +232,7 @@ public class SeatService {
      * @param areaId The area id; {@code null} resolves to no area
      * @param eventLocation The event location the area must belong to
      * @return The resolved area, or {@code null} if {@code areaId} is {@code null}
-     * @throws IllegalArgumentException if the area does not exist or belongs to another location
+     * @throws ValidationException if the area does not exist or belongs to another location
      */
     private EventLocationArea resolveArea(UUID areaId, EventLocation eventLocation) {
         if (areaId == null) {
@@ -241,10 +243,10 @@ public class SeatService {
                         .findByIdOptional(areaId)
                         .orElseThrow(
                                 () ->
-                                        new IllegalArgumentException(
+                                        new ValidationException(
                                                 "Area with id " + areaId + " not found"));
         if (!area.getEventLocation().getId().equals(eventLocation.getId())) {
-            throw new IllegalArgumentException(
+            throw new ValidationException(
                     "Area with id " + areaId + " does not belong to this EventLocation");
         }
         return area;
@@ -258,8 +260,7 @@ public class SeatService {
      * @param entranceId The entrance id; {@code null} resolves to no entrance
      * @param eventLocation The event location the entrance must belong to
      * @return The resolved entrance, or {@code null} if {@code entranceId} is {@code null}
-     * @throws IllegalArgumentException if the entrance does not exist or belongs to another
-     *     location
+     * @throws ValidationException if the entrance does not exist or belongs to another location
      */
     private EventLocationEntrance resolveEntrance(UUID entranceId, EventLocation eventLocation) {
         if (entranceId == null) {
@@ -270,10 +271,10 @@ public class SeatService {
                         .findByIdOptional(entranceId)
                         .orElseThrow(
                                 () ->
-                                        new IllegalArgumentException(
+                                        new ValidationException(
                                                 "Entrance with id " + entranceId + " not found"));
         if (!entrance.getEventLocation().getId().equals(eventLocation.getId())) {
-            throw new IllegalArgumentException(
+            throw new ValidationException(
                     "Entrance with id " + entranceId + " does not belong to this EventLocation");
         }
         return entrance;
@@ -285,15 +286,15 @@ public class SeatService {
      *
      * @param ids list of seat IDs to delete
      * @param manager the manager attempting to delete the seats
-     * @throws SecurityException if the manager does not own any of the seats
-     * @throws IllegalArgumentException if the ids list is null or empty
+     * @throws AccessDeniedException if the manager does not own any of the seats
+     * @throws ValidationException if the ids list is null or empty
      */
     @Transactional
     public void deleteSeatForManager(List<UUID> ids, AuthenticatedUser manager)
-            throws SecurityException, IllegalArgumentException {
+            throws AccessDeniedException, ValidationException {
         if (ids == null || ids.isEmpty()) {
             LOG.warnf("No seat IDs provided for deletion by manager ID: %s", manager.id());
-            throw new IllegalArgumentException("No seat IDs provided for deletion");
+            throw new ValidationException("No seat IDs provided for deletion");
         }
 
         LOG.debugf("Attempting to delete seats with IDs: %s for manager ID: %s", ids, manager.id());
@@ -329,10 +330,10 @@ public class SeatService {
      * @param currentUser the user attempting to access the seat
      * @return the seat entity
      * @throws SeatNotFoundException if the seat is not found
-     * @throws SecurityException if the user does not have permission to access the seat
+     * @throws AccessDeniedException if the user does not have permission to access the seat
      */
     public Seat findSeatEntityById(UUID id, AuthenticatedUser currentUser)
-            throws SeatNotFoundException, SecurityException {
+            throws SeatNotFoundException, AccessDeniedException {
         LOG.debugf(
                 "Attempting to find seat entity by ID: %s for user ID: %s", id, currentUser.id());
         // Check if user has access to linked location
@@ -355,11 +356,11 @@ public class SeatService {
 
         try {
             eventLocationAccessService.requireAccess(seat.getLocation(), currentUser);
-        } catch (SecurityException e) {
+        } catch (AccessDeniedException e) {
             LOG.warnf(
                     "user ID: %s does not have permission to access seat ID %s.",
                     currentUser.id(), id);
-            throw new SecurityException("You do not have permission to access this seat");
+            throw new AccessDeniedException("You do not have permission to access this seat");
         }
         LOG.debugf("user ID: %s has permission to access seat ID %s.", currentUser.id(), id);
         return seat;

--- a/src/main/java/de/felixhertweck/seatreservation/reservation/resource/ReservationResource.java
+++ b/src/main/java/de/felixhertweck/seatreservation/reservation/resource/ReservationResource.java
@@ -37,6 +37,7 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 
+import de.felixhertweck.seatreservation.common.exception.AccessDeniedException;
 import de.felixhertweck.seatreservation.common.exception.ReservationNotFoundException;
 import de.felixhertweck.seatreservation.model.entity.Roles;
 import de.felixhertweck.seatreservation.model.entity.User;
@@ -161,7 +162,7 @@ public class ReservationResource {
     public void deleteReservation(@QueryParam("ids") List<UUID> ids)
             throws PersistenceException,
                     ReservationNotFoundException,
-                    SecurityException,
+                    AccessDeniedException,
                     IOException {
         User currentUser = userSecurityContext.getCurrentUser();
         LOG.debugf(

--- a/src/main/java/de/felixhertweck/seatreservation/reservation/service/EventLocationService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/reservation/service/EventLocationService.java
@@ -33,6 +33,7 @@ import de.felixhertweck.seatreservation.common.dto.AreaDTO;
 import de.felixhertweck.seatreservation.common.dto.CoordinateDTO;
 import de.felixhertweck.seatreservation.common.dto.EventLocationMakerDTO;
 import de.felixhertweck.seatreservation.common.dto.SeatDTO;
+import de.felixhertweck.seatreservation.common.exception.AccessDeniedException;
 import de.felixhertweck.seatreservation.common.exception.UserNotFoundException;
 import de.felixhertweck.seatreservation.management.dto.AreaResponseDTO;
 import de.felixhertweck.seatreservation.management.exception.EventLocationNotFoundException;
@@ -95,11 +96,11 @@ public class EventLocationService {
      * @return the detail DTO of the event location
      * @throws UserNotFoundException if the user is not found
      * @throws EventLocationNotFoundException if the event location is not found
-     * @throws SecurityException if the user is not authorized to access the location
+     * @throws AccessDeniedException if the user is not authorized to access the location
      */
     public UserEventLocationResponseDTO getLocationByIdForCurrentUser(
             UUID locationId, String username)
-            throws UserNotFoundException, EventLocationNotFoundException, SecurityException {
+            throws UserNotFoundException, EventLocationNotFoundException, AccessDeniedException {
         List<UserEventLocationSummaryDTO> allowedLocations = getLocationsForCurrentUser(username);
         boolean hasAccess = allowedLocations.stream().anyMatch(loc -> loc.id().equals(locationId));
 
@@ -109,7 +110,7 @@ public class EventLocationService {
                 throw new EventLocationNotFoundException(
                         "EventLocation with id " + locationId + " not found");
             }
-            throw new SecurityException("User is not authorized to access this location");
+            throw new AccessDeniedException("User is not authorized to access this location");
         }
 
         EventLocation location =

--- a/src/main/java/de/felixhertweck/seatreservation/reservation/service/ReservationService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/reservation/service/ReservationService.java
@@ -33,8 +33,10 @@ import jakarta.inject.Inject;
 import jakarta.persistence.PersistenceException;
 import jakarta.transaction.Transactional;
 
+import de.felixhertweck.seatreservation.common.exception.AccessDeniedException;
 import de.felixhertweck.seatreservation.common.exception.EventNotFoundException;
 import de.felixhertweck.seatreservation.common.exception.ReservationNotFoundException;
+import de.felixhertweck.seatreservation.common.exception.ValidationException;
 import de.felixhertweck.seatreservation.email.service.EmailService;
 import de.felixhertweck.seatreservation.model.entity.CheckInToken;
 import de.felixhertweck.seatreservation.model.entity.Event;
@@ -91,10 +93,10 @@ public class ReservationService {
      * @param currentUser the currently authenticated user
      * @return the user reservation response DTO
      * @throws ReservationNotFoundException if the reservation is not found
-     * @throws SecurityException if the current user does not own the reservation
+     * @throws AccessDeniedException if the current user does not own the reservation
      */
     public UserReservationResponseDTO findReservationByIdForUser(UUID id, User currentUser)
-            throws ReservationNotFoundException, SecurityException {
+            throws ReservationNotFoundException, AccessDeniedException {
         LOG.debugf("Attempting to find reservation with ID %s for user ID: %s", id, currentUser.id);
         Reservation reservation =
                 reservationRepository
@@ -111,7 +113,7 @@ public class ReservationService {
             LOG.warnf(
                     "user ID: %s attempted to access reservation %s which belongs to user ID: %s.",
                     currentUser.id, id, reservation.getUser().id);
-            throw new SecurityException("You are not allowed to access this reservation");
+            throw new AccessDeniedException("You are not allowed to access this reservation");
         }
         LOG.debugf("Reservation with ID %s found for user ID: %s.", id, currentUser.id);
         return new UserReservationResponseDTO(reservation);
@@ -132,8 +134,8 @@ public class ReservationService {
      * @throws EventBookingClosedException if the event booking has not started or has already ended
      * @throws SeatAlreadyReservedException if any of the requested seats are already reserved
      * @throws SeatBlockedException if any of the requested seats are blocked
-     * @throws IllegalStateException if the user does not have a verified email address
-     * @throws IllegalArgumentException if no seats are selected
+     * @throws ValidationException if the user does not have a verified email address, or if no
+     *     seats are selected
      */
     @Transactional
     public List<UserReservationResponseDTO> createReservationForUser(
@@ -150,7 +152,7 @@ public class ReservationService {
             LOG.warnf(
                     "user ID: %s attempted to create reservation without a verified email.",
                     currentUser.id);
-            throw new IllegalStateException(
+            throw new ValidationException(
                     "User must have a verified email address to create a reservation.");
         }
 
@@ -158,7 +160,7 @@ public class ReservationService {
             LOG.warnf(
                     "user ID: %s attempted to create reservation with no seats selected.",
                     currentUser.id);
-            throw new IllegalArgumentException("At least one seat must be selected");
+            throw new ValidationException("At least one seat must be selected");
         }
 
         // Validate the eventId, ensure it exists
@@ -343,24 +345,24 @@ public class ReservationService {
      * @param ids List of reservation IDs to delete.
      * @param currentUser The user attempting to delete the reservations.
      * @throws ReservationNotFoundException if any reservation is not found.
-     * @throws SecurityException if the user is not authorized to delete any reservation.
+     * @throws AccessDeniedException if the user is not authorized to delete any reservation.
      * @throws IOException if sending the confirmation email fails.
      * @throws PersistenceException if the reservation cannot be deleted from the database.
-     * @throws IllegalArgumentException if the list of IDs is null or empty.
+     * @throws ValidationException if the list of IDs is null or empty.
      */
     @Transactional
     public void deleteReservationForUser(List<UUID> ids, User currentUser)
             throws IOException,
                     PersistenceException,
                     ReservationNotFoundException,
-                    SecurityException,
-                    IllegalArgumentException {
+                    AccessDeniedException,
+                    ValidationException {
         LOG.debugf(
                 "Attempting to delete reservations with IDs %s for user ID: %s",
                 ids != null ? ids : Collections.emptyList(), currentUser.id);
         if (ids == null || ids.isEmpty()) {
             LOG.warnf("No reservation IDs provided for deletion by user ID: %s", currentUser.id);
-            throw new IllegalArgumentException(
+            throw new ValidationException(
                     "At least one reservation ID must be provided for deletion");
         }
 
@@ -383,14 +385,14 @@ public class ReservationService {
                         "user ID: %s attempted to delete reservation %s which belongs to user ID:"
                                 + " %s.",
                         currentUser.id, id, uncheckedReservation.getUser().id);
-                throw new SecurityException("You are not allowed to delete this reservation");
+                throw new AccessDeniedException("You are not allowed to delete this reservation");
             }
             reservations.add(uncheckedReservation);
         }
 
         if (reservations.isEmpty()) {
             LOG.warnf("No valid reservations found for deletion by user ID: %s", currentUser.id);
-            throw new IllegalArgumentException("No valid reservations found for deletion");
+            throw new ValidationException("No valid reservations found for deletion");
         }
 
         // Group reservations by event to handle allowance updates and email confirmations correctly

--- a/src/main/java/de/felixhertweck/seatreservation/security/resource/WebAuthnResource.java
+++ b/src/main/java/de/felixhertweck/seatreservation/security/resource/WebAuthnResource.java
@@ -44,6 +44,7 @@ import jakarta.ws.rs.core.Response;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.felixhertweck.seatreservation.common.exception.DuplicateUserException;
 import de.felixhertweck.seatreservation.common.exception.RegistrationDisabledException;
+import de.felixhertweck.seatreservation.common.exception.ValidationException;
 import de.felixhertweck.seatreservation.model.entity.User;
 import de.felixhertweck.seatreservation.model.repository.UserRepository;
 import de.felixhertweck.seatreservation.security.dto.TwoFactorRequiredDTO;
@@ -193,11 +194,11 @@ public class WebAuthnResource {
         JsonObject root = parseWebAuthnPayload(body);
         JsonObject registrationJson = root.getJsonObject("registration");
         if (registrationJson == null) {
-            throw new IllegalArgumentException("Missing registration details");
+            throw new ValidationException("Missing registration details");
         }
         JsonObject credential = root.getJsonObject("credential");
         if (credential == null) {
-            throw new IllegalArgumentException("Missing credential");
+            throw new ValidationException("Missing credential");
         }
 
         // Deserialize the profile fields through the CDI (XSS-sanitizing) mapper, then validate.
@@ -207,12 +208,12 @@ public class WebAuthnResource {
                     objectMapper.readValue(
                             registrationJson.encode(), WebAuthnRegistrationStartDTO.class);
         } catch (com.fasterxml.jackson.core.JsonProcessingException e) {
-            throw new IllegalArgumentException("Invalid registration details", e);
+            throw new ValidationException("Invalid registration details", e);
         }
         Set<ConstraintViolation<WebAuthnRegistrationStartDTO>> violations =
                 validator.validate(registration);
         if (!violations.isEmpty()) {
-            throw new IllegalArgumentException(violations.iterator().next().getMessage());
+            throw new ValidationException(violations.iterator().next().getMessage());
         }
 
         RoutingContext ctx = currentVertxRequest.getCurrent();
@@ -368,7 +369,7 @@ public class WebAuthnResource {
             return webAuthnSecurity.register(username, credential, ctx).await().indefinitely();
         } catch (RuntimeException e) {
             LOG.debugf("Passkey registration verification failed: %s", e.getMessage());
-            throw new IllegalArgumentException("Passkey registration failed: " + e.getMessage(), e);
+            throw new ValidationException("Passkey registration failed", e);
         }
     }
 
@@ -392,12 +393,12 @@ public class WebAuthnResource {
      */
     private JsonObject parseWebAuthnPayload(String body) {
         if (body == null || body.isBlank()) {
-            throw new IllegalArgumentException("Missing request body");
+            throw new ValidationException("Missing request body");
         }
         try {
             return new JsonObject(RAW_JSON_MAPPER.readValue(body, java.util.Map.class));
         } catch (com.fasterxml.jackson.core.JsonProcessingException e) {
-            throw new IllegalArgumentException("Invalid JSON body", e);
+            throw new ValidationException("Invalid JSON body", e);
         }
     }
 

--- a/src/main/java/de/felixhertweck/seatreservation/supervisor/service/BoxOfficeService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/supervisor/service/BoxOfficeService.java
@@ -34,6 +34,7 @@ import jakarta.transaction.Transactional;
 import de.felixhertweck.seatreservation.common.dto.LimitedUserInfoDTO;
 import de.felixhertweck.seatreservation.common.exception.EventNotFoundException;
 import de.felixhertweck.seatreservation.common.exception.UserNotFoundException;
+import de.felixhertweck.seatreservation.common.exception.ValidationException;
 import de.felixhertweck.seatreservation.email.service.EmailService;
 import de.felixhertweck.seatreservation.email.service.ReservationEmailContent.BoxOfficeConfirmationContent;
 import de.felixhertweck.seatreservation.model.entity.BoxOfficeGuestInfo;
@@ -214,7 +215,7 @@ public class BoxOfficeService {
             boolean deductAllowance,
             CheckInToken checkInToken) {
         if (seatIds == null || seatIds.isEmpty()) {
-            throw new IllegalArgumentException("No seat IDs provided.");
+            throw new ValidationException("No seat IDs provided.");
         }
 
         Map<UUID, Seat> seatMap =
@@ -229,7 +230,7 @@ public class BoxOfficeService {
                         event.getId(), new ArrayList<>(seatIds));
         if (!conflicting.isEmpty()) {
             UUID conflictingSeatId = conflicting.getFirst().getSeat().id;
-            throw new IllegalStateException(
+            throw new ValidationException(
                     "Seat with id " + conflictingSeatId + " is already reserved or blocked.");
         }
 
@@ -240,7 +241,7 @@ public class BoxOfficeService {
                             .findByUserAndEvent(reservationOwner, event)
                             .orElseThrow(
                                     () ->
-                                            new IllegalArgumentException(
+                                            new ValidationException(
                                                     "User has no reservation allowance for this"
                                                             + " event."));
         }
@@ -249,12 +250,12 @@ public class BoxOfficeService {
         for (UUID seatId : seatIds) {
             Seat seat = seatMap.get(seatId);
             if (seat == null) {
-                throw new IllegalArgumentException("Seat with id " + seatId + " not found");
+                throw new ValidationException("Seat with id " + seatId + " not found");
             }
 
             if (deductAllowance) {
                 if (allowance.getReservationsAllowedCount() <= 0) {
-                    throw new IllegalArgumentException(
+                    throw new ValidationException(
                             "No more reservations allowed for this user and event.");
                 }
                 allowance.setReservationsAllowedCount(allowance.getReservationsAllowedCount() - 1);

--- a/src/main/java/de/felixhertweck/seatreservation/supervisor/service/CheckInService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/supervisor/service/CheckInService.java
@@ -34,6 +34,7 @@ import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
 
 import de.felixhertweck.seatreservation.common.dto.LimitedUserInfoDTO;
+import de.felixhertweck.seatreservation.common.exception.AccessDeniedException;
 import de.felixhertweck.seatreservation.common.exception.EventNotFoundException;
 import de.felixhertweck.seatreservation.common.exception.ReservationNotFoundException;
 import de.felixhertweck.seatreservation.model.entity.CheckInToken;
@@ -97,7 +98,7 @@ public class CheckInService {
 
         if (currentUser != null
                 && !eventAuthorizationService.isAuthorizedForEvent(currentUser, eventId)) {
-            throw new SecurityException("User is not authorized to access event " + eventId);
+            throw new AccessDeniedException("User is not authorized to access event " + eventId);
         }
         assertBookingDeadlinePassed(loadEvent(eventId));
         List<SupervisorReservationResponseDTO> processedReservations = new ArrayList<>();
@@ -156,7 +157,7 @@ public class CheckInService {
         UUID eventId = requestDTO.eventId;
         if (currentUser != null
                 && !eventAuthorizationService.isAuthorizedForEvent(currentUser, eventId)) {
-            throw new SecurityException("User is not authorized to access event " + eventId);
+            throw new AccessDeniedException("User is not authorized to access event " + eventId);
         }
         assertBookingDeadlinePassed(loadEvent(eventId));
         UUID userId = requestDTO.userId;
@@ -306,7 +307,7 @@ public class CheckInService {
         LOG.debugf("Retrieving usernames with reservations for event %s.", eventId);
         if (currentUser != null
                 && !eventAuthorizationService.isAuthorizedForEvent(currentUser, eventId)) {
-            throw new SecurityException("User is not authorized to access event " + eventId);
+            throw new AccessDeniedException("User is not authorized to access event " + eventId);
         }
         return reservationRepository.findDistinctUsernamesByEventId(eventId);
     }

--- a/src/main/java/de/felixhertweck/seatreservation/supervisor/service/EventAuthorizationService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/supervisor/service/EventAuthorizationService.java
@@ -23,6 +23,7 @@ import java.util.UUID;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
+import de.felixhertweck.seatreservation.common.exception.AccessDeniedException;
 import de.felixhertweck.seatreservation.model.repository.EventRepository;
 import de.felixhertweck.seatreservation.utils.AuthenticatedUser;
 
@@ -62,12 +63,12 @@ public class EventAuthorizationService {
      *
      * @param user the user attempting access
      * @param eventId the event ID
-     * @throws SecurityException if the user is neither a supervisor/manager of the event nor an
+     * @throws AccessDeniedException if the user is neither a supervisor/manager of the event nor an
      *     ADMIN
      */
     public void assertAuthorizedForEvent(AuthenticatedUser user, UUID eventId) {
         if (!isAuthorizedForEvent(user, eventId)) {
-            throw new SecurityException("User is not authorized to access event " + eventId);
+            throw new AccessDeniedException("User is not authorized to access event " + eventId);
         }
     }
 }

--- a/src/main/java/de/felixhertweck/seatreservation/supervisor/service/LiveViewService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/supervisor/service/LiveViewService.java
@@ -33,6 +33,7 @@ import jakarta.inject.Inject;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import de.felixhertweck.seatreservation.common.exception.AccessDeniedException;
 import de.felixhertweck.seatreservation.model.entity.BoxOfficeGuestInfo;
 import de.felixhertweck.seatreservation.model.entity.Event;
 import de.felixhertweck.seatreservation.model.entity.EventLocation;
@@ -106,7 +107,7 @@ public class LiveViewService {
             throws InvalidEventIdException {
         UUID eventId = parseEventId(eventIdStr);
         if (!eventAuthorizationService.isAuthorizedForEvent(currentUser, eventId)) {
-            throw new SecurityException("User is not authorized to access event " + eventId);
+            throw new AccessDeniedException("User is not authorized to access event " + eventId);
         }
         assertBookingDeadlinePassed(eventRepository.findById(eventId));
         registerConnection(eventId, connection);
@@ -131,7 +132,7 @@ public class LiveViewService {
             throws InvalidEventIdException {
         UUID eventId = parseEventId(eventIdStr);
         if (!eventAuthorizationService.isAuthorizedForEvent(currentUser, eventId)) {
-            throw new SecurityException("User is not authorized to access event " + eventId);
+            throw new AccessDeniedException("User is not authorized to access event " + eventId);
         }
         unregisterConnection(eventId, connection);
     }

--- a/src/main/java/de/felixhertweck/seatreservation/userManagment/service/UserService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/userManagment/service/UserService.java
@@ -37,9 +37,11 @@ import jakarta.transaction.Transactional;
 
 import de.felixhertweck.seatreservation.common.dto.LimitedUserInfoDTO;
 import de.felixhertweck.seatreservation.common.dto.UserDTO;
+import de.felixhertweck.seatreservation.common.exception.AccessDeniedException;
 import de.felixhertweck.seatreservation.common.exception.DuplicateUserException;
 import de.felixhertweck.seatreservation.common.exception.InvalidUserException;
 import de.felixhertweck.seatreservation.common.exception.UserNotFoundException;
+import de.felixhertweck.seatreservation.common.exception.ValidationException;
 import de.felixhertweck.seatreservation.email.service.EmailService;
 import de.felixhertweck.seatreservation.model.entity.EmailVerification;
 import de.felixhertweck.seatreservation.model.entity.Roles;
@@ -426,13 +428,13 @@ public class UserService {
      * @throws InvalidUserException If the provided data is invalid.
      * @throws DuplicateUserException If a user with the same username or email already exists.
      * @throws SendEmailException If an error occurs while sending email confirmation.
-     * @throws SecurityException If roles are being updated without a known authenticated user, if
-     *     an admin attempts to remove their own admin role, or if roles are being granted to the
+     * @throws AccessDeniedException If roles are being updated without a known authenticated user,
+     *     if an admin attempts to remove their own admin role, or if roles are being granted to the
      *     reserved "boxoffice" system account.
      */
     @Transactional
     public UserDTO updateUser(UUID id, AdminUserUpdateDTO user, AuthenticatedUser currentUser)
-            throws UserNotFoundException, SecurityException {
+            throws UserNotFoundException, AccessDeniedException {
         if (user == null) {
             LOG.warnf("AdminUserUpdateDTO is null for user ID: %s.", id);
             throw new InvalidUserException("User update data cannot be null.");
@@ -456,18 +458,18 @@ public class UserService {
                         "Refusing role update for user ID %s: no authenticated user available to"
                                 + " check self-lockout.",
                         id);
-                throw new SecurityException("Authenticated user is required to update roles.");
+                throw new AccessDeniedException("Authenticated user is required to update roles.");
             }
             if (id.equals(currentUser.id()) && !user.getRoles().contains(Roles.ADMIN)) {
                 LOG.warnf("User %s attempted to remove their own admin role.", currentUser.id());
-                throw new SecurityException("Admins cannot remove their own admin role.");
+                throw new AccessDeniedException("Admins cannot remove their own admin role.");
             }
             if ("boxoffice".equalsIgnoreCase(existingUser.getUsername())
                     && !user.getRoles().isEmpty()) {
                 LOG.warnf(
                         "Attempt to grant roles to reserved system account: %s",
                         existingUser.getUsername());
-                throw new SecurityException(
+                throw new AccessDeniedException(
                         "The box office system account must never be granted roles.");
             }
         }
@@ -499,11 +501,11 @@ public class UserService {
      * @param ids The IDs of the users to delete.
      * @param currentUser The currently authenticated user performing the deletion.
      * @throws UserNotFoundException If the user with the given ID does not exist.
-     * @throws SecurityException If the user is attempting to delete their own account.
+     * @throws AccessDeniedException If the user is attempting to delete their own account.
      */
     @Transactional
     public void deleteUser(List<UUID> ids, AuthenticatedUser currentUser)
-            throws UserNotFoundException, SecurityException {
+            throws UserNotFoundException, AccessDeniedException {
         if (ids == null || ids.isEmpty()) {
             return;
         }
@@ -524,11 +526,11 @@ public class UserService {
             }
             if (currentUser != null && id.equals(currentUser.id())) {
                 LOG.warnf("User %s attempted to delete their own account.", currentUser.id());
-                throw new SecurityException("Admins cannot delete their own accounts.");
+                throw new AccessDeniedException("Admins cannot delete their own accounts.");
             }
             if (RESERVED_USERNAMES.contains(user.getUsername().toLowerCase())) {
                 LOG.warnf("Attempt to delete reserved system account: %s", user.getUsername());
-                throw new SecurityException("The box office system account cannot be deleted.");
+                throw new AccessDeniedException("The box office system account cannot be deleted.");
             }
         }
 
@@ -631,8 +633,8 @@ public class UserService {
      *
      * @param verificationCode The 6-digit verification code to verify (must not be null or empty).
      * @return The email address of the user if verification is successful.
-     * @throws IllegalArgumentException If the verification code format is invalid (null, empty, or
-     *     not 6 digits).
+     * @throws ValidationException If the verification code format is invalid (null, empty, or not 6
+     *     digits).
      * @throws VerificationCodeNotFoundException If the verification code is not found.
      * @throws VerifyTokenExpiredException If the verification code has expired.
      */
@@ -643,13 +645,13 @@ public class UserService {
         // Validate verification code
         if (verificationCode == null || verificationCode.trim().isEmpty()) {
             LOG.warn("Invalid verification code provided for email verification.");
-            throw new IllegalArgumentException("Invalid verification code");
+            throw new ValidationException("Invalid verification code");
         }
 
         // Validate that it's a 6-digit code
         if (!verificationCode.matches("\\d{6}")) {
             LOG.warnf("Invalid verification code format: %s", verificationCode);
-            throw new IllegalArgumentException("Verification code must be 6 digits");
+            throw new ValidationException("Verification code must be 6 digits");
         }
 
         // Get the email verification record by token
@@ -709,8 +711,7 @@ public class UserService {
 
         if (user.getEmail() == null || user.getEmail().trim().isEmpty()) {
             LOG.warnf("User %s has no email address, cannot resend confirmation.", username);
-            throw new IllegalArgumentException(
-                    "User has no email address to send confirmation to.");
+            throw new ValidationException("User has no email address to send confirmation to.");
         }
 
         Optional<Instant> retryAfter =

--- a/src/main/java/de/felixhertweck/seatreservation/utils/ManagerResolutionUtils.java
+++ b/src/main/java/de/felixhertweck/seatreservation/utils/ManagerResolutionUtils.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import de.felixhertweck.seatreservation.common.exception.ValidationException;
 import de.felixhertweck.seatreservation.model.entity.Roles;
 import de.felixhertweck.seatreservation.model.entity.User;
 import de.felixhertweck.seatreservation.model.repository.UserRepository;
@@ -49,7 +50,7 @@ public final class ManagerResolutionUtils {
      * @param context short label identifying the assignment target for log/error messages, e.g.
      *     "event" or "event location"
      * @return Set of User entities
-     * @throws IllegalArgumentException if any manager ID is invalid or the user lacks MANAGER/ADMIN
+     * @throws ValidationException if any manager ID is invalid or the user lacks MANAGER/ADMIN
      */
     public static Set<User> resolveManagers(
             UserRepository userRepository, Set<UUID> managerIds, String context) {
@@ -67,7 +68,7 @@ public final class ManagerResolutionUtils {
                     LOG.warnf(
                             "User with id %s not found for %s manager assignment.",
                             managerId, context);
-                    throw new IllegalArgumentException("User with id " + managerId + " not found");
+                    throw new ValidationException("User with id " + managerId + " not found");
                 }
             }
         }
@@ -78,7 +79,7 @@ public final class ManagerResolutionUtils {
                 LOG.warnf(
                         "User with id %s lacks MANAGER/ADMIN role for %s manager assignment.",
                         candidate.id, context);
-                throw new IllegalArgumentException(
+                throw new ValidationException(
                         "User with id "
                                 + candidate.id
                                 + " must have the MANAGER or ADMIN role to be assigned as a"

--- a/src/main/java/de/felixhertweck/seatreservation/utils/SvgToPngConverter.java
+++ b/src/main/java/de/felixhertweck/seatreservation/utils/SvgToPngConverter.java
@@ -24,6 +24,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
+import de.felixhertweck.seatreservation.common.exception.ValidationException;
 import org.apache.batik.transcoder.TranscoderException;
 import org.apache.batik.transcoder.TranscoderInput;
 import org.apache.batik.transcoder.TranscoderOutput;
@@ -47,7 +48,7 @@ public class SvgToPngConverter {
     public static byte[] convertSvgToPng(String svgContent)
             throws IOException, TranscoderException {
         if (svgContent == null || svgContent.isEmpty()) {
-            throw new IllegalArgumentException("SVG content cannot be null or empty");
+            throw new ValidationException("SVG content cannot be null or empty");
         }
 
         LOG.debug("Converting SVG to PNG...");

--- a/src/test/java/de/felixhertweck/seatreservation/GlobalExceptionHandlerTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/GlobalExceptionHandlerTest.java
@@ -28,12 +28,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 import de.felixhertweck.seatreservation.common.dto.ErrorResponseDTO;
+import de.felixhertweck.seatreservation.common.exception.AccessDeniedException;
 import de.felixhertweck.seatreservation.common.exception.DuplicateUserException;
 import de.felixhertweck.seatreservation.common.exception.EventNotFoundException;
 import de.felixhertweck.seatreservation.common.exception.InvalidUserException;
 import de.felixhertweck.seatreservation.common.exception.RegistrationDisabledException;
 import de.felixhertweck.seatreservation.common.exception.ReservationNotFoundException;
 import de.felixhertweck.seatreservation.common.exception.UserNotFoundException;
+import de.felixhertweck.seatreservation.common.exception.ValidationException;
 import de.felixhertweck.seatreservation.management.exception.EventLocationNotFoundException;
 import de.felixhertweck.seatreservation.management.exception.SeatNotFoundException;
 import de.felixhertweck.seatreservation.reservation.exception.EventBookingClosedException;
@@ -215,6 +217,62 @@ class GlobalExceptionHandlerTest {
         assertTrue(response.getEntity() instanceof ErrorResponseDTO);
         ErrorResponseDTO errorResponse = (ErrorResponseDTO) response.getEntity();
         assertEquals("No seats available", errorResponse.getMessage());
+    }
+
+    @Test
+    void testValidationException() {
+        ValidationException exception = new ValidationException("Area name cannot be empty");
+        Response response = exceptionHandler.toResponse(exception);
+
+        assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+        assertTrue(response.getEntity() instanceof ErrorResponseDTO);
+        ErrorResponseDTO errorResponse = (ErrorResponseDTO) response.getEntity();
+        assertEquals("Area name cannot be empty", errorResponse.getMessage());
+    }
+
+    @Test
+    void testAccessDeniedException() {
+        AccessDeniedException exception =
+                new AccessDeniedException("You are not allowed to access this reservation");
+        Response response = exceptionHandler.toResponse(exception);
+
+        assertEquals(Response.Status.FORBIDDEN.getStatusCode(), response.getStatus());
+        assertTrue(response.getEntity() instanceof ErrorResponseDTO);
+        ErrorResponseDTO errorResponse = (ErrorResponseDTO) response.getEntity();
+        assertEquals("You are not allowed to access this reservation", errorResponse.getMessage());
+    }
+
+    @Test
+    void testIllegalArgumentException() {
+        IllegalArgumentException exception = new IllegalArgumentException("Internal detail");
+        Response response = exceptionHandler.toResponse(exception);
+
+        assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+        assertTrue(response.getEntity() instanceof ErrorResponseDTO);
+        ErrorResponseDTO errorResponse = (ErrorResponseDTO) response.getEntity();
+        assertEquals("Bad Request", errorResponse.getMessage());
+    }
+
+    @Test
+    void testSecurityException() {
+        SecurityException exception = new SecurityException("Internal path");
+        Response response = exceptionHandler.toResponse(exception);
+
+        assertEquals(Response.Status.FORBIDDEN.getStatusCode(), response.getStatus());
+        assertTrue(response.getEntity() instanceof ErrorResponseDTO);
+        ErrorResponseDTO errorResponse = (ErrorResponseDTO) response.getEntity();
+        assertEquals("Forbidden", errorResponse.getMessage());
+    }
+
+    @Test
+    void testIllegalStateException() {
+        IllegalStateException exception = new IllegalStateException("Internal state");
+        Response response = exceptionHandler.toResponse(exception);
+
+        assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+        assertTrue(response.getEntity() instanceof ErrorResponseDTO);
+        ErrorResponseDTO errorResponse = (ErrorResponseDTO) response.getEntity();
+        assertEquals("Bad Request", errorResponse.getMessage());
     }
 
     @Test

--- a/src/test/java/de/felixhertweck/seatreservation/management/service/AreaServiceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/management/service/AreaServiceTest.java
@@ -37,6 +37,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import de.felixhertweck.seatreservation.common.dto.CoordinateDTO;
+import de.felixhertweck.seatreservation.common.exception.AccessDeniedException;
+import de.felixhertweck.seatreservation.common.exception.ValidationException;
 import de.felixhertweck.seatreservation.management.dto.AreaRequestDTO;
 import de.felixhertweck.seatreservation.management.dto.AreaResponseDTO;
 import de.felixhertweck.seatreservation.management.exception.AreaInUseException;
@@ -176,7 +178,7 @@ public class AreaServiceTest {
     void createArea_Forbidden_NotManagerOfLocation() {
         AreaRequestDTO dto = new AreaRequestDTO(eventLocation.id, "Balkon", List.of());
 
-        assertThrows(SecurityException.class, () -> areaService.createArea(dto, regularAuth));
+        assertThrows(AccessDeniedException.class, () -> areaService.createArea(dto, regularAuth));
         verify(areaRepository, never()).persist(any(EventLocationArea.class));
     }
 
@@ -184,8 +186,7 @@ public class AreaServiceTest {
     void createArea_InvalidInput_EmptyName() {
         AreaRequestDTO dto = new AreaRequestDTO(eventLocation.id, "  ", List.of());
 
-        assertThrows(
-                IllegalArgumentException.class, () -> areaService.createArea(dto, managerAuth));
+        assertThrows(ValidationException.class, () -> areaService.createArea(dto, managerAuth));
         verify(areaRepository, never()).persist(any(EventLocationArea.class));
     }
 
@@ -222,7 +223,7 @@ public class AreaServiceTest {
     @Test
     void findAreasByLocation_Forbidden_NotOwner() {
         assertThrows(
-                SecurityException.class,
+                AccessDeniedException.class,
                 () -> areaService.findAreasByLocation(otherLocation.id, managerAuth));
     }
 
@@ -265,7 +266,7 @@ public class AreaServiceTest {
                 .thenReturn(Optional.of(areaInOtherLocation));
 
         assertThrows(
-                SecurityException.class,
+                AccessDeniedException.class,
                 () -> areaService.findAreaByIdForManager(areaInOtherLocation.id, managerAuth));
     }
 
@@ -300,7 +301,7 @@ public class AreaServiceTest {
         AreaRequestDTO dto = new AreaRequestDTO(otherLocation.id, "Loge", List.of());
 
         assertThrows(
-                SecurityException.class,
+                AccessDeniedException.class,
                 () -> areaService.updateArea(existingArea.id, dto, managerAuth));
     }
 
@@ -311,7 +312,7 @@ public class AreaServiceTest {
         AreaRequestDTO dto = new AreaRequestDTO(eventLocation.id, "  ", List.of());
 
         assertThrows(
-                IllegalArgumentException.class,
+                ValidationException.class,
                 () -> areaService.updateArea(existingArea.id, dto, managerAuth));
         verify(areaRepository, never()).persist(any(EventLocationArea.class));
     }
@@ -371,8 +372,7 @@ public class AreaServiceTest {
     @Test
     void deleteAreas_InvalidInput_EmptyIds() {
         assertThrows(
-                IllegalArgumentException.class,
-                () -> areaService.deleteAreas(List.of(), managerAuth));
+                ValidationException.class, () -> areaService.deleteAreas(List.of(), managerAuth));
         verify(areaRepository, never()).delete(any(EventLocationArea.class));
     }
 
@@ -405,7 +405,7 @@ public class AreaServiceTest {
                 .thenReturn(List.of(areaInOtherLocation));
 
         assertThrows(
-                SecurityException.class,
+                AccessDeniedException.class,
                 () -> areaService.deleteAreas(List.of(areaInOtherLocation.id), managerAuth));
     }
 

--- a/src/test/java/de/felixhertweck/seatreservation/management/service/EntranceServiceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/management/service/EntranceServiceTest.java
@@ -36,6 +36,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import de.felixhertweck.seatreservation.common.exception.AccessDeniedException;
+import de.felixhertweck.seatreservation.common.exception.ValidationException;
 import de.felixhertweck.seatreservation.management.dto.EntranceRequestDTO;
 import de.felixhertweck.seatreservation.management.dto.EntranceResponseDTO;
 import de.felixhertweck.seatreservation.management.exception.EntranceInUseException;
@@ -175,7 +177,8 @@ public class EntranceServiceTest {
         EntranceRequestDTO dto = new EntranceRequestDTO(eventLocation.id, "B");
 
         assertThrows(
-                SecurityException.class, () -> entranceService.createEntrance(dto, regularAuth));
+                AccessDeniedException.class,
+                () -> entranceService.createEntrance(dto, regularAuth));
         verify(entranceRepository, never()).persist(any(EventLocationEntrance.class));
     }
 
@@ -184,8 +187,7 @@ public class EntranceServiceTest {
         EntranceRequestDTO dto = new EntranceRequestDTO(eventLocation.id, "  ");
 
         assertThrows(
-                IllegalArgumentException.class,
-                () -> entranceService.createEntrance(dto, managerAuth));
+                ValidationException.class, () -> entranceService.createEntrance(dto, managerAuth));
         verify(entranceRepository, never()).persist(any(EventLocationEntrance.class));
     }
 
@@ -214,7 +216,7 @@ public class EntranceServiceTest {
     @Test
     void findEntrancesByLocation_Forbidden_NotOwner() {
         assertThrows(
-                SecurityException.class,
+                AccessDeniedException.class,
                 () -> entranceService.findEntrancesByLocation(otherLocation.id, managerAuth));
     }
 
@@ -258,7 +260,7 @@ public class EntranceServiceTest {
                 .thenReturn(Optional.of(entranceInOtherLocation));
 
         assertThrows(
-                SecurityException.class,
+                AccessDeniedException.class,
                 () ->
                         entranceService.findEntranceByIdForManager(
                                 entranceInOtherLocation.id, managerAuth));
@@ -295,7 +297,7 @@ public class EntranceServiceTest {
         EntranceRequestDTO dto = new EntranceRequestDTO(otherLocation.id, "C");
 
         assertThrows(
-                SecurityException.class,
+                AccessDeniedException.class,
                 () -> entranceService.updateEntrance(existingEntrance.id, dto, managerAuth));
     }
 
@@ -306,7 +308,7 @@ public class EntranceServiceTest {
         EntranceRequestDTO dto = new EntranceRequestDTO(eventLocation.id, "  ");
 
         assertThrows(
-                IllegalArgumentException.class,
+                ValidationException.class,
                 () -> entranceService.updateEntrance(existingEntrance.id, dto, managerAuth));
         verify(entranceRepository, never()).persist(any(EventLocationEntrance.class));
     }
@@ -365,7 +367,7 @@ public class EntranceServiceTest {
     @Test
     void deleteEntrances_InvalidInput_EmptyIds() {
         assertThrows(
-                IllegalArgumentException.class,
+                ValidationException.class,
                 () -> entranceService.deleteEntrances(List.of(), managerAuth));
         verify(entranceRepository, never()).delete(any(EventLocationEntrance.class));
     }

--- a/src/test/java/de/felixhertweck/seatreservation/management/service/EventLocationServiceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/management/service/EventLocationServiceTest.java
@@ -41,6 +41,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import de.felixhertweck.seatreservation.common.dto.CoordinateDTO;
+import de.felixhertweck.seatreservation.common.exception.AccessDeniedException;
+import de.felixhertweck.seatreservation.common.exception.ValidationException;
 import de.felixhertweck.seatreservation.management.dto.EventLocationRequestDTO;
 import de.felixhertweck.seatreservation.management.dto.EventLocationResponseDTO;
 import de.felixhertweck.seatreservation.management.dto.EventLocationUpdateDTO;
@@ -239,7 +241,7 @@ public class EventLocationServiceTest {
         dto.setAddress("Some Address");
 
         assertThrows(
-                IllegalArgumentException.class,
+                ValidationException.class,
                 () -> eventLocationService.createEventLocation(dto, managerAuth));
         verify(eventLocationRepository, never()).persist(any(EventLocation.class));
     }
@@ -280,7 +282,7 @@ public class EventLocationServiceTest {
         when(userRepository.findByIds(List.of(regularUser.id))).thenReturn(List.of(regularUser));
 
         assertThrows(
-                IllegalArgumentException.class,
+                ValidationException.class,
                 () -> eventLocationService.createEventLocation(dto, managerAuth));
         verify(eventLocationRepository, never()).persist(any(EventLocation.class));
     }
@@ -349,7 +351,7 @@ public class EventLocationServiceTest {
         when(userRepository.findByIds(List.of(regularUser.id))).thenReturn(List.of(regularUser));
 
         assertThrows(
-                IllegalArgumentException.class,
+                ValidationException.class,
                 () -> eventLocationService.updateEventLocation(id(1), dto, managerAuth));
         verify(eventLocationRepository, never()).persist(any(EventLocation.class));
     }
@@ -364,7 +366,7 @@ public class EventLocationServiceTest {
                 .thenReturn(Optional.of(existingLocation));
 
         assertThrows(
-                SecurityException.class,
+                AccessDeniedException.class,
                 () -> eventLocationService.updateEventLocation(id(1), dto, regularAuth));
         verify(eventLocationRepository, never()).persist(any(EventLocation.class));
     }
@@ -379,7 +381,7 @@ public class EventLocationServiceTest {
                 .thenReturn(Optional.of(existingLocation));
 
         assertThrows(
-                SecurityException.class,
+                AccessDeniedException.class,
                 () -> eventLocationService.updateEventLocation(id(1), dto, otherManagerAuth));
         verify(eventLocationRepository, never()).persist(any(EventLocation.class));
     }
@@ -427,7 +429,7 @@ public class EventLocationServiceTest {
                 .thenReturn(List.of(existingLocation));
 
         assertThrows(
-                SecurityException.class,
+                AccessDeniedException.class,
                 () -> eventLocationService.deleteEventLocation(List.of(id(1)), regularAuth));
         verify(eventLocationRepository, never()).delete(any(EventLocation.class));
     }
@@ -439,7 +441,7 @@ public class EventLocationServiceTest {
                 .thenReturn(List.of(existingLocation));
 
         assertThrows(
-                SecurityException.class,
+                AccessDeniedException.class,
                 () -> eventLocationService.deleteEventLocation(List.of(id(1)), otherManagerAuth));
         verify(eventLocationRepository, never()).delete(any(EventLocation.class));
     }
@@ -447,7 +449,7 @@ public class EventLocationServiceTest {
     @Test
     void deleteEventLocation_NullIds_ThrowsIllegalArgumentException() {
         assertThrows(
-                IllegalArgumentException.class,
+                ValidationException.class,
                 () -> eventLocationService.deleteEventLocation(null, managerAuth));
         verify(eventLocationRepository, never()).delete(any(EventLocation.class));
     }
@@ -455,7 +457,7 @@ public class EventLocationServiceTest {
     @Test
     void deleteEventLocation_EmptyIds_ThrowsIllegalArgumentException() {
         assertThrows(
-                IllegalArgumentException.class,
+                ValidationException.class,
                 () ->
                         eventLocationService.deleteEventLocation(
                                 Collections.emptyList(), managerAuth));
@@ -490,7 +492,7 @@ public class EventLocationServiceTest {
                 .thenReturn(List.of(existingLocation, unauthorizedLocation));
 
         assertThrows(
-                SecurityException.class,
+                AccessDeniedException.class,
                 () -> eventLocationService.deleteEventLocation(List.of(id(1), id(2)), managerAuth));
 
         verify(eventLocationRepository, never()).delete(any(EventLocation.class));
@@ -503,7 +505,7 @@ public class EventLocationServiceTest {
         dto.setAddress("Some Address");
 
         assertThrows(
-                IllegalArgumentException.class,
+                ValidationException.class,
                 () -> eventLocationService.createEventLocation(dto, managerAuth));
         verify(eventLocationRepository, never()).persist(any(EventLocation.class));
     }
@@ -515,7 +517,7 @@ public class EventLocationServiceTest {
         dto.setAddress(null); // Null address
 
         assertThrows(
-                IllegalArgumentException.class,
+                ValidationException.class,
                 () -> eventLocationService.createEventLocation(dto, managerAuth));
         verify(eventLocationRepository, never()).persist(any(EventLocation.class));
     }
@@ -527,7 +529,7 @@ public class EventLocationServiceTest {
         dto.setAddress("  "); // Empty or blank address
 
         assertThrows(
-                IllegalArgumentException.class,
+                ValidationException.class,
                 () -> eventLocationService.createEventLocation(dto, managerAuth));
         verify(eventLocationRepository, never()).persist(any(EventLocation.class));
     }

--- a/src/test/java/de/felixhertweck/seatreservation/management/service/EventServiceDeleteEventTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/management/service/EventServiceDeleteEventTest.java
@@ -29,6 +29,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
+import de.felixhertweck.seatreservation.common.exception.AccessDeniedException;
 import de.felixhertweck.seatreservation.common.exception.EventNotFoundException;
 import de.felixhertweck.seatreservation.model.entity.Event;
 import de.felixhertweck.seatreservation.model.entity.Roles;
@@ -146,7 +147,7 @@ public class EventServiceDeleteEventTest {
                 .thenReturn(List.of(event1));
 
         assertThrows(
-                SecurityException.class,
+                AccessDeniedException.class,
                 () -> eventService.deleteEvent(List.of(id(101)), otherUser));
 
         verify(eventRepository, never()).delete(any());

--- a/src/test/java/de/felixhertweck/seatreservation/management/service/EventServiceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/management/service/EventServiceTest.java
@@ -42,8 +42,10 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import de.felixhertweck.seatreservation.common.exception.AccessDeniedException;
 import de.felixhertweck.seatreservation.common.exception.EventNotFoundException;
 import de.felixhertweck.seatreservation.common.exception.UserNotFoundException;
+import de.felixhertweck.seatreservation.common.exception.ValidationException;
 import de.felixhertweck.seatreservation.email.service.NotificationService;
 import de.felixhertweck.seatreservation.management.dto.EventRequestDTO;
 import de.felixhertweck.seatreservation.management.dto.EventResponseDTO;
@@ -285,8 +287,7 @@ public class EventServiceTest {
         when(eventLocationRepository.findByIdOptional(any(UUID.class)))
                 .thenReturn(Optional.empty());
 
-        assertThrows(
-                IllegalArgumentException.class, () -> eventService.createEvent(dto, managerUser));
+        assertThrows(ValidationException.class, () -> eventService.createEvent(dto, managerUser));
         verify(eventRepository, never()).persist(any(Event.class));
     }
 
@@ -435,7 +436,7 @@ public class EventServiceTest {
                 .thenReturn(Optional.of(eventLocation));
 
         assertThrows(
-                SecurityException.class,
+                AccessDeniedException.class,
                 () -> eventService.updateEvent(existingEvent.id, dto, regularUser));
         verify(eventRepository, never()).persist(any(Event.class));
     }
@@ -456,7 +457,7 @@ public class EventServiceTest {
                 .thenReturn(Optional.empty());
 
         assertThrows(
-                IllegalArgumentException.class,
+                ValidationException.class,
                 () -> eventService.updateEvent(existingEvent.id, dto, managerUser));
         verify(eventRepository, never()).persist(any(Event.class));
     }
@@ -635,7 +636,7 @@ public class EventServiceTest {
         when(userRepository.findByIdOptional(regularUser.id)).thenReturn(Optional.of(regularUser));
 
         assertThrows(
-                SecurityException.class,
+                AccessDeniedException.class,
                 () ->
                         eventReservationAllowanceService.setReservationsAllowedForUser(
                                 dto, regularAuth));
@@ -750,7 +751,7 @@ public class EventServiceTest {
                 .thenReturn(Optional.of(existingAllowance));
 
         assertThrows(
-                SecurityException.class,
+                AccessDeniedException.class,
                 () ->
                         eventReservationAllowanceService.updateReservationAllowance(
                                 dto, regularUser));
@@ -824,7 +825,7 @@ public class EventServiceTest {
                 .thenReturn(Optional.of(allowance));
 
         assertThrows(
-                SecurityException.class,
+                AccessDeniedException.class,
                 () ->
                         eventReservationAllowanceService.getReservationAllowanceById(
                                 allowance.id, regularUser));
@@ -1170,8 +1171,7 @@ public class EventServiceTest {
                 .thenReturn(Optional.of(eventLocation));
         when(userRepository.findByIds(List.of(regularUser.id))).thenReturn(List.of(regularUser));
 
-        assertThrows(
-                IllegalArgumentException.class, () -> eventService.createEvent(dto, managerUser));
+        assertThrows(ValidationException.class, () -> eventService.createEvent(dto, managerUser));
         verify(eventRepository, never()).persist(any(Event.class));
     }
 
@@ -1208,7 +1208,7 @@ public class EventServiceTest {
         when(userRepository.findByIds(List.of(regularUser.id))).thenReturn(List.of(regularUser));
 
         assertThrows(
-                IllegalArgumentException.class,
+                ValidationException.class,
                 () -> eventService.addManager(existingEvent.id, regularUser.id, managerUser));
         verify(eventRepository, never()).persist(any(Event.class));
     }

--- a/src/test/java/de/felixhertweck/seatreservation/management/service/MarkerServiceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/management/service/MarkerServiceTest.java
@@ -38,6 +38,8 @@ import static org.mockito.Mockito.when;
 
 import de.felixhertweck.seatreservation.common.dto.CoordinateDTO;
 import de.felixhertweck.seatreservation.common.dto.EventLocationMakerDTO;
+import de.felixhertweck.seatreservation.common.exception.AccessDeniedException;
+import de.felixhertweck.seatreservation.common.exception.ValidationException;
 import de.felixhertweck.seatreservation.management.dto.MakerRequestDTO;
 import de.felixhertweck.seatreservation.management.exception.EventLocationNotFoundException;
 import de.felixhertweck.seatreservation.management.exception.MarkerNotFoundException;
@@ -156,7 +158,8 @@ public class MarkerServiceTest {
         MakerRequestDTO dto =
                 new MakerRequestDTO(eventLocation.id, "Stage", new CoordinateDTO(5, 5));
 
-        assertThrows(SecurityException.class, () -> markerService.createMarker(dto, regularAuth));
+        assertThrows(
+                AccessDeniedException.class, () -> markerService.createMarker(dto, regularAuth));
         verify(markerRepository, never()).persist(any(EventLocationMarker.class));
     }
 
@@ -164,8 +167,7 @@ public class MarkerServiceTest {
     void createMarker_InvalidInput_EmptyLabel() {
         MakerRequestDTO dto = new MakerRequestDTO(eventLocation.id, "  ", new CoordinateDTO(5, 5));
 
-        assertThrows(
-                IllegalArgumentException.class, () -> markerService.createMarker(dto, managerAuth));
+        assertThrows(ValidationException.class, () -> markerService.createMarker(dto, managerAuth));
         verify(markerRepository, never()).persist(any(EventLocationMarker.class));
     }
 
@@ -194,7 +196,7 @@ public class MarkerServiceTest {
     @Test
     void findMarkersByLocation_Forbidden_NotOwner() {
         assertThrows(
-                SecurityException.class,
+                AccessDeniedException.class,
                 () -> markerService.findMarkersByLocation(otherLocation.id, managerAuth));
     }
 
@@ -263,7 +265,7 @@ public class MarkerServiceTest {
                 new MakerRequestDTO(otherLocation.id, "Updated", new CoordinateDTO(1, 1));
 
         assertThrows(
-                SecurityException.class,
+                AccessDeniedException.class,
                 () -> markerService.updateMarker(existingMarker.id, dto, managerAuth));
     }
 
@@ -274,7 +276,7 @@ public class MarkerServiceTest {
         MakerRequestDTO dto = new MakerRequestDTO(eventLocation.id, "  ", new CoordinateDTO(1, 1));
 
         assertThrows(
-                IllegalArgumentException.class,
+                ValidationException.class,
                 () -> markerService.updateMarker(existingMarker.id, dto, managerAuth));
         verify(markerRepository, never()).persist(any(EventLocationMarker.class));
     }
@@ -282,7 +284,7 @@ public class MarkerServiceTest {
     @Test
     void deleteMarkers_InvalidInput_EmptyIds() {
         assertThrows(
-                IllegalArgumentException.class,
+                ValidationException.class,
                 () -> markerService.deleteMarkers(List.of(), managerAuth));
         verify(markerRepository, never()).delete(any(EventLocationMarker.class));
     }
@@ -315,7 +317,7 @@ public class MarkerServiceTest {
                 .thenReturn(List.of(markerInOtherLocation));
 
         assertThrows(
-                SecurityException.class,
+                AccessDeniedException.class,
                 () -> markerService.deleteMarkers(List.of(markerInOtherLocation.id), managerAuth));
     }
 }

--- a/src/test/java/de/felixhertweck/seatreservation/management/service/ReservationServiceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/management/service/ReservationServiceTest.java
@@ -43,7 +43,9 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import de.felixhertweck.seatreservation.common.exception.AccessDeniedException;
 import de.felixhertweck.seatreservation.common.exception.ReservationNotFoundException;
+import de.felixhertweck.seatreservation.common.exception.ValidationException;
 import de.felixhertweck.seatreservation.email.service.EmailService;
 import de.felixhertweck.seatreservation.management.dto.ReservationRequestDTO;
 import de.felixhertweck.seatreservation.management.dto.ReservationResponseDTO;
@@ -351,7 +353,7 @@ public class ReservationServiceTest {
         mockSeatFind(dto.getSeatIds(), List.of(seat));
 
         assertThrows(
-                SecurityException.class,
+                AccessDeniedException.class,
                 () -> reservationService.createReservations(dto, regularUser));
     }
 
@@ -369,7 +371,7 @@ public class ReservationServiceTest {
                 .thenReturn(Optional.empty());
 
         assertThrows(
-                IllegalArgumentException.class,
+                ValidationException.class,
                 () -> reservationService.createReservations(dto, adminUser));
     }
 
@@ -388,7 +390,7 @@ public class ReservationServiceTest {
                 .thenReturn(Optional.of(allowance));
 
         assertThrows(
-                IllegalArgumentException.class,
+                ValidationException.class,
                 () -> reservationService.createReservations(dto, managerUser));
     }
 
@@ -426,7 +428,7 @@ public class ReservationServiceTest {
         reservation.getEvent().setManager(otherManager);
 
         assertThrows(
-                SecurityException.class,
+                AccessDeniedException.class,
                 () -> reservationService.findReservationById(reservation.id, managerUser));
     }
 
@@ -457,7 +459,7 @@ public class ReservationServiceTest {
         mockReservationFind(List.of(reservation.id), List.of(reservation));
 
         assertThrows(
-                SecurityException.class,
+                AccessDeniedException.class,
                 () -> reservationService.deleteReservation(List.of(reservation.id), regularUser));
         verify(reservationRepository, never()).delete(any(Reservation.class));
     }
@@ -637,7 +639,7 @@ public class ReservationServiceTest {
         reservation.getEvent().setManager(otherManager);
 
         assertThrows(
-                SecurityException.class,
+                AccessDeniedException.class,
                 () -> reservationService.deleteReservation(List.of(reservation.id), managerUser));
     }
 
@@ -658,7 +660,7 @@ public class ReservationServiceTest {
         when(eventRepository.findByIdOptional(event.id)).thenReturn(Optional.of(event));
 
         assertThrows(
-                SecurityException.class,
+                AccessDeniedException.class,
                 () -> reservationService.blockSeats(event.id, List.of(seat.id), regularUser));
     }
 
@@ -670,7 +672,7 @@ public class ReservationServiceTest {
                 .thenReturn(List.of(reservation));
 
         assertThrows(
-                IllegalStateException.class,
+                ValidationException.class,
                 () -> reservationService.blockSeats(event.id, List.of(seat.id), managerUser));
     }
 
@@ -680,7 +682,7 @@ public class ReservationServiceTest {
         event.setManager(new User()); // Different manager
 
         assertThrows(
-                SecurityException.class,
+                AccessDeniedException.class,
                 () -> reservationService.exportReservationsToPdf(event.id, managerUser));
     }
 

--- a/src/test/java/de/felixhertweck/seatreservation/management/service/SeatServiceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/management/service/SeatServiceTest.java
@@ -41,6 +41,8 @@ import static org.mockito.Mockito.when;
 
 import de.felixhertweck.seatreservation.common.dto.CoordinateDTO;
 import de.felixhertweck.seatreservation.common.dto.SeatDTO;
+import de.felixhertweck.seatreservation.common.exception.AccessDeniedException;
+import de.felixhertweck.seatreservation.common.exception.ValidationException;
 import de.felixhertweck.seatreservation.management.dto.SeatRequestDTO;
 import de.felixhertweck.seatreservation.management.exception.EventLocationNotFoundException;
 import de.felixhertweck.seatreservation.management.exception.SeatNotFoundException;
@@ -267,7 +269,7 @@ public class SeatServiceTest {
                 .thenReturn(Optional.of(eventLocation));
 
         assertThrows(
-                SecurityException.class, () -> seatService.createSeatManager(dto, regularAuth));
+                AccessDeniedException.class, () -> seatService.createSeatManager(dto, regularAuth));
         verify(seatRepository, never()).persist(any(Seat.class));
     }
 
@@ -281,15 +283,13 @@ public class SeatServiceTest {
         when(eventLocationRepository.findByIdOptional(eventLocation.id))
                 .thenReturn(Optional.of(eventLocation));
         assertThrows(
-                IllegalArgumentException.class,
-                () -> seatService.createSeatManager(dto, managerAuth));
+                ValidationException.class, () -> seatService.createSeatManager(dto, managerAuth));
         verify(seatRepository, never()).persist(any(Seat.class));
 
         dto.setSeatNumber("C3");
         dto.setCoordinate(new CoordinateDTO(1, -1)); // Negative coordinate
         assertThrows(
-                IllegalArgumentException.class,
-                () -> seatService.createSeatManager(dto, managerAuth));
+                ValidationException.class, () -> seatService.createSeatManager(dto, managerAuth));
         verify(seatRepository, never()).persist(any(Seat.class));
     }
 
@@ -303,8 +303,7 @@ public class SeatServiceTest {
         when(eventLocationAreaRepository.findByIdOptional(id(999))).thenReturn(Optional.empty());
 
         assertThrows(
-                IllegalArgumentException.class,
-                () -> seatService.createSeatManager(dto, managerAuth));
+                ValidationException.class, () -> seatService.createSeatManager(dto, managerAuth));
         verify(seatRepository, never()).persist(any(Seat.class));
     }
 
@@ -318,8 +317,7 @@ public class SeatServiceTest {
                 .thenReturn(Optional.of(eventLocation));
 
         assertThrows(
-                IllegalArgumentException.class,
-                () -> seatService.createSeatManager(dto, managerAuth));
+                ValidationException.class, () -> seatService.createSeatManager(dto, managerAuth));
         verify(seatRepository, never()).persist(any(Seat.class));
     }
 
@@ -334,8 +332,7 @@ public class SeatServiceTest {
                 .thenReturn(Optional.empty());
 
         assertThrows(
-                IllegalArgumentException.class,
-                () -> seatService.createSeatManager(dto, managerAuth));
+                ValidationException.class, () -> seatService.createSeatManager(dto, managerAuth));
         verify(seatRepository, never()).persist(any(Seat.class));
     }
 
@@ -349,8 +346,7 @@ public class SeatServiceTest {
                 .thenReturn(Optional.of(eventLocation));
 
         assertThrows(
-                IllegalArgumentException.class,
-                () -> seatService.createSeatManager(dto, managerAuth));
+                ValidationException.class, () -> seatService.createSeatManager(dto, managerAuth));
         verify(seatRepository, never()).persist(any(Seat.class));
     }
 
@@ -397,7 +393,7 @@ public class SeatServiceTest {
                 .thenReturn(Optional.of(otherLocation));
 
         assertThrows(
-                SecurityException.class,
+                AccessDeniedException.class,
                 () -> seatService.findSeatsForManagerByLocation(otherLocation.id, managerAuth));
     }
 
@@ -458,7 +454,7 @@ public class SeatServiceTest {
         when(seatRepository.findByIdOptional(seatInOtherLocation.id))
                 .thenReturn(Optional.of(seatInOtherLocation));
         assertThrows(
-                SecurityException.class,
+                AccessDeniedException.class,
                 () -> seatService.findSeatByIdForManager(seatInOtherLocation.id, managerAuth));
     }
 
@@ -531,7 +527,7 @@ public class SeatServiceTest {
                 .thenReturn(Optional.of(eventLocation));
 
         assertThrows(
-                IllegalArgumentException.class,
+                ValidationException.class,
                 () -> seatService.updateSeatForManager(existingSeat.id, dto, managerAuth));
         verify(seatRepository, never()).persist(any(Seat.class));
     }
@@ -551,7 +547,7 @@ public class SeatServiceTest {
                 .thenReturn(Optional.of(eventLocation));
 
         assertThrows(
-                IllegalArgumentException.class,
+                ValidationException.class,
                 () -> seatService.updateSeatForManager(existingSeat.id, dto, managerAuth));
         verify(seatRepository, never()).persist(any(Seat.class));
     }
@@ -609,21 +605,21 @@ public class SeatServiceTest {
                 .thenReturn(Optional.of(eventLocation));
 
         assertThrows(
-                IllegalArgumentException.class,
+                ValidationException.class,
                 () -> seatService.updateSeatForManager(existingSeat.id, dto, managerAuth));
         verify(seatRepository, never()).persist(any(Seat.class));
 
         dto.setSeatNumber("A1");
         dto.setCoordinate(new CoordinateDTO(1, -1)); // Invalid coordinate
         assertThrows(
-                IllegalArgumentException.class,
+                ValidationException.class,
                 () -> seatService.updateSeatForManager(existingSeat.id, dto, managerAuth));
         verify(seatRepository, never()).persist(any(Seat.class));
 
         dto.setCoordinate(new CoordinateDTO(1, 1));
         dto.setSeatRow(""); // Invalid seat row
         assertThrows(
-                IllegalArgumentException.class,
+                ValidationException.class,
                 () -> seatService.updateSeatForManager(existingSeat.id, dto, managerAuth));
         verify(seatRepository, never()).persist(any(Seat.class));
     }
@@ -665,7 +661,7 @@ public class SeatServiceTest {
     @Test
     void deleteSeat_InvalidInput_EmptyIds() {
         assertThrows(
-                IllegalArgumentException.class,
+                ValidationException.class,
                 () -> seatService.deleteSeatForManager(List.of(), managerAuth));
         verify(seatRepository, never()).delete(any(Seat.class));
     }
@@ -688,7 +684,7 @@ public class SeatServiceTest {
                 .thenReturn(Optional.of(otherLocation));
 
         assertThrows(
-                SecurityException.class,
+                AccessDeniedException.class,
                 () -> seatService.updateSeatForManager(seatInOtherLocation.id, dto, managerAuth));
         verify(seatRepository, never()).persist(any(Seat.class));
     }
@@ -710,7 +706,7 @@ public class SeatServiceTest {
                 .thenReturn(Optional.of(newOtherLocation));
 
         assertThrows(
-                SecurityException.class,
+                AccessDeniedException.class,
                 () -> seatService.updateSeatForManager(existingSeat.id, dto, managerAuth));
         verify(seatRepository, never()).persist(any(Seat.class));
     }
@@ -758,7 +754,7 @@ public class SeatServiceTest {
                 .thenReturn(List.of(seatInOtherLocation));
 
         assertThrows(
-                SecurityException.class,
+                AccessDeniedException.class,
                 () ->
                         seatService.deleteSeatForManager(
                                 List.of(seatInOtherLocation.id), managerAuth));
@@ -781,7 +777,7 @@ public class SeatServiceTest {
                 .thenReturn(Optional.of(existingSeat));
 
         assertThrows(
-                SecurityException.class,
+                AccessDeniedException.class,
                 () -> seatService.findSeatEntityById(existingSeat.id, regularAuth));
     }
 }

--- a/src/test/java/de/felixhertweck/seatreservation/management/service/SeatmapCacheServiceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/management/service/SeatmapCacheServiceTest.java
@@ -36,6 +36,7 @@ import static org.mockito.Mockito.when;
 import de.felixhertweck.seatreservation.common.dto.CoordinateDTO;
 import de.felixhertweck.seatreservation.common.dto.EventLocationMakerDTO;
 import de.felixhertweck.seatreservation.common.dto.SeatDTO;
+import de.felixhertweck.seatreservation.common.exception.AccessDeniedException;
 import de.felixhertweck.seatreservation.management.dto.AreaRequestDTO;
 import de.felixhertweck.seatreservation.management.dto.AreaResponseDTO;
 import de.felixhertweck.seatreservation.management.dto.EntranceRequestDTO;
@@ -189,7 +190,7 @@ public class SeatmapCacheServiceTest {
 
         // Unauthorized user attempts to read same locationId
         assertThrows(
-                SecurityException.class,
+                AccessDeniedException.class,
                 () -> seatService.findSeatsForManagerByLocation(locationId, unauthorizedUserAuth));
     }
 

--- a/src/test/java/de/felixhertweck/seatreservation/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/reservation/service/ReservationServiceTest.java
@@ -46,8 +46,10 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import de.felixhertweck.seatreservation.common.exception.AccessDeniedException;
 import de.felixhertweck.seatreservation.common.exception.EventNotFoundException;
 import de.felixhertweck.seatreservation.common.exception.ReservationNotFoundException;
+import de.felixhertweck.seatreservation.common.exception.ValidationException;
 import de.felixhertweck.seatreservation.email.service.EmailService;
 import de.felixhertweck.seatreservation.model.entity.CheckInToken;
 import de.felixhertweck.seatreservation.model.entity.Event;
@@ -211,7 +213,7 @@ class ReservationServiceTest {
         when(reservationRepository.findByIdOptional(id(1))).thenReturn(Optional.of(reservation));
 
         assertThrows(
-                SecurityException.class,
+                AccessDeniedException.class,
                 () -> reservationService.findReservationByIdForUser(id(1), otherUser));
     }
 
@@ -267,7 +269,7 @@ class ReservationServiceTest {
 
         var exception =
                 assertThrows(
-                        IllegalStateException.class,
+                        ValidationException.class,
                         () -> reservationService.createReservationForUser(dto, currentUser));
 
         assertEquals(
@@ -282,7 +284,7 @@ class ReservationServiceTest {
         dto.setSeatIds(Collections.emptySet());
 
         assertThrows(
-                IllegalArgumentException.class,
+                ValidationException.class,
                 () -> reservationService.createReservationForUser(dto, currentUser));
     }
 
@@ -489,7 +491,7 @@ class ReservationServiceTest {
         when(reservationRepository.findByIds(List.of(id(1)))).thenReturn(List.of(reservation));
 
         assertThrows(
-                SecurityException.class,
+                AccessDeniedException.class,
                 () -> reservationService.deleteReservationForUser(List.of(id(1)), otherUser));
     }
 

--- a/src/test/java/de/felixhertweck/seatreservation/supervisor/service/BoxOfficeServiceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/supervisor/service/BoxOfficeServiceTest.java
@@ -43,6 +43,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import de.felixhertweck.seatreservation.common.dto.LimitedUserInfoDTO;
+import de.felixhertweck.seatreservation.common.exception.AccessDeniedException;
+import de.felixhertweck.seatreservation.common.exception.ValidationException;
 import de.felixhertweck.seatreservation.email.service.EmailService;
 import de.felixhertweck.seatreservation.email.service.ReservationEmailContent.BoxOfficeConfirmationContent;
 import de.felixhertweck.seatreservation.model.entity.BoxOfficeGuestInfo;
@@ -208,7 +210,7 @@ class BoxOfficeServiceTest {
         when(eventRepository.isUserSupervisor(EVENT_ID, id(99))).thenReturn(false);
 
         assertThrows(
-                SecurityException.class,
+                AccessDeniedException.class,
                 () -> boxOfficeService.reserveForKnownUser(knownUserRequest(false), unrelated));
         verify(reservationRepository, never()).persistAll(anyList());
     }
@@ -221,7 +223,7 @@ class BoxOfficeServiceTest {
                 .thenReturn(List.of(existing));
 
         assertThrows(
-                IllegalStateException.class,
+                ValidationException.class,
                 () ->
                         boxOfficeService.reserveForKnownUser(
                                 knownUserRequest(false), supervisorAuth()));
@@ -237,7 +239,7 @@ class BoxOfficeServiceTest {
         dto.setDeductAllowance(true);
 
         assertThrows(
-                IllegalArgumentException.class,
+                ValidationException.class,
                 () -> boxOfficeService.reserveForKnownUser(dto, supervisorAuth()));
         verify(reservationRepository, never()).persistAll(anyList());
     }
@@ -356,7 +358,7 @@ class BoxOfficeServiceTest {
                 .thenReturn(List.of(existing));
 
         assertThrows(
-                IllegalStateException.class,
+                ValidationException.class,
                 () ->
                         boxOfficeService.reserveForGuest(
                                 guestRequest(null, false), supervisorAuth()));

--- a/src/test/java/de/felixhertweck/seatreservation/supervisor/service/CheckInServiceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/supervisor/service/CheckInServiceTest.java
@@ -43,6 +43,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import de.felixhertweck.seatreservation.common.exception.AccessDeniedException;
 import de.felixhertweck.seatreservation.model.entity.CheckInToken;
 import de.felixhertweck.seatreservation.model.entity.Event;
 import de.felixhertweck.seatreservation.model.entity.EventLocation;
@@ -488,7 +489,7 @@ class CheckInServiceTest {
         user.setRoles(Set.of(Roles.SUPERVISOR));
         when(eventRepository.isUserSupervisor(eq(eventId), eq(id(1)))).thenReturn(false);
         assertThrows(
-                SecurityException.class,
+                AccessDeniedException.class,
                 () -> checkInService.getUsernamesWithReservations(auth(user), eventId));
     }
 

--- a/src/test/java/de/felixhertweck/seatreservation/userManagment/service/UserServiceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/userManagment/service/UserServiceTest.java
@@ -51,9 +51,11 @@ import static org.mockito.Mockito.when;
 
 import de.felixhertweck.seatreservation.common.dto.LimitedUserInfoDTO;
 import de.felixhertweck.seatreservation.common.dto.UserDTO;
+import de.felixhertweck.seatreservation.common.exception.AccessDeniedException;
 import de.felixhertweck.seatreservation.common.exception.DuplicateUserException;
 import de.felixhertweck.seatreservation.common.exception.InvalidUserException;
 import de.felixhertweck.seatreservation.common.exception.UserNotFoundException;
+import de.felixhertweck.seatreservation.common.exception.ValidationException;
 import de.felixhertweck.seatreservation.email.service.EmailService;
 import de.felixhertweck.seatreservation.model.entity.EmailVerification;
 import de.felixhertweck.seatreservation.model.entity.Roles;
@@ -941,7 +943,8 @@ public class UserServiceTest {
 
         AuthenticatedUser caller = new AuthenticatedUser(id(1), Set.of(Roles.ADMIN));
 
-        assertThrows(SecurityException.class, () -> userService.deleteUser(List.of(id(1)), caller));
+        assertThrows(
+                AccessDeniedException.class, () -> userService.deleteUser(List.of(id(1)), caller));
         verify(userRepository, never()).delete(any(User.class));
     }
 
@@ -967,7 +970,8 @@ public class UserServiceTest {
         // guard should fire here.
         AuthenticatedUser caller = new AuthenticatedUser(id(1), Set.of(Roles.ADMIN));
 
-        assertThrows(SecurityException.class, () -> userService.deleteUser(List.of(id(5)), caller));
+        assertThrows(
+                AccessDeniedException.class, () -> userService.deleteUser(List.of(id(5)), caller));
         verify(userRepository, never()).delete(any(User.class));
     }
 
@@ -1692,26 +1696,26 @@ public class UserServiceTest {
 
     @Test
     void verifyEmailWithCode_BadRequestException_NullCode() {
-        assertThrows(IllegalArgumentException.class, () -> userService.verifyEmailWithCode(null));
+        assertThrows(ValidationException.class, () -> userService.verifyEmailWithCode(null));
     }
 
     @Test
     void verifyEmailWithCode_BadRequestException_EmptyCode() {
-        assertThrows(IllegalArgumentException.class, () -> userService.verifyEmailWithCode(""));
+        assertThrows(ValidationException.class, () -> userService.verifyEmailWithCode(""));
     }
 
     @Test
     void verifyEmailWithCode_BadRequestException_InvalidFormat() {
         assertThrows(
-                IllegalArgumentException.class,
+                ValidationException.class,
                 () -> userService.verifyEmailWithCode("12345")); // 5 digits instead of 6
 
         assertThrows(
-                IllegalArgumentException.class,
+                ValidationException.class,
                 () -> userService.verifyEmailWithCode("abcdef")); // letters instead of digits
 
         assertThrows(
-                IllegalArgumentException.class,
+                ValidationException.class,
                 () -> userService.verifyEmailWithCode("1234567")); // 7 digits instead of 6
     }
 
@@ -1815,7 +1819,7 @@ public class UserServiceTest {
 
         AuthenticatedUser caller = new AuthenticatedUser(id(1), Set.of(Roles.ADMIN));
 
-        assertThrows(SecurityException.class, () -> userService.updateUser(id(1), dto, caller));
+        assertThrows(AccessDeniedException.class, () -> userService.updateUser(id(1), dto, caller));
     }
 
     @Test
@@ -1848,7 +1852,7 @@ public class UserServiceTest {
 
         AuthenticatedUser caller = new AuthenticatedUser(id(1), Set.of(Roles.ADMIN));
 
-        assertThrows(SecurityException.class, () -> userService.updateUser(id(1), dto, caller));
+        assertThrows(AccessDeniedException.class, () -> userService.updateUser(id(1), dto, caller));
 
         verify(emailService, never()).sendPasswordChangedNotification(any(User.class));
         verify(userRepository, never()).persist(any(User.class));
@@ -1878,7 +1882,7 @@ public class UserServiceTest {
 
         AuthenticatedUser caller = new AuthenticatedUser(id(2), Set.of(Roles.ADMIN));
 
-        assertThrows(SecurityException.class, () -> userService.updateUser(id(1), dto, caller));
+        assertThrows(AccessDeniedException.class, () -> userService.updateUser(id(1), dto, caller));
 
         verify(userRepository, never()).persist(any(User.class));
         assertTrue(existingUser.getRoles().isEmpty());
@@ -1912,7 +1916,7 @@ public class UserServiceTest {
 
         when(userRepository.findByIdOptional(id(1))).thenReturn(Optional.of(existingUser));
 
-        assertThrows(SecurityException.class, () -> userService.updateUser(id(1), dto, null));
+        assertThrows(AccessDeniedException.class, () -> userService.updateUser(id(1), dto, null));
 
         verify(userRepository, never()).persist(any(User.class));
     }


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: `GlobalExceptionHandler` returns the raw `exception.getMessage()` for Java standard exceptions like `IllegalArgumentException`, `IllegalStateException`, and `SecurityException`. This risks leaking internal implementation details (e.g., stack traces, SQL errors, or system paths) wrapped within the exception message.
🎯 Impact: An attacker could glean internal details or implementation patterns from verbose Java exceptions, aiding them in exploiting other vulnerabilities.
🔧 Fix: Masked the original exception messages for standard exception types in `GlobalExceptionHandler` with generic, safe responses like "Bad Request" and "Forbidden".
✅ Verification: Added unit tests in `GlobalExceptionHandlerTest` and ran `./mvnw test` to verify that throwing these exceptions returns the expected generic error payload instead of the raw exception message.

---
*PR created automatically by Jules for task [10916682925343056951](https://jules.google.com/task/10916682925343056951) started by @FelixHertweck*