### PR TITLE
🔒 Enforce strict SVG profile sanitization for email seatmap rendering

### DIFF
--- a/webapp/app/[locale]/email/seatmap/page.tsx
+++ b/webapp/app/[locale]/email/seatmap/page.tsx
@@ -80,7 +80,11 @@ export default function EmailSeatmapPage() {
 
         // Convert Blob to SVG text
         const svg = await response.data.text();
-        setSvgContent(DOMPurify.sanitize(svg));
+        setSvgContent(
+          DOMPurify.sanitize(svg, {
+            USE_PROFILES: { svg: true, svgFilters: true },
+          }),
+        );
       } catch (err) {
         const errorMessage =
           err instanceof Error


### PR DESCRIPTION
🎯 **What:** Enforce strict SVG profile sanitization on email seatmap rendering.
⚠️ **Risk:** Rendering SVG content via dangerouslySetInnerHTML without explicit SVG profile restrictions could expose users to XSS attacks if malicious script tags or handlers bypass default sanitization.
🛡️ **Solution:** Explicitly pass `{ USE_PROFILES: { svg: true, svgFilters: true } }` options to `DOMPurify.sanitize()` prior to rendering via `dangerouslySetInnerHTML`.

---
*PR created automatically by Jules for task [5629157919874060969](https://jules.google.com/task/5629157919874060969) started by @FelixHertweck*