### PR TITLE
⚡ Bolt: Optimize single event lookup

### DIFF
--- a/src/main/java/de/felixhertweck/seatreservation/model/repository/EventUserAllowanceRepository.java
+++ b/src/main/java/de/felixhertweck/seatreservation/model/repository/EventUserAllowanceRepository.java
@@ -135,7 +135,12 @@ public class EventUserAllowanceRepository
      * @return Optional event user allowance entity
      */
     public Optional<EventUserAllowance> findByUserAndEventId(User user, UUID eventId) {
-        return find("user = ?1 and event.id = ?2", user, eventId).firstResultOptional();
+        return find(
+                        "select a from EventUserAllowance a join fetch a.event e left join fetch"
+                                + " e.event_location where a.user = ?1 and a.event.id = ?2",
+                        user,
+                        eventId)
+                .firstResultOptional();
     }
 
     /**

--- a/src/main/java/de/felixhertweck/seatreservation/model/repository/ReservationRepository.java
+++ b/src/main/java/de/felixhertweck/seatreservation/model/repository/ReservationRepository.java
@@ -285,7 +285,12 @@ public class ReservationRepository implements PanacheRepositoryBase<Reservation,
      * @return a list of reservations for the specified user and event
      */
     public List<Reservation> findByUserAndEventId(User user, UUID eventId) {
-        return find("user = ?1 and event.id = ?2", user, eventId).list();
+        return find(
+                        "select r from Reservation r join fetch r.event e left join fetch"
+                                + " e.event_location where r.user = ?1 and r.event.id = ?2",
+                        user,
+                        eventId)
+                .list();
     }
 
     /**

--- a/src/main/java/de/felixhertweck/seatreservation/reservation/service/EventService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/reservation/service/EventService.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -112,30 +113,38 @@ public class EventService {
     public UserEventResponseDTO getEventByIdForCurrentUser(UUID eventId, User user)
             throws EventNotFoundException {
         LOG.debugf("Retrieving event detail for event ID %s, user ID %s", eventId, user.id);
-        List<UserEventResponseDTO> userEvents = getEventsForCurrentUser(user);
-        UserEventResponseDTO userEvent =
-                userEvents.stream()
-                        .filter(e -> e.id().equals(eventId))
-                        .findFirst()
-                        .orElseThrow(
-                                () ->
-                                        new EventNotFoundException(
-                                                "Event with id " + eventId + " not found"));
+
+        Event event = null;
+        int allowedCount = 0;
+
+        Optional<EventUserAllowance> allowanceOpt =
+                eventUserAllowanceRepository.findByUserAndEventId(user, eventId);
+        if (allowanceOpt.isPresent()) {
+            EventUserAllowance allowance = allowanceOpt.get();
+            event = allowance.getEvent();
+            allowedCount = allowance.getReservationsAllowedCount();
+            seatCartService.grantAccess(
+                    event.getId(), user.id, allowance.getReservationsAllowedCount());
+        } else {
+            // BLOCKED reservations must not grant access here, matching
+            // getEventsForCurrentUser()/findByUserWithEvent, which excludes them too.
+            event =
+                    reservationRepository.findByUserAndEventId(user, eventId).stream()
+                            .filter(r -> r.getStatus() != ReservationStatus.BLOCKED)
+                            .findFirst()
+                            .map(Reservation::getEvent)
+                            .orElse(null);
+        }
+
+        if (event == null) {
+            throw new EventNotFoundException("Event with id " + eventId + " not found");
+        }
 
         List<Reservation> reservations =
                 reservationRepository.findByEventIdsWithSeat(Set.of(eventId));
+
         UserEventResponseDTO dtoWithStatuses =
-                new UserEventResponseDTO(
-                        userEvent.id(),
-                        userEvent.name(),
-                        userEvent.description(),
-                        userEvent.startTime(),
-                        userEvent.endTime(),
-                        userEvent.bookingDeadline(),
-                        userEvent.bookingStartTime(),
-                        reservations.stream().map(SeatStatusDTO::new).toList(),
-                        userEvent.locationId(),
-                        userEvent.reservationsAllowed());
+                new UserEventResponseDTO(event, allowedCount, reservations);
 
         return withPendingSeatStatuses(dtoWithStatuses, user.id);
     }

--- a/src/test/java/de/felixhertweck/seatreservation/reservation/service/EventServiceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/reservation/service/EventServiceTest.java
@@ -23,6 +23,7 @@ import static de.felixhertweck.seatreservation.testutil.TestIds.id;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import jakarta.inject.Inject;
@@ -32,6 +33,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import de.felixhertweck.seatreservation.common.exception.EventNotFoundException;
 import de.felixhertweck.seatreservation.model.entity.Event;
 import de.felixhertweck.seatreservation.model.entity.EventLocation;
 import de.felixhertweck.seatreservation.model.entity.EventUserAllowance;
@@ -183,9 +185,8 @@ class EventServiceTest {
     @Test
     void getEventByIdForCurrentUser_MergesPendingSeatStatusesFromCart() {
         UUID pendingSeatId = id(10);
-        when(eventUserAllowanceRepository.findByUserWithEvent(user))
-                .thenReturn(List.of(allowance1));
-        when(reservationRepository.findByUserWithEvent(user)).thenReturn(Collections.emptyList());
+        when(eventUserAllowanceRepository.findByUserAndEventId(user, event1.id))
+                .thenReturn(Optional.of(allowance1));
         mockReservationsByEventQuery(Set.of(event1.id), List.of());
         when(seatCartService.findPendingSeatIds(event1.id, user.id))
                 .thenReturn(Set.of(pendingSeatId));
@@ -217,9 +218,8 @@ class EventServiceTest {
 
     @Test
     void getEventByIdForCurrentUser_PassesCurrentUserIdToExcludeOwnHoldsFromPending() {
-        when(eventUserAllowanceRepository.findByUserWithEvent(user))
-                .thenReturn(List.of(allowance1));
-        when(reservationRepository.findByUserWithEvent(user)).thenReturn(Collections.emptyList());
+        when(eventUserAllowanceRepository.findByUserAndEventId(user, event1.id))
+                .thenReturn(Optional.of(allowance1));
         mockReservationsByEventQuery(Set.of(event1.id), List.of());
         when(seatCartService.findPendingSeatIds(event1.id, user.id))
                 .thenReturn(Collections.emptySet());
@@ -227,6 +227,53 @@ class EventServiceTest {
         eventService.getEventByIdForCurrentUser(event1.id, user);
 
         verify(seatCartService, times(1)).findPendingSeatIds(event1.id, user.id);
+    }
+
+    @Test
+    void getEventByIdForCurrentUser_FallbackToReservationIfNoAllowance() {
+        when(eventUserAllowanceRepository.findByUserAndEventId(user, event1.id))
+                .thenReturn(Optional.empty());
+        when(reservationRepository.findByUserAndEventId(user, event1.id))
+                .thenReturn(List.of(reservation1));
+        mockReservationsByEventQuery(Set.of(event1.id), List.of());
+        when(seatCartService.findPendingSeatIds(event1.id, user.id))
+                .thenReturn(Collections.emptySet());
+
+        UserEventResponseDTO dto = eventService.getEventByIdForCurrentUser(event1.id, user);
+
+        assertNotNull(dto);
+        assertEquals(event1.id, dto.id());
+        assertEquals(0, dto.reservationsAllowed());
+    }
+
+    @Test
+    void getEventByIdForCurrentUser_ThrowsExceptionIfNotFound() {
+        when(eventUserAllowanceRepository.findByUserAndEventId(user, event1.id))
+                .thenReturn(Optional.empty());
+        when(reservationRepository.findByUserAndEventId(user, event1.id))
+                .thenReturn(Collections.emptyList());
+
+        assertThrows(
+                EventNotFoundException.class,
+                () -> {
+                    eventService.getEventByIdForCurrentUser(event1.id, user);
+                });
+    }
+
+    @Test
+    void getEventByIdForCurrentUser_ThrowsExceptionIfOnlyBlockedReservationExists() {
+        reservation1.setStatus(ReservationStatus.BLOCKED);
+
+        when(eventUserAllowanceRepository.findByUserAndEventId(user, event1.id))
+                .thenReturn(Optional.empty());
+        when(reservationRepository.findByUserAndEventId(user, event1.id))
+                .thenReturn(List.of(reservation1));
+
+        assertThrows(
+                EventNotFoundException.class,
+                () -> {
+                    eventService.getEventByIdForCurrentUser(event1.id, user);
+                });
     }
 
     @Test


### PR DESCRIPTION
💡 What: Refactored `getEventByIdForCurrentUser` to use targeted O(1) database queries (`findByUserAndEventId`) to find the requested event directly.
🎯 Why: The previous implementation fetched all events the user had access to and filtered them in-memory, causing major database overhead and N+1-like behavior when finding just a single event.
📊 Impact: Reduces database queries from O(N) to O(1) and decreases memory consumption significantly for the `GET /events/{eventId}` endpoint.
🔬 Measurement: Check the database query logs and measure the response time of the `GET /events/{eventId}` endpoint under load.

---
*PR created automatically by Jules for task [15918923428906830577](https://jules.google.com/task/15918923428906830577) started by @FelixHertweck*