### PR TITLE
🛡️ Sentinel: [HIGH] Fix CSV Injection vulnerability

### DIFF
--- a/src/main/java/de/felixhertweck/seatreservation/utils/ReservationExporter.java
+++ b/src/main/java/de/felixhertweck/seatreservation/utils/ReservationExporter.java
@@ -67,12 +67,13 @@ public class ReservationExporter {
         }
         if (index < escaped.length()) {
             char firstNonWs = escaped.charAt(index);
-            if (firstNonWs == '=' || firstNonWs == '+' || firstNonWs == '-' || firstNonWs == '@') {
+            if (firstNonWs == '='
+                    || firstNonWs == '+'
+                    || firstNonWs == '-'
+                    || firstNonWs == '@'
+                    || firstNonWs == '\t') {
                 escaped = "'" + escaped;
             }
-        }
-        if (!escaped.startsWith("'") && escaped.charAt(0) == '\t') {
-            escaped = "'" + escaped;
         }
 
         // Standard CSV escaping if field contains quotes, commas or newlines
@@ -94,7 +95,7 @@ public class ReservationExporter {
      * leading-whitespace check below.
      */
     private static boolean isSpreadsheetTrimmable(char c) {
-        return Character.isWhitespace(c) || Character.isSpaceChar(c);
+        return c != '\t' && (Character.isWhitespace(c) || Character.isSpaceChar(c));
     }
 
     private static final String TEMPLATE_PATH_BLOCKED = "/export-template/blocked.pdf";

--- a/src/test/java/de/felixhertweck/seatreservation/utils/ReservationExporterTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/utils/ReservationExporterTest.java
@@ -188,6 +188,17 @@ class ReservationExporterTest {
     }
 
     @Test
+    void exportReservationsToCsv_fieldWithLeadingTabAfterWhitespace_isEscaped() throws IOException {
+        Reservation reservation =
+                createReservation(
+                        id(1), "A1", "1", " \n\tcmd", "Mustermann", ReservationStatus.RESERVED);
+        byte[] csvBytes =
+                ReservationExporter.exportReservationsToCsv(List.of(reservation)).toByteArray();
+        String csv = new String(csvBytes);
+        assertTrue(csv.contains("' \n\tcmd"), csv);
+    }
+
+    @Test
     void exportReservationsToCsv_fieldWithoutFormulaTrigger_isNotEscaped() throws IOException {
         Reservation reservation =
                 createReservation(


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: CSV Injection vulnerability in `ReservationExporter` where leading tab characters (`\t`) were incorrectly treated as trimmable whitespace, allowing attackers to bypass the formula prefix check by prepending whitespaces before the tab character (e.g. ` \n\tcmd`).
🎯 Impact: An attacker could craft user data containing leading spaces followed by a tab character and a malicious payload. When an admin exports the reservations to CSV and opens it in Excel, the payload could be executed (Formula Injection/DDE), potentially leading to arbitrary command execution on the admin's machine.
🔧 Fix: Excluded the tab character (`\t`) from the `isSpreadsheetTrimmable` check so it is correctly identified as a formula trigger, and updated the `firstNonWs` check to prepend a single quote (`'`) if the first non-whitespace character is a tab. Also removed the redundant index 0 tab check.
✅ Verification: Unit tests in `ReservationExporterTest` were updated and pass, verifying that ` \n\tcmd` is properly escaped as `' \n\tcmd`.

---
*PR created automatically by Jules for task [14194835298960304373](https://jules.google.com/task/14194835298960304373) started by @FelixHertweck*