### PR TITLE
refactor(backend): encapsulate raw JPQL queries in named repository methods

### DIFF
--- a/src/main/java/de/felixhertweck/seatreservation/model/repository/EmailVerificationRepository.java
+++ b/src/main/java/de/felixhertweck/seatreservation/model/repository/EmailVerificationRepository.java
@@ -19,6 +19,7 @@
  */
 package de.felixhertweck.seatreservation.model.repository;
 
+import java.time.Instant;
 import java.util.Optional;
 import java.util.UUID;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -95,5 +96,18 @@ public class EmailVerificationRepository implements PanacheRepositoryBase<EmailV
             LOG.debug("No EmailVerification found for token.");
         }
         return result;
+    }
+
+    /**
+     * Deletes all email verification entries whose expiration time is before {@code now}.
+     *
+     * @param now the reference instant; all entries with {@code expirationTime < now} are deleted
+     * @return the number of deleted entries
+     */
+    public long deleteExpired(Instant now) {
+        LOG.debugf("Deleting expired email verification entries (before %s).", now);
+        long deletedCount = delete("expirationTime < ?1", now);
+        LOG.debugf("Deleted %d expired email verification entries.", deletedCount);
+        return deletedCount;
     }
 }

--- a/src/main/java/de/felixhertweck/seatreservation/model/repository/RefreshTokenRepository.java
+++ b/src/main/java/de/felixhertweck/seatreservation/model/repository/RefreshTokenRepository.java
@@ -19,6 +19,7 @@
  */
 package de.felixhertweck.seatreservation.model.repository;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -59,5 +60,15 @@ public class RefreshTokenRepository implements PanacheRepositoryBase<RefreshToke
      */
     public boolean deleteWithIdAndUser(UUID id, User user) {
         return delete("id = ?1 and user = ?2", id, user) > 0;
+    }
+
+    /**
+     * Deletes all refresh tokens that expired before {@code cutoff}.
+     *
+     * @param cutoff the reference instant; all tokens with {@code expiresAt < cutoff} are deleted
+     * @return the number of deleted tokens
+     */
+    public long deleteExpired(Instant cutoff) {
+        return delete("expiresAt < ?1", cutoff);
     }
 }

--- a/src/main/java/de/felixhertweck/seatreservation/model/repository/TwoFactorChallengeRepository.java
+++ b/src/main/java/de/felixhertweck/seatreservation/model/repository/TwoFactorChallengeRepository.java
@@ -19,6 +19,7 @@
  */
 package de.felixhertweck.seatreservation.model.repository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -27,10 +28,13 @@ import jakarta.transaction.Transactional;
 import de.felixhertweck.seatreservation.model.entity.TwoFactorChallenge;
 import de.felixhertweck.seatreservation.model.entity.User;
 import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
+import org.jboss.logging.Logger;
 
 @ApplicationScoped
 public class TwoFactorChallengeRepository
         implements PanacheRepositoryBase<TwoFactorChallenge, UUID> {
+
+    private static final Logger LOG = Logger.getLogger(TwoFactorChallengeRepository.class);
 
     public Optional<TwoFactorChallenge> findByChallengeToken(String challengeToken) {
         return find("challengeToken", challengeToken).firstResultOptional();
@@ -39,5 +43,16 @@ public class TwoFactorChallengeRepository
     @Transactional
     public void deleteByUser(User user) {
         delete("user", user);
+    }
+
+    /**
+     * Returns all unused 2FA challenges for the given user.
+     *
+     * @param user the user whose unused challenges to retrieve
+     * @return a list of unused {@link TwoFactorChallenge} entities for {@code user}
+     */
+    public List<TwoFactorChallenge> findUnusedByUser(User user) {
+        LOG.debugf("Finding unused 2FA challenges for user ID: %s", user.id);
+        return list("user = ?1 and used = false", user);
     }
 }

--- a/src/main/java/de/felixhertweck/seatreservation/model/repository/UserRepository.java
+++ b/src/main/java/de/felixhertweck/seatreservation/model/repository/UserRepository.java
@@ -125,6 +125,22 @@ public class UserRepository implements PanacheRepositoryBase<User, UUID> {
     }
 
     /**
+     * Deletes users by their IDs in a single batch query.
+     *
+     * @param ids the IDs of the users to delete
+     * @return the number of users deleted
+     */
+    public long deleteByIds(List<UUID> ids) {
+        if (ids == null || ids.isEmpty()) {
+            return 0;
+        }
+        LOG.debugf("Batch deleting users with IDs: %s.", ids);
+        long deletedCount = delete("id in ?1", ids);
+        LOG.infof("Batch deleted %d users.", deletedCount);
+        return deletedCount;
+    }
+
+    /**
      * Finds which of the given usernames already exist, used to batch-check duplicates for a bulk
      * user import instead of querying once per username.
      *

--- a/src/main/java/de/felixhertweck/seatreservation/scheduler/DatabaseCleanup.java
+++ b/src/main/java/de/felixhertweck/seatreservation/scheduler/DatabaseCleanup.java
@@ -103,7 +103,7 @@ public class DatabaseCleanup {
             Instant now = Instant.now();
 
             // Delete all expired email verification entries
-            long deletedCount = emailVerificationRepository.delete("expirationTime < ?1", now);
+            long deletedCount = emailVerificationRepository.deleteExpired(now);
 
             if (deletedCount > 0) {
                 LOG.infof(
@@ -131,7 +131,7 @@ public class DatabaseCleanup {
             // Delete tokens that expired more than 1 day ago
             Instant oneDayAgo = Instant.now().minus(1, ChronoUnit.DAYS);
 
-            long deletedCount = refreshTokenRepository.delete("expiresAt < ?1", oneDayAgo);
+            long deletedCount = refreshTokenRepository.deleteExpired(oneDayAgo);
 
             if (deletedCount > 0) {
                 LOG.infof(
@@ -154,7 +154,7 @@ public class DatabaseCleanup {
     public int manualCleanupExpiredEmailVerifications() {
         LOG.info("Manual cleanup of expired email verifications triggered.");
         Instant now = Instant.now();
-        long deletedCount = emailVerificationRepository.delete("expirationTime < ?1", now);
+        long deletedCount = emailVerificationRepository.deleteExpired(now);
         LOG.infof("Manually cleaned up %d expired email verification entries.", deletedCount);
         return (int) deletedCount;
     }
@@ -168,7 +168,7 @@ public class DatabaseCleanup {
     public int manualCleanupExpiredRefreshTokens() {
         LOG.info("Manual cleanup of expired refresh tokens triggered.");
         Instant oneDayAgo = Instant.now().minus(1, ChronoUnit.DAYS);
-        long deletedCount = refreshTokenRepository.delete("expiresAt < ?1", oneDayAgo);
+        long deletedCount = refreshTokenRepository.deleteExpired(oneDayAgo);
         LOG.infof("Manually cleaned up %d expired refresh tokens.", deletedCount);
         return (int) deletedCount;
     }

--- a/src/main/java/de/felixhertweck/seatreservation/security/service/EmailSecondFactor.java
+++ b/src/main/java/de/felixhertweck/seatreservation/security/service/EmailSecondFactor.java
@@ -54,8 +54,7 @@ public class EmailSecondFactor implements SecondFactor {
                 || code.isBlank()) {
             return false;
         }
-        List<TwoFactorChallenge> challenges =
-                challengeRepository.list("user = ?1 and used = false", user);
+        List<TwoFactorChallenge> challenges = challengeRepository.findUnusedByUser(user);
         for (TwoFactorChallenge ch : challenges) {
             if (ch.getEmailCode() != null
                     && SecurityUtils.constantTimeEquals(ch.getEmailCode(), code.trim())

--- a/src/main/java/de/felixhertweck/seatreservation/userManagment/service/UserService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/userManagment/service/UserService.java
@@ -534,7 +534,7 @@ public class UserService {
             }
         }
 
-        userRepository.delete("id in ?1", ids);
+        userRepository.deleteByIds(ids);
 
         LOG.infof("Users with IDs %s deleted successfully.", ids);
     }

--- a/src/test/java/de/felixhertweck/seatreservation/userManagment/service/UserServiceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/userManagment/service/UserServiceTest.java
@@ -902,14 +902,14 @@ public class UserServiceTest {
         existingUser.id = id(1);
 
         when(userRepository.findByIds(List.of(id(1)))).thenReturn(List.of(existingUser));
-        when(userRepository.delete("id in ?1", List.of(id(1)))).thenReturn(1L);
+        when(userRepository.deleteByIds(List.of(id(1)))).thenReturn(1L);
 
         // the caller has a different id
         AuthenticatedUser caller = new AuthenticatedUser(id(2), Set.of(Roles.ADMIN));
 
         userService.deleteUser(List.of(id(1)), caller);
 
-        verify(userRepository, times(1)).delete("id in ?1", List.of(id(1)));
+        verify(userRepository, times(1)).deleteByIds(List.of(id(1)));
     }
 
     @Test


### PR DESCRIPTION
Move raw Panache query strings out of services and 
the scheduler into dedicated named methods on their 
respective repositories.