### PR TITLE
🛡️ Sentinel: [HIGH] Fix CSV injection bypass via tab characters

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-08-23 - Fix CSV injection bypass via tab characters
+**Vulnerability:** Tab characters (`\t`) were treated as trimmable whitespace in CSV export fields (`ReservationExporter`), allowing an attacker to inject formulas into exported CSV files by using a tab as the first non-whitespace character, thereby bypassing the CSV injection check.
+**Learning:** `Character.isWhitespace()` returns `true` for tab characters (`\t`). Spreadsheet applications also treat tab characters as formula triggers in CSV files (or ignore them when looking for one). Because `isSpreadsheetTrimmable` used `Character.isWhitespace(c)`, the tab character would be skipped during whitespace trimming, allowing a payload starting with `\t` to bypass the formula injection checks.
+**Prevention:** Explicitly exclude tab characters (`\t`) from the trimmable characters loop in `isSpreadsheetTrimmable` so that they can be evaluated and escaped properly in `escapeCsvField`.

--- a/src/main/java/de/felixhertweck/seatreservation/utils/ReservationExporter.java
+++ b/src/main/java/de/felixhertweck/seatreservation/utils/ReservationExporter.java
@@ -67,12 +67,13 @@ public class ReservationExporter {
         }
         if (index < escaped.length()) {
             char firstNonWs = escaped.charAt(index);
-            if (firstNonWs == '=' || firstNonWs == '+' || firstNonWs == '-' || firstNonWs == '@') {
+            if (firstNonWs == '='
+                    || firstNonWs == '+'
+                    || firstNonWs == '-'
+                    || firstNonWs == '@'
+                    || firstNonWs == '\t') {
                 escaped = "'" + escaped;
             }
-        }
-        if (!escaped.startsWith("'") && escaped.charAt(0) == '\t') {
-            escaped = "'" + escaped;
         }
 
         // Standard CSV escaping if field contains quotes, commas or newlines
@@ -94,7 +95,7 @@ public class ReservationExporter {
      * leading-whitespace check below.
      */
     private static boolean isSpreadsheetTrimmable(char c) {
-        return Character.isWhitespace(c) || Character.isSpaceChar(c);
+        return c != '\t' && (Character.isWhitespace(c) || Character.isSpaceChar(c));
     }
 
     private static final String TEMPLATE_PATH_BLOCKED = "/export-template/blocked.pdf";


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Tab characters (`\t`) were treated as trimmable whitespace, allowing CSV injection payloads using `\t` as a trigger or hidden behind leading spaces to bypass the initial character checks.
🎯 Impact: An attacker could craft user inputs that execute arbitrary formulas in spreadsheet applications when exported and opened by administrators.
🔧 Fix: Excluded `\t` from `isSpreadsheetTrimmable` and explicitly added it as a formula trigger in `escapeCsvField`.
✅ Verification: Run `./mvnw test` to ensure tests pass and the logic correctly sanitizes tab characters in CSV exports.

---
*PR created automatically by Jules for task [30143980888020953](https://jules.google.com/task/30143980888020953) started by @FelixHertweck*