### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix unhandled UUID parsing exception in JWT

### DIFF
--- a/src/main/java/de/felixhertweck/seatreservation/utils/UserSecurityContext.java
+++ b/src/main/java/de/felixhertweck/seatreservation/utils/UserSecurityContext.java
@@ -27,6 +27,7 @@ import jakarta.inject.Inject;
 import de.felixhertweck.seatreservation.common.exception.UserNotFoundException;
 import de.felixhertweck.seatreservation.model.entity.User;
 import de.felixhertweck.seatreservation.model.repository.UserRepository;
+import de.felixhertweck.seatreservation.security.exceptions.JwtInvalidException;
 import io.quarkus.security.identity.SecurityIdentity;
 import org.eclipse.microprofile.jwt.JsonWebToken;
 
@@ -67,8 +68,12 @@ public class UserSecurityContext {
         if (uidClaim == null) {
             throw new IllegalStateException("JWT missing uid claim");
         }
-        UUID id = UUID.fromString(uidClaim.toString());
-        return new AuthenticatedUser(id, securityIdentity.getRoles());
+        try {
+            UUID id = UUID.fromString(uidClaim.toString());
+            return new AuthenticatedUser(id, securityIdentity.getRoles());
+        } catch (IllegalArgumentException e) {
+            throw new JwtInvalidException("Invalid uid in JWT", e);
+        }
     }
 
     /**


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Parsing a malformed UUID from the JWT `uid` claim throws an unhandled `IllegalArgumentException`, bypassing mapped error handling and causing an application crash or generic 500 error instead of a secure 401 Unauthorized response.
🎯 Impact: An attacker or a user with a corrupted JWT can cause internal server errors and potentially leak stack traces or cause localized denial of service if unhandled exceptions bypass global security handlers.
🔧 Fix: Wrapped `UUID.fromString` in a `try-catch` block within `UserSecurityContext.getAuthenticatedUser()` to catch `IllegalArgumentException` and safely throw a `JwtInvalidException`.
✅ Verification: Ran the test suite. The existing `UserSecurityContextTest` passes and verifies that standard behavior remains intact. Invalid IDs would now throw a JwtInvalidException and map to 401 Unauthorized via the GlobalExceptionHandler.

---
*PR created automatically by Jules for task [13523228513089473909](https://jules.google.com/task/13523228513089473909) started by @FelixHertweck*