### PR TITLE
refactor(events): decouple EventService and ReservationService via CDI events

### DIFF
--- a/Todo_cdi-event-refactoring.md
+++ b/Todo_cdi-event-refactoring.md
@@ -1,0 +1,111 @@
+# Cross-Domain Service Coupling – Refactoring zu CDI Events
+
+Dieses Dokument beschreibt alle bekannten Stellen im Projekt, an denen Services direkt in eine fremde Domäne injiziert werden, obwohl eine lose Kopplung über CDI Events (`jakarta.enterprise.event.Event`) sauberer wäre.
+
+## Warum CDI Events?
+
+| Direkte Injection (Status quo) | CDI Events (Ziel) |
+|---|---|
+| Aufrufer importiert Klassen der Ziel-Domäne | Aufrufer kennt nur sein eigenes Event-POJO |
+| Neue Integrations-Empfänger erfordern Änderungen am Aufrufer | Neuer Empfänger: einfach `@Observes` hinzufügen, Aufrufer bleibt unberührt |
+| Direkte Abhängigkeitskette erschwert Unit-Tests | Empfänger einzeln testbar, kein Mocking fremder Services nötig |
+| Zirkuläre Abhängigkeiten möglich | Strukturell unmöglich |
+
+CDI Events in Quarkus werden mit `@Inject Event<MyEvent> event; event.fire(new MyEvent(...))` ausgelöst. Für asynchrone Ausführung (z.B. externe API-Calls) `event.fireAsync(...)` verwenden.
+
+---
+
+## Bekannte Cross-Domain-Kopplungen
+
+### 🔴 Priorität Hoch
+
+#### 1. `management.EventService` → `email.NotificationService`
+- **Datei**: `management/service/EventService.java`
+- **Aufrufe**: `notificationService.scheduleEventReminder(event)`, `notificationService.cancelEventReminder(...)`
+- **Ziel-Events**:
+  - `EventCreatedEvent(Event event)`
+  - `EventUpdatedEvent(Event event)` ← wird auch für Google Wallet Sync genutzt (siehe unten)
+  - `EventDeletedEvent(UUID eventId)`
+
+#### 2. `reservation.ReservationService` → `email.EmailService`
+- **Datei**: `reservation/service/ReservationService.java`
+- **Aufrufe**: Bestätigungs-E-Mail beim Erstellen/Stornieren von Reservierungen
+- **Ziel-Events**:
+  - `ReservationCreatedEvent(Reservation reservation, User user)`
+  - `ReservationCancelledEvent(Reservation reservation, User user)`
+
+#### 3. `supervisor.BoxOfficeService` → `email.EmailService` — ⚠️ kein CDI-Event geeignet
+- **Datei**: `supervisor/service/BoxOfficeService.java`
+- **Aufrufe**: `emailService.sendBoxOfficeConfirmation(...)`
+- **Warum kein Event**: `sendBoxOfficeConfirmation(...)` liefert `BoxOfficeConfirmationContent` (u.a.
+  `displayHtml()`) zurück, das `BoxOfficeService` synchron in dieselbe HTTP-Response einbaut (Druck-Beleg
+  für den Schalter). `event.fire()`/`fireAsync()` sind aber grundsätzlich `void` bzw. liefern keinen
+  Rückgabewert eines Observers zurück – das Pattern passt nur für Fire-and-forget-Seiteneffekte.
+  Ein Split (Rendering direkt aufrufen + Versand per Event) würde QR-Code-Generierung und
+  Seatmap-Token-Erzeugung doppelt ausführen (u.a. doppelte `EmailSeatMapToken`-Zeilen in der DB) – das
+  Risiko wiegt den Kopplungs-Vorteil hier nicht auf. Bleibt bewusst als direkte Injection bestehen.
+
+#### 4. `email.EmailSeatMapResource` → `wallet.WalletPassService` — ⚠️ kein CDI-Event geeignet
+- **Datei**: `email/resource/EmailSeatMapResource.java`
+- **Aufrufe**: `walletPassService.generatePass(...)` für Apple/Google-Wallet-Download
+- **Warum kein Event**: Der Resource-Endpunkt braucht das generierte `WalletPassResponseDTO` synchron,
+  um die HTTP-Response (Datei-Download bzw. Redirect) zu bauen. Gleiches Problem wie bei Punkt 3 – ein
+  CDI-Event ohne Rückgabewert kann das nicht abbilden. Der allgemeine Hinweis "Resource-Klassen sollten
+  keine fremden Domain-Services kennen" bleibt gültig, ist hier aber eher ein Fall für eine dünne
+  Fassade *innerhalb* der `email`-Domäne (die intern `WalletPassService` injiziert) als für CDI Events.
+
+### 🟢 Akzeptabel (gleiche Domäne, kein Refactoring nötig)
+
+#### 5. `supervisor.BoxOfficeService` → `supervisor.LiveViewService`
+- Gleiche `supervisor`-Domäne, direkte Kopplung ist hier vertretbar.
+
+#### 6. `supervisor.CheckInService` → `supervisor.LiveViewService`
+- Gleiche `supervisor`-Domäne, direkte Kopplung ist hier vertretbar.
+
+---
+
+## Ziel-Paketstruktur für CDI Events
+
+```
+de.felixhertweck.seatreservation.common.events
+├── EventCreatedEvent.java
+├── EventUpdatedEvent.java
+├── EventDeletedEvent.java
+├── ReservationCreatedEvent.java
+├── ReservationCancelledEvent.java
+└── BoxOfficeReservationCreatedEvent.java
+```
+
+Alle Event-POJOs sind einfache `record`s ohne Business-Logik:
+
+```java
+// Beispiel
+public record EventUpdatedEvent(UUID eventId, String eventName, String locationName,
+                                 String locationAddress, Instant startTime, Instant endTime) {}
+```
+
+---
+
+## Migrations-Anleitung (pro Kopplung)
+
+1. **Event-POJO erstellen** in `common.events`
+2. **`event.fire(new XyzEvent(...))`** im Aufrufer ersetzen (`@Inject Event<XyzEvent>`)
+3. **`@Observes` im Empfänger** hinzufügen (bisherige Logik bleibt gleich)
+4. Direkte `@Inject`-Abhängigkeit im Aufrufer **entfernen**
+5. Tests anpassen
+
+> **Hinweis**: Bei externen API-Calls (z.B. Google Wallet PATCH) `event.fireAsync()` verwenden, damit die REST-Antwort nicht auf den externen Call wartet.
+
+> **Tipp**: Schrittweise Migration möglich – jede Kopplung ist unabhängig migrierbar ohne andere zu beeinflussen.
+
+---
+
+## Status
+
+| Kopplung | Status |
+|---|---|
+| `management.EventService` → `wallet` (Google Wallet Sync) | ✅ Erledigt – CDI Event implementiert |
+| `management.EventService` → `email.NotificationService` | ✅ Erledigt – `EventCreatedEvent`/`EventUpdatedEvent`/`EventDeletedEvent` |
+| `reservation.ReservationService` → `email.EmailService` | ✅ Erledigt – `ReservationCreatedEvent`/`ReservationCancelledEvent` (synchrones `fire()`) |
+| `supervisor.BoxOfficeService` → `email.EmailService` | ❌ Bewusst nicht migriert – Rückgabewert wird synchron für die HTTP-Response gebraucht, siehe Punkt 3 |
+| `email.EmailSeatMapResource` → `wallet.WalletPassService` | ❌ Bewusst nicht migriert – Rückgabewert wird synchron für die HTTP-Response gebraucht, siehe Punkt 4 |

--- a/src/main/java/de/felixhertweck/seatreservation/common/events/EventCreatedEvent.java
+++ b/src/main/java/de/felixhertweck/seatreservation/common/events/EventCreatedEvent.java
@@ -23,15 +23,7 @@ import java.time.Instant;
 import java.util.UUID;
 
 /**
- * Event fired when an Event's details (e.g. name, location, timing) are updated by a manager.
- * Observers can react asynchronously (e.g. updating Google Wallet classes, rescheduling the
- * reminder email).
+ * Event fired when a new Event is created by a manager. Observers can react (e.g. scheduling the
+ * event's reminder email).
  */
-public record EventUpdatedEvent(
-        UUID eventId,
-        String eventName,
-        String locationName,
-        String locationAddress,
-        Instant startTime,
-        Instant endTime,
-        Instant reminderSendDate) {}
+public record EventCreatedEvent(UUID eventId, Instant reminderSendDate) {}

--- a/src/main/java/de/felixhertweck/seatreservation/common/events/EventDeletedEvent.java
+++ b/src/main/java/de/felixhertweck/seatreservation/common/events/EventDeletedEvent.java
@@ -19,19 +19,10 @@
  */
 package de.felixhertweck.seatreservation.common.events;
 
-import java.time.Instant;
 import java.util.UUID;
 
 /**
- * Event fired when an Event's details (e.g. name, location, timing) are updated by a manager.
- * Observers can react asynchronously (e.g. updating Google Wallet classes, rescheduling the
- * reminder email).
+ * Event fired when an Event is deleted by a manager. Observers can react (e.g. cancelling any
+ * reminder scheduled for the event).
  */
-public record EventUpdatedEvent(
-        UUID eventId,
-        String eventName,
-        String locationName,
-        String locationAddress,
-        Instant startTime,
-        Instant endTime,
-        Instant reminderSendDate) {}
+public record EventDeletedEvent(UUID eventId) {}

--- a/src/main/java/de/felixhertweck/seatreservation/common/events/ReservationCancelledEvent.java
+++ b/src/main/java/de/felixhertweck/seatreservation/common/events/ReservationCancelledEvent.java
@@ -19,19 +19,15 @@
  */
 package de.felixhertweck.seatreservation.common.events;
 
-import java.time.Instant;
-import java.util.UUID;
+import java.util.List;
+
+import de.felixhertweck.seatreservation.model.entity.Reservation;
+import de.felixhertweck.seatreservation.model.entity.User;
 
 /**
- * Event fired when an Event's details (e.g. name, location, timing) are updated by a manager.
- * Observers can react asynchronously (e.g. updating Google Wallet classes, rescheduling the
- * reminder email).
+ * Event fired synchronously, while the persistence context is still open, when a user cancels
+ * reservations for an event. Carries both the cancelled reservations and the user's still-active
+ * reservations for the same event, so observers can build an accurate "what's left" confirmation.
  */
-public record EventUpdatedEvent(
-        UUID eventId,
-        String eventName,
-        String locationName,
-        String locationAddress,
-        Instant startTime,
-        Instant endTime,
-        Instant reminderSendDate) {}
+public record ReservationCancelledEvent(
+        User user, List<Reservation> deletedReservations, List<Reservation> activeReservations) {}

--- a/src/main/java/de/felixhertweck/seatreservation/common/events/ReservationCreatedEvent.java
+++ b/src/main/java/de/felixhertweck/seatreservation/common/events/ReservationCreatedEvent.java
@@ -19,19 +19,14 @@
  */
 package de.felixhertweck.seatreservation.common.events;
 
-import java.time.Instant;
-import java.util.UUID;
+import java.util.List;
+
+import de.felixhertweck.seatreservation.model.entity.Reservation;
+import de.felixhertweck.seatreservation.model.entity.User;
 
 /**
- * Event fired when an Event's details (e.g. name, location, timing) are updated by a manager.
- * Observers can react asynchronously (e.g. updating Google Wallet classes, rescheduling the
- * reminder email).
+ * Event fired synchronously, while the persistence context is still open, when a user successfully
+ * creates one or more reservations. Observers can react (e.g. sending a confirmation email) while
+ * the entities are still attached and safe to lazy-load.
  */
-public record EventUpdatedEvent(
-        UUID eventId,
-        String eventName,
-        String locationName,
-        String locationAddress,
-        Instant startTime,
-        Instant endTime,
-        Instant reminderSendDate) {}
+public record ReservationCreatedEvent(User user, List<Reservation> reservations) {}

--- a/src/main/java/de/felixhertweck/seatreservation/email/service/EmailService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/email/service/EmailService.java
@@ -23,8 +23,12 @@ import java.io.IOException;
 import java.time.Instant;
 import java.util.List;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
+import jakarta.persistence.PersistenceException;
 
+import de.felixhertweck.seatreservation.common.events.ReservationCancelledEvent;
+import de.felixhertweck.seatreservation.common.events.ReservationCreatedEvent;
 import de.felixhertweck.seatreservation.common.exception.AccessDeniedException;
 import de.felixhertweck.seatreservation.common.exception.EventNotFoundException;
 import de.felixhertweck.seatreservation.email.service.notifications.EmailConfirmationNotification;
@@ -240,6 +244,34 @@ public class EmailService {
         emailSender.send(
                 new PasswordChangedNotification(
                         user, EMAIL_HEADER_PASSWORD_CHANGED, passwordChangedTemplate));
+    }
+
+    /**
+     * Reacts to a reservation creation by sending the confirmation email. Observed synchronously
+     * (same transaction as the reservation) so the entities are still attached and safe to
+     * lazy-load. Failures are swallowed here rather than propagated, matching the previous
+     * caller-side behavior of not letting a mail failure roll back the reservation.
+     *
+     * @param event the reservation-created notification
+     */
+    public void onReservationCreated(@Observes ReservationCreatedEvent event) {
+        try {
+            sendReservationConfirmation(event.user(), event.reservations());
+        } catch (PersistenceException | IllegalStateException e) {
+            LOG.error("Failed to send reservation confirmation email", e);
+        }
+    }
+
+    /**
+     * Reacts to a reservation cancellation by sending the update confirmation email. Observed
+     * synchronously (same transaction as the cancellation) so the entities are still attached and
+     * safe to lazy-load.
+     *
+     * @param event the reservation-cancelled notification
+     */
+    public void onReservationCancelled(@Observes ReservationCancelledEvent event) {
+        sendUpdateReservationConfirmation(
+                event.user(), event.deletedReservations(), event.activeReservations());
     }
 
     /**

--- a/src/main/java/de/felixhertweck/seatreservation/email/service/NotificationService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/email/service/NotificationService.java
@@ -26,15 +26,21 @@ import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.event.ObservesAsync;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
 
+import de.felixhertweck.seatreservation.common.events.EventCreatedEvent;
+import de.felixhertweck.seatreservation.common.events.EventDeletedEvent;
+import de.felixhertweck.seatreservation.common.events.EventUpdatedEvent;
 import de.felixhertweck.seatreservation.common.exception.AccessDeniedException;
 import de.felixhertweck.seatreservation.common.exception.EventNotFoundException;
 import de.felixhertweck.seatreservation.management.service.EventService;
@@ -66,36 +72,83 @@ public class NotificationService {
     private final Set<String> scheduledJobIds = ConcurrentHashMap.newKeySet();
 
     /**
-     * Schedules a reminder job for the given event.
-     *
-     * @param event The event for which to schedule a reminder
+     * Cache of the reminder time each scheduled job was scheduled for, to avoid redundant
+     * reschedules
      */
-    public void scheduleEventReminder(Event event) {
-        if (event.getReminderSendDate() == null) {
-            LOG.debugf("No reminder date set for event ID: %s, skipping", event.id);
+    private final Map<String, Instant> scheduledReminderTimes = new ConcurrentHashMap<>();
+
+    /**
+     * Reacts to a newly created event by scheduling its reminder job, if any.
+     *
+     * @param event the event-created notification
+     */
+    public void onEventCreated(@Observes EventCreatedEvent event) {
+        if (event.reminderSendDate() != null) {
+            scheduleEventReminder(event.eventId(), event.reminderSendDate());
+        }
+    }
+
+    /**
+     * Reacts to an updated event by rescheduling (or cancelling) its reminder job to match the
+     * event's current reminder date. Other fields (e.g. venue name/address) can also trigger this
+     * event without affecting the reminder, so this is a no-op when the reminder date is unchanged.
+     *
+     * @param event the event-updated notification
+     */
+    public void onEventUpdated(@ObservesAsync EventUpdatedEvent event) {
+        String jobId = reminderJobId(event.eventId());
+        if (Objects.equals(scheduledReminderTimes.get(jobId), event.reminderSendDate())) {
+            LOG.debugf(
+                    "Reminder date for event ID: %s is unchanged, skipping reschedule",
+                    event.eventId());
             return;
         }
+        scheduleEventReminder(event.eventId(), event.reminderSendDate());
+    }
 
-        cancelEventReminder(event.id);
+    /**
+     * Reacts to a deleted event by cancelling any reminder job scheduled for it.
+     *
+     * @param event the event-deleted notification
+     */
+    public void onEventDeleted(@Observes EventDeletedEvent event) {
+        cancelEventReminder(event.eventId());
+    }
+
+    /**
+     * Schedules a reminder job for the given event. Always cancels any previously scheduled job for
+     * the event first, so this also serves as the reschedule/cancel path when {@code
+     * reminderSendDate} changes or is cleared.
+     *
+     * @param eventId The ID of the event for which to schedule a reminder
+     * @param reminderSendDate The time the reminder should be sent, or {@code null} if no reminder
+     *     should be scheduled
+     */
+    public void scheduleEventReminder(UUID eventId, Instant reminderSendDate) {
+        cancelEventReminder(eventId);
+
+        if (reminderSendDate == null) {
+            LOG.debugf("No reminder date set for event ID: %s, skipping", eventId);
+            return;
+        }
 
         // Calculate delay until reminder should be sent
         Instant now = Instant.now();
-        Instant reminderTime = event.getReminderSendDate();
 
-        if (reminderTime.isBefore(now)) {
+        if (reminderSendDate.isBefore(now)) {
             LOG.warnf(
                     "Reminder date %s for event ID: %s is in the past, skipping",
-                    reminderTime, event.id);
+                    reminderSendDate, eventId);
             return;
         }
 
-        long delaySeconds = Duration.between(now, reminderTime).getSeconds();
+        long delaySeconds = Duration.between(now, reminderSendDate).getSeconds();
 
         LOG.infof(
                 "Scheduling reminder for event ID: %s at %s (in %d seconds)",
-                event.id, reminderTime, delaySeconds);
+                eventId, reminderSendDate, delaySeconds);
 
-        String jobId = "reminder-event-" + event.id;
+        String jobId = reminderJobId(eventId);
         // Schedule the reminder job as a one-time task
         // We use a very long interval (1 year) to make it effectively a one-time job
         // The task itself will unschedule the job after execution
@@ -104,11 +157,12 @@ public class NotificationService {
                 .setInterval("365d") // Set a long interval to satisfy the scheduler requirement
                 .setDelayed(delaySeconds + "s") // Set the delay until first execution
                 // Fast enqueue into the email outbox; no extra thread pool needed
-                .setTask(executionContext -> self.sendReminderForEvent(event.id))
+                .setTask(executionContext -> self.sendReminderForEvent(eventId))
                 .schedule();
 
         // Add to cache for efficient lookups
         scheduledJobIds.add(jobId);
+        scheduledReminderTimes.put(jobId, reminderSendDate);
     }
 
     /**
@@ -310,7 +364,8 @@ public class NotificationService {
      * @param eventId The ID of the event
      */
     public void cancelEventReminder(UUID eventId) {
-        String jobId = "reminder-event-" + eventId;
+        String jobId = reminderJobId(eventId);
+        scheduledReminderTimes.remove(jobId);
 
         if (!scheduledJobIds.contains(jobId)) {
             LOG.debugf("No existing reminder job for event ID: %s to cancel.", eventId);
@@ -320,6 +375,16 @@ public class NotificationService {
         scheduler.unscheduleJob(jobId);
         scheduledJobIds.remove(jobId);
         LOG.debugf("Cancelled reminder job for event ID: %s", eventId);
+    }
+
+    /**
+     * Builds the Quartz job ID used to identify the reminder job for the given event.
+     *
+     * @param eventId The ID of the event
+     * @return the job ID
+     */
+    private static String reminderJobId(UUID eventId) {
+        return "reminder-event-" + eventId;
     }
 
     /**

--- a/src/main/java/de/felixhertweck/seatreservation/management/service/EventLocationService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/management/service/EventLocationService.java
@@ -247,7 +247,8 @@ public class EventLocationService {
                             location.getName(),
                             location.getAddress(),
                             ev.getStartTime(),
-                            ev.getEndTime()));
+                            ev.getEndTime(),
+                            ev.getReminderSendDate()));
         }
 
         return new EventLocationResponseDTO(location);

--- a/src/main/java/de/felixhertweck/seatreservation/management/service/EventService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/management/service/EventService.java
@@ -31,11 +31,12 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
 
+import de.felixhertweck.seatreservation.common.events.EventCreatedEvent;
+import de.felixhertweck.seatreservation.common.events.EventDeletedEvent;
 import de.felixhertweck.seatreservation.common.events.EventUpdatedEvent;
 import de.felixhertweck.seatreservation.common.exception.AccessDeniedException;
 import de.felixhertweck.seatreservation.common.exception.EventNotFoundException;
 import de.felixhertweck.seatreservation.common.exception.ValidationException;
-import de.felixhertweck.seatreservation.email.service.NotificationService;
 import de.felixhertweck.seatreservation.management.dto.EventRequestDTO;
 import de.felixhertweck.seatreservation.management.dto.EventResponseDTO;
 import de.felixhertweck.seatreservation.model.entity.Event;
@@ -63,11 +64,13 @@ public class EventService {
 
     @Inject ReservationRepository reservationRepository;
 
-    @Inject NotificationService notificationService;
-
     @Inject EventAccessService eventAccessService;
 
+    @Inject jakarta.enterprise.event.Event<EventCreatedEvent> eventCreatedBus;
+
     @Inject jakarta.enterprise.event.Event<EventUpdatedEvent> eventUpdatedBus;
+
+    @Inject jakarta.enterprise.event.Event<EventDeletedEvent> eventDeletedBus;
 
     /**
      * Creates a new Event and assigns the currently authenticated manager as its creator. Access
@@ -133,10 +136,7 @@ public class EventService {
                 supervisors.size(),
                 event.getManagers().size());
 
-        // Schedule reminder if reminder date is set
-        if (event.getReminderSendDate() != null) {
-            notificationService.scheduleEventReminder(event);
-        }
+        eventCreatedBus.fire(new EventCreatedEvent(event.getId(), event.getReminderSendDate()));
 
         return new EventResponseDTO(event);
     }
@@ -244,23 +244,15 @@ public class EventService {
                 "Event '%s' (ID: %s) updated successfully by manager: %s (ID: %s)",
                 event.getName(), event.getId(), manager.id, manager.getId());
 
-        // Reschedule reminder when event is updated
-        if (event.getReminderSendDate() != null) {
-            notificationService.cancelEventReminder(event.getId());
-            notificationService.scheduleEventReminder(event);
-        } else {
-            // Cancel reminder if reminder date was removed
-            notificationService.cancelEventReminder(event.getId());
-        }
-
         eventUpdatedBus.fireAsync(
-                new de.felixhertweck.seatreservation.common.events.EventUpdatedEvent(
+                new EventUpdatedEvent(
                         event.getId(),
                         event.getName(),
                         location != null ? location.getName() : null,
                         location != null ? location.getAddress() : null,
                         event.getStartTime(),
-                        event.getEndTime()));
+                        event.getEndTime(),
+                        event.getReminderSendDate()));
 
         return new EventResponseDTO(event);
     }
@@ -472,6 +464,7 @@ public class EventService {
             LOG.debugf(
                     "Event '%s' (ID: %s) deleted successfully by user ID: %s (ID: %s)",
                     event.getName(), event.getId(), currentUser.id, currentUser.getId());
+            eventDeletedBus.fire(new EventDeletedEvent(event.getId()));
         }
 
         LOG.infof("Events '%s' deleted successfully", ids);

--- a/src/main/java/de/felixhertweck/seatreservation/reservation/service/ReservationService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/reservation/service/ReservationService.java
@@ -33,11 +33,12 @@ import jakarta.inject.Inject;
 import jakarta.persistence.PersistenceException;
 import jakarta.transaction.Transactional;
 
+import de.felixhertweck.seatreservation.common.events.ReservationCancelledEvent;
+import de.felixhertweck.seatreservation.common.events.ReservationCreatedEvent;
 import de.felixhertweck.seatreservation.common.exception.AccessDeniedException;
 import de.felixhertweck.seatreservation.common.exception.EventNotFoundException;
 import de.felixhertweck.seatreservation.common.exception.ReservationNotFoundException;
 import de.felixhertweck.seatreservation.common.exception.ValidationException;
-import de.felixhertweck.seatreservation.email.service.EmailService;
 import de.felixhertweck.seatreservation.model.entity.CheckInToken;
 import de.felixhertweck.seatreservation.model.entity.Event;
 import de.felixhertweck.seatreservation.model.entity.EventUserAllowance;
@@ -68,9 +69,10 @@ public class ReservationService {
     @Inject EventRepository eventRepository;
     @Inject SeatRepository seatRepository;
     @Inject EventUserAllowanceRepository eventUserAllowanceRepository;
-    @Inject EmailService emailService;
     @Inject SeatCartService seatCartService;
     @Inject CheckInTokenService checkInTokenService;
+    @Inject jakarta.enterprise.event.Event<ReservationCreatedEvent> reservationCreatedBus;
+    @Inject jakarta.enterprise.event.Event<ReservationCancelledEvent> reservationCancelledBus;
 
     /**
      * Retrieves all reservations for the currently authenticated user.
@@ -319,18 +321,7 @@ public class ReservationService {
                 event.id,
                 eventUserAllowance.getReservationsAllowedCount());
 
-        try {
-            LOG.debugf(
-                    "Attempting to send reservation confirmation email to user ID: %s.",
-                    currentUser.id);
-            emailService.sendReservationConfirmation(currentUser, newReservations);
-            LOG.debugf(
-                    "Reservation confirmation email sent to %s for user ID: %s.",
-                    currentUser.id, currentUser.id);
-        } catch (PersistenceException | IllegalStateException e) {
-            // Log the exception, but don't let it fail the transaction
-            LOG.error("Failed to send reservation confirmation email", e);
-        }
+        reservationCreatedBus.fire(new ReservationCreatedEvent(currentUser, newReservations));
 
         return newReservations.stream()
                 .map(UserReservationResponseDTO::new)
@@ -435,8 +426,9 @@ public class ReservationService {
             List<Reservation> activeReservations =
                     reservationRepository.findByUserAndEventId(currentUser, entry.getKey());
 
-            emailService.sendUpdateReservationConfirmation(
-                    currentUser, entry.getValue(), activeReservations);
+            reservationCancelledBus.fire(
+                    new ReservationCancelledEvent(
+                            currentUser, entry.getValue(), activeReservations));
 
             LOG.debugf(
                     "Sent reservation update confirmation for user ID: %s (ID: %s) and reservations"

--- a/src/test/java/de/felixhertweck/seatreservation/management/service/EventServiceDeleteEventTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/management/service/EventServiceDeleteEventTest.java
@@ -29,6 +29,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
+import de.felixhertweck.seatreservation.common.events.EventDeletedEvent;
 import de.felixhertweck.seatreservation.common.exception.AccessDeniedException;
 import de.felixhertweck.seatreservation.common.exception.EventNotFoundException;
 import de.felixhertweck.seatreservation.model.entity.Event;
@@ -44,6 +45,8 @@ import org.mockito.MockitoAnnotations;
 public class EventServiceDeleteEventTest {
 
     @Mock EventRepository eventRepository;
+
+    @Mock jakarta.enterprise.event.Event<EventDeletedEvent> eventDeletedBus;
 
     @InjectMocks EventService eventService;
 

--- a/src/test/java/de/felixhertweck/seatreservation/management/service/EventServiceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/management/service/EventServiceTest.java
@@ -42,11 +42,11 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import de.felixhertweck.seatreservation.common.events.EventCreatedEvent;
 import de.felixhertweck.seatreservation.common.exception.AccessDeniedException;
 import de.felixhertweck.seatreservation.common.exception.EventNotFoundException;
 import de.felixhertweck.seatreservation.common.exception.UserNotFoundException;
 import de.felixhertweck.seatreservation.common.exception.ValidationException;
-import de.felixhertweck.seatreservation.email.service.NotificationService;
 import de.felixhertweck.seatreservation.management.dto.EventRequestDTO;
 import de.felixhertweck.seatreservation.management.dto.EventResponseDTO;
 import de.felixhertweck.seatreservation.management.dto.EventUserAllowanceUpdateDto;
@@ -76,11 +76,18 @@ public class EventServiceTest {
     @InjectMock EventLocationRepository eventLocationRepository;
     @InjectMock UserRepository userRepository;
     @InjectMock EventUserAllowanceRepository eventUserAllowanceRepository;
-    @InjectMock NotificationService notificationService;
+
+    @InjectMock
+    jakarta.enterprise.event.Event<de.felixhertweck.seatreservation.common.events.EventCreatedEvent>
+            eventCreatedBus;
 
     @InjectMock
     jakarta.enterprise.event.Event<de.felixhertweck.seatreservation.common.events.EventUpdatedEvent>
             eventUpdatedBus;
+
+    @InjectMock
+    jakarta.enterprise.event.Event<de.felixhertweck.seatreservation.common.events.EventDeletedEvent>
+            eventDeletedBus;
 
     @Inject EventService eventService;
     @Inject EventReservationAllowanceService eventReservationAllowanceService;
@@ -104,7 +111,6 @@ public class EventServiceTest {
         Mockito.reset(eventLocationRepository);
         Mockito.reset(userRepository);
         Mockito.reset(eventUserAllowanceRepository);
-        Mockito.reset(notificationService);
 
         adminUser =
                 new User(
@@ -949,8 +955,9 @@ public class EventServiceTest {
     }
 
     @Test
-    void createEvent_WithoutReminderSendDate_NoReminderScheduled() {
-        // Event without reminder date should not schedule a reminder
+    void createEvent_WithoutReminderSendDate_FiresCreatedEventWithNullReminder() {
+        // Event without reminder date should still fire EventCreatedEvent, with a null reminder
+        // date -- NotificationService's own observer decides not to schedule anything for that.
         EventRequestDTO dto = new EventRequestDTO();
         dto.setName("Event without Reminder");
         dto.setDescription("Event Description");
@@ -979,13 +986,16 @@ public class EventServiceTest {
         assertEquals("Event without Reminder", createdEvent.name());
         assertEquals(null, createdEvent.reminderSendDate());
         verify(eventRepository, times(1)).persist(any(Event.class));
-        // Verify that no reminder was scheduled
-        verify(notificationService, never()).scheduleEventReminder(any(Event.class));
+
+        ArgumentCaptor<EventCreatedEvent> captor = ArgumentCaptor.forClass(EventCreatedEvent.class);
+        verify(eventCreatedBus, times(1)).fire(captor.capture());
+        assertEquals(id(10), captor.getValue().eventId());
+        assertEquals(null, captor.getValue().reminderSendDate());
     }
 
     @Test
-    void createEvent_WithReminderSendDate_ReminderScheduled() {
-        // Event with reminder date should schedule a reminder
+    void createEvent_WithReminderSendDate_FiresCreatedEventWithReminder() {
+        // Event with reminder date should fire EventCreatedEvent carrying that reminder date
         EventRequestDTO dto = new EventRequestDTO();
         dto.setName("Event with Reminder");
         dto.setDescription("Event Description");
@@ -1015,12 +1025,15 @@ public class EventServiceTest {
         assertEquals("Event with Reminder", createdEvent.name());
         assertEquals(reminderDate, createdEvent.reminderSendDate());
         verify(eventRepository, times(1)).persist(any(Event.class));
-        // Verify that reminder was scheduled
-        verify(notificationService, times(1)).scheduleEventReminder(any(Event.class));
+
+        ArgumentCaptor<EventCreatedEvent> captor = ArgumentCaptor.forClass(EventCreatedEvent.class);
+        verify(eventCreatedBus, times(1)).fire(captor.capture());
+        assertEquals(id(10), captor.getValue().eventId());
+        assertEquals(reminderDate, captor.getValue().reminderSendDate());
     }
 
     @Test
-    void updateEvent_FromNoReminderToReminder_ReminderScheduled() throws Exception {
+    void updateEvent_FromNoReminderToReminder_FiresUpdatedEventWithReminder() throws Exception {
         // Update event from no reminder to having a reminder
         existingEvent.setReminderSendDate(null); // Start without reminder
 
@@ -1047,13 +1060,16 @@ public class EventServiceTest {
         assertEquals("Updated Event", updatedEvent.name());
         assertEquals(newReminderDate, updatedEvent.reminderSendDate());
         verify(eventRepository, times(1)).persist(any(Event.class));
-        // Should cancel old (non-existent) reminder and schedule new one
-        verify(notificationService, times(1)).cancelEventReminder(existingEvent.id);
-        verify(notificationService, times(1)).scheduleEventReminder(any(Event.class));
+
+        ArgumentCaptor<de.felixhertweck.seatreservation.common.events.EventUpdatedEvent> captor =
+                ArgumentCaptor.forClass(
+                        de.felixhertweck.seatreservation.common.events.EventUpdatedEvent.class);
+        verify(eventUpdatedBus, times(1)).fireAsync(captor.capture());
+        assertEquals(newReminderDate, captor.getValue().reminderSendDate());
     }
 
     @Test
-    void updateEvent_FromReminderToNoReminder_ReminderCancelled() throws Exception {
+    void updateEvent_FromReminderToNoReminder_FiresUpdatedEventWithNullReminder() throws Exception {
         // Update event from having a reminder to no reminder
         Instant oldReminderDate = Instant.now().plusSeconds(Duration.ofDays(3).toSeconds());
         existingEvent.setReminderSendDate(oldReminderDate); // Start with reminder
@@ -1080,13 +1096,16 @@ public class EventServiceTest {
         assertEquals("Updated Event", updatedEvent.name());
         assertEquals(null, updatedEvent.reminderSendDate());
         verify(eventRepository, times(1)).persist(any(Event.class));
-        // Should cancel old reminder and not schedule a new one
-        verify(notificationService, times(1)).cancelEventReminder(existingEvent.id);
-        verify(notificationService, never()).scheduleEventReminder(any(Event.class));
+
+        ArgumentCaptor<de.felixhertweck.seatreservation.common.events.EventUpdatedEvent> captor =
+                ArgumentCaptor.forClass(
+                        de.felixhertweck.seatreservation.common.events.EventUpdatedEvent.class);
+        verify(eventUpdatedBus, times(1)).fireAsync(captor.capture());
+        assertEquals(null, captor.getValue().reminderSendDate());
     }
 
     @Test
-    void updateEvent_FromReminderToNewReminder_ReminderRescheduled() throws Exception {
+    void updateEvent_FromReminderToNewReminder_FiresUpdatedEventWithNewReminder() throws Exception {
         // Update event from one reminder time to another
         Instant oldReminderDate = Instant.now().plusSeconds(Duration.ofDays(3).toSeconds());
         existingEvent.setReminderSendDate(oldReminderDate); // Start with old reminder
@@ -1114,9 +1133,12 @@ public class EventServiceTest {
         assertEquals("Updated Event", updatedEvent.name());
         assertEquals(newReminderDate, updatedEvent.reminderSendDate());
         verify(eventRepository, times(1)).persist(any(Event.class));
-        // Should cancel old reminder and schedule new one
-        verify(notificationService, times(1)).cancelEventReminder(existingEvent.id);
-        verify(notificationService, times(1)).scheduleEventReminder(any(Event.class));
+
+        ArgumentCaptor<de.felixhertweck.seatreservation.common.events.EventUpdatedEvent> captor =
+                ArgumentCaptor.forClass(
+                        de.felixhertweck.seatreservation.common.events.EventUpdatedEvent.class);
+        verify(eventUpdatedBus, times(1)).fireAsync(captor.capture());
+        assertEquals(newReminderDate, captor.getValue().reminderSendDate());
     }
 
     @Test

--- a/src/test/java/de/felixhertweck/seatreservation/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/reservation/service/ReservationServiceTest.java
@@ -46,11 +46,12 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import de.felixhertweck.seatreservation.common.events.ReservationCancelledEvent;
+import de.felixhertweck.seatreservation.common.events.ReservationCreatedEvent;
 import de.felixhertweck.seatreservation.common.exception.AccessDeniedException;
 import de.felixhertweck.seatreservation.common.exception.EventNotFoundException;
 import de.felixhertweck.seatreservation.common.exception.ReservationNotFoundException;
 import de.felixhertweck.seatreservation.common.exception.ValidationException;
-import de.felixhertweck.seatreservation.email.service.EmailService;
 import de.felixhertweck.seatreservation.model.entity.CheckInToken;
 import de.felixhertweck.seatreservation.model.entity.Event;
 import de.felixhertweck.seatreservation.model.entity.EventLocation;
@@ -92,7 +93,9 @@ class ReservationServiceTest {
 
     @InjectMock EmailSeatMapTokenRepository emailSeatMapTokenRepository;
 
-    @InjectMock EmailService emailService;
+    @InjectMock jakarta.enterprise.event.Event<ReservationCreatedEvent> reservationCreatedBus;
+
+    @InjectMock jakarta.enterprise.event.Event<ReservationCancelledEvent> reservationCancelledBus;
 
     @InjectMock SeatCartService seatCartService;
 

--- a/src/test/java/de/felixhertweck/seatreservation/wallet/service/GoogleWalletPassGeneratorTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/wallet/service/GoogleWalletPassGeneratorTest.java
@@ -52,7 +52,8 @@ class GoogleWalletPassGeneratorTest {
                         "Main Hall",
                         "123 Music St",
                         Instant.now(),
-                        Instant.now().plusSeconds(3600));
+                        Instant.now().plusSeconds(3600),
+                        null);
 
         assertDoesNotThrow(() -> googleWalletPassGenerator.onEventUpdated(event));
     }
@@ -68,7 +69,8 @@ class GoogleWalletPassGeneratorTest {
                         "Stadthalle",
                         "Haupstrasse 1",
                         Instant.now(),
-                        Instant.now().plusSeconds(7200));
+                        Instant.now().plusSeconds(7200),
+                        null);
 
         // When key file or remote API is missing/unreachable, onEventUpdated catches exception
         // gracefully (best-effort)


### PR DESCRIPTION
Replace direct calls into email.NotificationService/EmailService with EventCreatedEvent/EventUpdatedEvent/EventDeletedEvent and ReservationCreatedEvent/ReservationCancelledEvent, observed by the email domain instead. Fixes a latent gap where deleting an event never cancelled its scheduled reminder.