### PR TITLE
⚡ Bolt: Batch delete reservations in management ReservationService

### DIFF
--- a/src/main/java/de/felixhertweck/seatreservation/management/service/ReservationService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/management/service/ReservationService.java
@@ -67,7 +67,6 @@ import org.jboss.logging.Logger;
 public class ReservationService {
 
     private static final Logger LOG = Logger.getLogger(ReservationService.class);
-    private static final String ID_IN_QUERY = "id in ?1";
 
     @ConfigProperty(name = "exporter.pdf.minutesBeforeEventStart", defaultValue = "10")
     Integer EXPORTER_PDF_MINUTES_BEFORE_EVENT_START;
@@ -368,8 +367,6 @@ public class ReservationService {
                 throw new AccessDeniedException("You are not allowed to delete this reservation.");
             }
 
-            reservationRepository.delete(reservation);
-
             if (reservation.getStatus() == ReservationStatus.RESERVED) {
                 LOG.debugf(
                         "Adding reservation ID %s to deleted reservations for email notification.",
@@ -377,6 +374,8 @@ public class ReservationService {
                 deletedReservations.add(reservation);
             }
         }
+
+        reservationRepository.deleteByIds(ids);
 
         // Restore allowance counts, grouped by event so each event needs only one allowance
         // lookup regardless of how many of its reservations were deleted.

--- a/src/main/java/de/felixhertweck/seatreservation/model/repository/ReservationRepository.java
+++ b/src/main/java/de/felixhertweck/seatreservation/model/repository/ReservationRepository.java
@@ -75,6 +75,19 @@ public class ReservationRepository implements PanacheRepositoryBase<Reservation,
     }
 
     /**
+     * Deletes all reservations matching the given IDs in a single batch operation.
+     *
+     * @param ids the reservation IDs to delete
+     * @return the number of reservations deleted
+     */
+    public long deleteByIds(List<UUID> ids) {
+        if (ids == null || ids.isEmpty()) {
+            return 0;
+        }
+        return delete("id in ?1", ids);
+    }
+
+    /**
      * Finds all reservations for a collection of event IDs, eagerly fetching each reservation's
      * seat.
      *

--- a/src/main/java/de/felixhertweck/seatreservation/reservation/service/ReservationService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/reservation/service/ReservationService.java
@@ -63,7 +63,6 @@ import org.jboss.logging.Logger;
 public class ReservationService {
 
     private static final Logger LOG = Logger.getLogger(ReservationService.class);
-    private static final String ID_IN_QUERY = "id in ?1";
 
     @Inject ReservationRepository reservationRepository;
     @Inject EventRepository eventRepository;
@@ -145,7 +144,7 @@ public class ReservationService {
             throws NoSeatsAvailableException, EventBookingClosedException {
         LOG.debugf(
                 "Attempting to create reservation for user ID: %s for event ID %s with %d seats.",
-                currentUser.id, dto.getEventId(), (Integer) dto.getSeatIds().size());
+                currentUser.id, dto.getEventId(), dto.getSeatIds().size());
         LOG.debugf("ReservationsRequestDTO: %s", dto.toString());
 
         if (currentUser.getEmail() == null
@@ -417,7 +416,7 @@ public class ReservationService {
 
             // Delete reservations for the current event in a single batch query
             List<UUID> reservationIdsToDelete = entry.getValue().stream().map(r -> r.id).toList();
-            reservationRepository.delete(ID_IN_QUERY, reservationIdsToDelete);
+            reservationRepository.deleteByIds(reservationIdsToDelete);
             LOG.infof(
                     "Deleted reservations with IDs %s for user ID: %s.",
                     reservationIdsToDelete, currentUser.id);

--- a/src/test/java/de/felixhertweck/seatreservation/management/service/ReservationServiceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/management/service/ReservationServiceTest.java
@@ -73,7 +73,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 @QuarkusTest
-public class ReservationServiceTest {
+class ReservationServiceTest {
 
     @InjectMock ReservationRepository reservationRepository;
     @InjectMock EventRepository eventRepository;
@@ -440,7 +440,7 @@ public class ReservationServiceTest {
 
         reservationService.deleteReservation(List.of(reservation.id), adminUser);
 
-        verify(reservationRepository, times(1)).delete(reservation);
+        verify(reservationRepository, times(1)).deleteByIds(List.of(reservation.id));
     }
 
     @Test
@@ -451,17 +451,18 @@ public class ReservationServiceTest {
 
         reservationService.deleteReservation(List.of(reservation.id), managerUser);
 
-        verify(reservationRepository, times(1)).delete(reservation);
+        verify(reservationRepository, times(1)).deleteByIds(List.of(reservation.id));
     }
 
     @Test
     void deleteReservation_Forbidden() {
         mockReservationFind(List.of(reservation.id), List.of(reservation));
+        List<UUID> ids = List.of(reservation.id);
 
         assertThrows(
                 AccessDeniedException.class,
-                () -> reservationService.deleteReservation(List.of(reservation.id), regularUser));
-        verify(reservationRepository, never()).delete(any(Reservation.class));
+                () -> reservationService.deleteReservation(ids, regularUser));
+        verify(reservationRepository, never()).deleteByIds(any());
     }
 
     @Test
@@ -476,7 +477,7 @@ public class ReservationServiceTest {
 
         reservationService.deleteReservation(List.of(reservation.id), managerUser);
 
-        verify(reservationRepository, times(1)).delete(reservation);
+        verify(reservationRepository, times(1)).deleteByIds(List.of(reservation.id));
         verify(eventUserAllowanceRepository, times(1)).persist(allowance);
         assertEquals(1, allowance.getReservationsAllowedCount()); // Allowance should be incremented
     }
@@ -490,7 +491,7 @@ public class ReservationServiceTest {
         // Should not throw exception when no allowance exists
         reservationService.deleteReservation(List.of(reservation.id), managerUser);
 
-        verify(reservationRepository, times(1)).delete(reservation);
+        verify(reservationRepository, times(1)).deleteByIds(List.of(reservation.id));
         verify(eventUserAllowanceRepository, never())
                 .persist(any(EventUserAllowance.class)); // Should not persist allowance
     }
@@ -512,7 +513,7 @@ public class ReservationServiceTest {
 
         reservationService.deleteReservation(List.of(blockedReservation.id), managerUser);
 
-        verify(reservationRepository, times(1)).delete(blockedReservation);
+        verify(reservationRepository, times(1)).deleteByIds(List.of(blockedReservation.id));
         // Verify allowance was never updated for blocked reservations
         verify(eventUserAllowanceRepository, never()).persist(any(EventUserAllowance.class));
     }
@@ -544,8 +545,8 @@ public class ReservationServiceTest {
 
         reservationService.deleteReservation(List.of(reservation.id, reservation2.id), managerUser);
 
-        verify(reservationRepository, times(1)).delete(reservation);
-        verify(reservationRepository, times(1)).delete(reservation2);
+        verify(reservationRepository, times(1))
+                .deleteByIds(List.of(reservation.id, reservation2.id));
         // Allowance should be incremented twice (once for each reservation)
         verify(eventUserAllowanceRepository, times(2)).persist(allowance);
         assertEquals(2, allowance.getReservationsAllowedCount());
@@ -597,8 +598,8 @@ public class ReservationServiceTest {
         reservationService.deleteReservation(
                 List.of(blockedReservation.id, reservedReservation.id), managerUser);
 
-        verify(reservationRepository, times(1)).delete(blockedReservation);
-        verify(reservationRepository, times(1)).delete(reservedReservation);
+        verify(reservationRepository, times(1))
+                .deleteByIds(List.of(blockedReservation.id, reservedReservation.id));
         // Allowance should be incremented only once (for the reserved reservation)
         verify(eventUserAllowanceRepository, times(1)).persist(allowance);
         assertEquals(1, allowance.getReservationsAllowedCount());
@@ -616,18 +617,19 @@ public class ReservationServiceTest {
 
         reservationService.deleteReservation(List.of(reservation.id), managerUser);
 
-        verify(reservationRepository, times(1)).delete(reservation);
+        verify(reservationRepository, times(1)).deleteByIds(List.of(reservation.id));
         verify(eventUserAllowanceRepository, times(1)).persist(allowance);
         assertEquals(6, allowance.getReservationsAllowedCount());
     }
 
     @Test
     void findReservationById_NotFoundException() {
-        when(reservationRepository.findByIdOptional(id(99))).thenReturn(Optional.empty());
+        UUID notFoundId = id(99);
+        when(reservationRepository.findByIdOptional(notFoundId)).thenReturn(Optional.empty());
 
         assertThrows(
                 ReservationNotFoundException.class,
-                () -> reservationService.findReservationById(id(99), adminUser));
+                () -> reservationService.findReservationById(notFoundId, adminUser));
     }
 
     @Test
@@ -637,10 +639,11 @@ public class ReservationServiceTest {
         otherManager.id = id(4);
         otherManager.setRoles(Set.of(Roles.MANAGER));
         reservation.getEvent().setManager(otherManager);
+        List<UUID> ids = List.of(reservation.id);
 
         assertThrows(
                 AccessDeniedException.class,
-                () -> reservationService.deleteReservation(List.of(reservation.id), managerUser));
+                () -> reservationService.deleteReservation(ids, managerUser));
     }
 
     @Test
@@ -658,10 +661,11 @@ public class ReservationServiceTest {
     @Test
     void blockSeats_Forbidden() {
         when(eventRepository.findByIdOptional(event.id)).thenReturn(Optional.of(event));
+        List<UUID> seatIds = List.of(seat.id);
 
         assertThrows(
                 AccessDeniedException.class,
-                () -> reservationService.blockSeats(event.id, List.of(seat.id), regularUser));
+                () -> reservationService.blockSeats(event.id, seatIds, regularUser));
     }
 
     @Test
@@ -670,10 +674,11 @@ public class ReservationServiceTest {
         mockSeatFind(List.of(seat.id), List.of(seat));
         when(reservationRepository.findByEventIdAndSeatIds(event.id, List.of(seat.id)))
                 .thenReturn(List.of(reservation));
+        List<UUID> seatIds = List.of(seat.id);
 
         assertThrows(
                 ValidationException.class,
-                () -> reservationService.blockSeats(event.id, List.of(seat.id), managerUser));
+                () -> reservationService.blockSeats(event.id, seatIds, managerUser));
     }
 
     @Test


### PR DESCRIPTION
💡 **What:** Replaced individual `reservationRepository.delete(reservation)` loop calls with a single `reservationRepository.delete(ID_IN_QUERY, ids)` batch delete in `ReservationService.deleteReservation`.

🎯 **Why:** Replaces N individual SQL `DELETE` queries with 1 batch `DELETE` query, eliminating the N+1 database roundtrips.

📊 **Impact:** O(N) database deletion calls reduced to O(1) query, drastically improving execution time and database IOPS when deleting bulk reservations.

🔬 **Measurement:** Batch delete query confirmed via unit test verification and mock expectations in `ReservationServiceTest`.

---
*PR created automatically by Jules for task [2063613030021318042](https://jules.google.com/task/2063613030021318042) started by @FelixHertweck*