### PR TITLE
🛡️ Sentinel: [HIGH] Fix CSV injection vulnerability with tab characters

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-08-22 - CSV Injection via Tab Whitespace Bypass
+**Vulnerability:** A CSV injection vulnerability existed because `Character.isWhitespace('\t')` evaluated to true. This allowed malicious payloads starting with leading spaces followed by a tab (e.g., `  \t=cmd|...`) to bypass the formula trigger check when exporting CSVs.
+**Learning:** `Character.isWhitespace()` and `Character.isSpaceChar()` cover characters like `\t`, which can still trigger formulas when opened in spreadsheet applications, bypassing checks that simply look past standard whitespaces for trigger characters.
+**Prevention:** Explicitly exclude `\t` from whitespace evaluation in CSV parsing logic, and ensure `\t` is checked alongside typical formula triggers (`=`, `+`, `-`, `@`) as a malicious prefix.

--- a/src/main/java/de/felixhertweck/seatreservation/utils/ReservationExporter.java
+++ b/src/main/java/de/felixhertweck/seatreservation/utils/ReservationExporter.java
@@ -67,12 +67,13 @@ public class ReservationExporter {
         }
         if (index < escaped.length()) {
             char firstNonWs = escaped.charAt(index);
-            if (firstNonWs == '=' || firstNonWs == '+' || firstNonWs == '-' || firstNonWs == '@') {
+            if (firstNonWs == '='
+                    || firstNonWs == '+'
+                    || firstNonWs == '-'
+                    || firstNonWs == '@'
+                    || firstNonWs == '\t') {
                 escaped = "'" + escaped;
             }
-        }
-        if (!escaped.startsWith("'") && escaped.charAt(0) == '\t') {
-            escaped = "'" + escaped;
         }
 
         // Standard CSV escaping if field contains quotes, commas or newlines
@@ -94,7 +95,7 @@ public class ReservationExporter {
      * leading-whitespace check below.
      */
     private static boolean isSpreadsheetTrimmable(char c) {
-        return Character.isWhitespace(c) || Character.isSpaceChar(c);
+        return (Character.isWhitespace(c) || Character.isSpaceChar(c)) && c != '\t';
     }
 
     private static final String TEMPLATE_PATH_BLOCKED = "/export-template/blocked.pdf";

--- a/src/test/java/de/felixhertweck/seatreservation/utils/ReservationExporterTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/utils/ReservationExporterTest.java
@@ -188,6 +188,23 @@ class ReservationExporterTest {
     }
 
     @Test
+    void exportReservationsToCsv_fieldWithLeadingSpacesAndTab_isEscapedWithLeadingApostrophe()
+            throws IOException {
+        Reservation reservation =
+                createReservation(
+                        id(1),
+                        "A1",
+                        "1",
+                        "   \t=cmd|'/C calc'!A0",
+                        "Mustermann",
+                        ReservationStatus.RESERVED);
+        byte[] csvBytes =
+                ReservationExporter.exportReservationsToCsv(List.of(reservation)).toByteArray();
+        String csv = new String(csvBytes);
+        assertTrue(csv.contains("'   \t=cmd|'/C calc'!A0"), csv);
+    }
+
+    @Test
     void exportReservationsToCsv_fieldWithoutFormulaTrigger_isNotEscaped() throws IOException {
         Reservation reservation =
                 createReservation(


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: CSV injection (Formula injection) where a malicious payload could bypass the leading whitespace check if it contained leading spaces followed by a tab (`\t`), because `Character.isWhitespace('\t')` evaluates to true, causing the tab to be treated as trimmable whitespace.
🎯 Impact: An attacker could craft a payload (e.g., `  \t=cmd|...`) that bypasses the formula trigger check, leading to arbitrary code execution when an admin exports reservations and opens the CSV in a spreadsheet application.
🔧 Fix: Excluded `\t` from `isSpreadsheetTrimmable` and included it in the trigger character check for the first non-whitespace character.
✅ Verification: Added unit tests ensuring strings with leading spaces followed by a tab are properly escaped with a single quote. Run `./mvnw test -Dtest=ReservationExporterTest` to verify.

---
*PR created automatically by Jules for task [5348059857374464828](https://jules.google.com/task/5348059857374464828) started by @FelixHertweck*