### PR TITLE
🧹 Remove leftover debugging statements from useWebSocket hook

### DIFF
--- a/webapp/hooks/use-webSocket.ts
+++ b/webapp/hooks/use-webSocket.ts
@@ -47,12 +47,10 @@ export const useWebSocket = (
           console.error(`[WebSocket] Error calling onConnecting:`, err);
         }
       }
-      console.log(`[WebSocket] Connecting to ${url}`);
 
       const ws = new WebSocket(url);
 
       ws.onopen = () => {
-        console.log(`[WebSocket] Connected to ${url}`);
         reconnectAttemptsRef.current = 0;
         setIsConnected(true);
         if (onConnectingRef.current) {
@@ -85,16 +83,12 @@ export const useWebSocket = (
       };
 
       ws.onclose = () => {
-        console.log(`[WebSocket] Connection closed`);
         wsRef.current = null;
         setIsConnected(false);
 
         // Attempt to reconnect
         if (enabled && reconnectAttemptsRef.current < maxReconnectAttempts) {
           reconnectAttemptsRef.current += 1;
-          console.log(
-            `[WebSocket] Attempting to reconnect (${reconnectAttemptsRef.current}/${maxReconnectAttempts}) in ${reconnectDelay}ms`,
-          );
 
           reconnectTimeoutRef.current = setTimeout(() => {
             // call via ref to avoid accessing `connect` before declaration in some lint paths
@@ -134,7 +128,6 @@ export const useWebSocket = (
         );
       }
     }
-    console.log(`[WebSocket] Disconnected`);
   }, []);
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
🎯 **What:** Removed leftover `console.log` debugging statements from `webapp/hooks/use-webSocket.ts`.
💡 **Why:** Cleans up unnecessary console clutter in production environments and improves codebase maintainability.
✅ **Verification:** Ran `npm run lint:check`, `npm run format:check`, and `./mvnw test`.
✨ **Result:** Clean WebSocket hook without noise logs during normal connection lifecycles while preserving error logging.

---
*PR created automatically by Jules for task [15285548703779302231](https://jules.google.com/task/15285548703779302231) started by @FelixHertweck*