### PR TITLE
⚡ Bolt: batch persist BoxOfficeGuestInfo to fix N+1 inserts

### DIFF
--- a/src/main/java/de/felixhertweck/seatreservation/supervisor/service/BoxOfficeService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/supervisor/service/BoxOfficeService.java
@@ -181,10 +181,11 @@ public class BoxOfficeService {
 
         reservationRepository.persistAll(newReservations);
 
-        for (Reservation reservation : newReservations) {
-            boxOfficeGuestInfoRepository.persist(
-                    new BoxOfficeGuestInfo(reservation, dto.getGuestName()));
-        }
+        List<BoxOfficeGuestInfo> guestInfos =
+                newReservations.stream()
+                        .map(r -> new BoxOfficeGuestInfo(r, dto.getGuestName()))
+                        .toList();
+        boxOfficeGuestInfoRepository.persist(guestInfos);
 
         String additionalMailAddress =
                 dto.getGuestEmail() != null && !dto.getGuestEmail().isBlank()

--- a/src/test/java/de/felixhertweck/seatreservation/supervisor/service/BoxOfficeServiceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/supervisor/service/BoxOfficeServiceTest.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.StreamSupport;
 import jakarta.inject.Inject;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -336,10 +337,14 @@ class BoxOfficeServiceTest {
     void reserveForGuest_persistsGuestNameLinkedToEachReservation() {
         boxOfficeService.reserveForGuest(guestRequest(null, false), supervisorAuth());
 
-        ArgumentCaptor<BoxOfficeGuestInfo> captor =
-                ArgumentCaptor.forClass(BoxOfficeGuestInfo.class);
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Iterable<BoxOfficeGuestInfo>> captor =
+                ArgumentCaptor.forClass(Iterable.class);
         verify(boxOfficeGuestInfoRepository, times(1)).persist(captor.capture());
-        assertEquals("Jane Doe", captor.getValue().getGuestName());
+        List<BoxOfficeGuestInfo> list =
+                StreamSupport.stream(captor.getValue().spliterator(), false).toList();
+        assertEquals(1, list.size());
+        assertEquals("Jane Doe", list.getFirst().getGuestName());
     }
 
     @Test


### PR DESCRIPTION
💡 What: Replaced individual `boxOfficeGuestInfoRepository.persist()` calls in a loop with batch persistence using `boxOfficeGuestInfoRepository.persist(guestInfos)`.
🎯 Why: Fixes an N+1 SQL insert problem when creating guest reservations for multiple seats at the box office.
📊 Impact: Reduces database round-trips from N calls to a single batch call when saving guest reservation info.
🔬 Measurement: Verified unit tests and repository batch persistence calls.

---
*PR created automatically by Jules for task [7654098589586677327](https://jules.google.com/task/7654098589586677327) started by @FelixHertweck*