### PR TITLE
🛡️ Sentinel: [HIGH] Fix CSV injection vulnerability

### DIFF
--- a/src/main/java/de/felixhertweck/seatreservation/utils/ReservationExporter.java
+++ b/src/main/java/de/felixhertweck/seatreservation/utils/ReservationExporter.java
@@ -67,12 +67,13 @@ public class ReservationExporter {
         }
         if (index < escaped.length()) {
             char firstNonWs = escaped.charAt(index);
-            if (firstNonWs == '=' || firstNonWs == '+' || firstNonWs == '-' || firstNonWs == '@') {
+            if (firstNonWs == '='
+                    || firstNonWs == '+'
+                    || firstNonWs == '-'
+                    || firstNonWs == '@'
+                    || firstNonWs == '\t') {
                 escaped = "'" + escaped;
             }
-        }
-        if (!escaped.startsWith("'") && escaped.charAt(0) == '\t') {
-            escaped = "'" + escaped;
         }
 
         // Standard CSV escaping if field contains quotes, commas or newlines
@@ -94,7 +95,7 @@ public class ReservationExporter {
      * leading-whitespace check below.
      */
     private static boolean isSpreadsheetTrimmable(char c) {
-        return Character.isWhitespace(c) || Character.isSpaceChar(c);
+        return c != '\t' && (Character.isWhitespace(c) || Character.isSpaceChar(c));
     }
 
     private static final String TEMPLATE_PATH_BLOCKED = "/export-template/blocked.pdf";

--- a/src/test/java/de/felixhertweck/seatreservation/utils/ReservationExporterTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/utils/ReservationExporterTest.java
@@ -188,6 +188,18 @@ class ReservationExporterTest {
     }
 
     @Test
+    void exportReservationsToCsv_fieldWithLeadingWhitespaceAndTab_isEscapedWithLeadingApostrophe()
+            throws IOException {
+        Reservation reservation =
+                createReservation(
+                        id(1), "A1", "1", " \tcmd", "Mustermann", ReservationStatus.RESERVED);
+        byte[] csvBytes =
+                ReservationExporter.exportReservationsToCsv(List.of(reservation)).toByteArray();
+        String csv = new String(csvBytes);
+        assertTrue(csv.contains("' \tcmd"), csv);
+    }
+
+    @Test
     void exportReservationsToCsv_fieldWithoutFormulaTrigger_isNotEscaped() throws IOException {
         Reservation reservation =
                 createReservation(


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: CSV Injection (Formula Injection) vulnerability in the reservation exporter where fields starting with a tab (`\t`) following whitespace were not properly escaped.
🎯 Impact: Attackers could inject formulas into CSV exports (e.g. ` \t=cmd|...`) which, when opened in spreadsheet applications, could execute arbitrary code.
🔧 Fix: Updated the `isSpreadsheetTrimmable` and `escapeCsvField` methods to accurately identify and escape the tab character even when preceded by non-tab whitespace. Removed redundant check for leading tabs.
✅ Verification: Added unit tests ensuring strings with space followed by tab are escaped, and ran the full test suite (`./mvnw test`).

---
*PR created automatically by Jules for task [5495545014049963786](https://jules.google.com/task/5495545014049963786) started by @FelixHertweck*