### PR TITLE
feat(security): switch JWT signing to ES256 and unify template overrides

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Generate keys for JWT and encryption tests
         run: |
           mkdir keys
-          openssl genpkey -algorithm RSA -out keys/privateKey.pem -pkeyopt rsa_keygen_bits:2048 && openssl rsa -pubout -in keys/privateKey.pem -out keys/publicKey.pem
+          openssl genpkey -algorithm EC -pkeyopt ec_paramgen_curve:P-256 -out keys/privateKey.pem && openssl ec -pubout -in keys/privateKey.pem -out keys/publicKey.pem
           openssl rand -base64 32 > keys/totp-encryption.key
 
       - name: Set up Maven Cache

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ The fastest way to run the full system (reverse proxy, frontend, backend, databa
 
 ```shell script
 # 1. Generate JWT and encryption keys (once)
-mkdir -p keys && openssl genpkey -algorithm RSA -out keys/privateKey.pem -pkeyopt rsa_keygen_bits:2048 && openssl rsa -pubout -in keys/privateKey.pem -out keys/publicKey.pem
+mkdir -p keys && openssl genpkey -algorithm EC -pkeyopt ec_paramgen_curve:P-256 -out keys/privateKey.pem && openssl ec -pubout -in keys/privateKey.pem -out keys/publicKey.pem
 openssl rand -base64 32 > keys/totp-encryption.key
 
 # 2. Create and edit your environment file
@@ -145,7 +145,7 @@ Execute the following commands to generate the necessary keys for JWT authentica
 encrypting sensitive data at rest (e.g. TOTP 2FA secrets):
 
 ```shell script
-mkdir -p keys && openssl genpkey -algorithm RSA -out keys/privateKey.pem -pkeyopt rsa_keygen_bits:2048 && openssl rsa -pubout -in keys/privateKey.pem -out keys/publicKey.pem
+mkdir -p keys && openssl genpkey -algorithm EC -pkeyopt ec_paramgen_curve:P-256 -out keys/privateKey.pem && openssl ec -pubout -in keys/privateKey.pem -out keys/publicKey.pem
 openssl rand -base64 32 > keys/totp-encryption.key
 ```
 
@@ -283,35 +283,42 @@ The application renders emails from customizable [Qute](https://quarkus.io/guide
 
 Edit these files directly to adjust the look and content of outgoing emails, keeping the existing `{placeholder}` expressions intact. Subject lines and small text snippets are configured under `email.header.*` and related keys in [`application.yaml`](src/main/resources/application.yaml).
 
-#### Overriding Templates in a Deployment
-
-Instead of editing the bundled files (which requires rebuilding the image), you can supply your own templates from an external directory via `email.template.override-dir` (env var `EMAIL_TEMPLATE_OVERRIDE_DIR`). This is picked up on application start and takes precedence over the bundled templates.
-
-To customize a template:
-
-1.   Create a directory, e.g. `./email-templates/email/`.
-2.   Add an `.html` file named after the template you want to replace, e.g. `password-changed.html`. It only needs to contain the templates you actually want to change — anything missing falls back to the bundled version.
-3.   Write it as a normal, self-contained HTML file (Qute `{placeholder}`, `{#if}`, `{#for}` syntax is supported), using the same `{placeholder}` names as the original.
-4.   Point the app at the directory:
-     -   Locally: set `EMAIL_TEMPLATE_OVERRIDE_DIR=/path/to/email-templates` in `.env`.
-     -   Docker Compose: mount the directory into the container and set the env var — see the commented `email-templates` volume and `EMAIL_TEMPLATE_OVERRIDE_DIR` entry in [`docker-compose.yml`](docker-compose.yml).
-5.   Restart the application to pick up the changes.
-
 ### PDF Export Templates
 
 The application supports exporting reservations as PDF documents, utilizing predefined PDF templates with AcroForm fields. There are two distinct templates used based on the reservation status:
 
--   **`/export-template/reserved.pdf`**: Used for reservations with the status `RESERVED`.
+-   **`reserved.pdf`**: Used for reservations with the status `RESERVED`.
     -   **Required Form Fields:**
         -   `reservedUntil`: The date until which the seat is reserved.
         -   `userName`: The full name of the user who made the reservation.
         -   `seatInfo`: Information about the seat (e.g., "A1 (Row 1)").
 
--   **`/export-template/blocked.pdf`**: Used for reservations with the status `BLOCKED`.
+-   **`blocked.pdf`**: Used for reservations with the status `BLOCKED`.
     -   **Required Form Fields:**
         -   `seatInfo`: Information about the seat (e.g., "A1 (Row 1)").
 
-If these template files are not found at the specified paths, the system will generate a standard PDF layout with basic reservation information.
+If these template files are not supplied (see below), the system generates a standard PDF layout with basic reservation information instead.
+
+#### Overriding Templates in a Deployment
+
+Instead of editing the bundled files (which requires rebuilding the image), you can supply your own email and PDF export templates from a single external directory via `template.override-dir` (env var `TEMPLATE_OVERRIDE_DIR`). This is picked up on application start and takes precedence over the bundled templates.
+
+The directory mirrors the bundled layout via two subfolders:
+
+-   `email/` — Qute HTML templates, e.g. `email/password-changed.html`, `email/fragments/card-layout-styles.html`.
+-   `export/` — PDF templates, e.g. `export/reserved.pdf`, `export/blocked.pdf`.
+
+Only place the files you actually want to override — anything missing falls back to the bundled email template or the standard programmatic PDF layout.
+
+To customize a template:
+
+1.   Create a directory, e.g. `./template-overrides/`, with an `email/` and/or `export/` subfolder.
+2.   Add the file(s) you want to replace, named as described above (e.g. `email/password-changed.html`, `export/blocked.pdf`).
+3.   Email templates are normal, self-contained HTML files (Qute `{placeholder}`, `{#if}`, `{#for}` syntax is supported), using the same `{placeholder}` names as the original. PDF templates are regular PDF files with the AcroForm text fields listed above.
+4.   Point the app at the directory:
+     -   Locally: set `TEMPLATE_OVERRIDE_DIR=/path/to/template-overrides` in `.env`.
+     -   Docker Compose: mount the directory into the container and set the env var — see the commented `template-overrides` volume and `TEMPLATE_OVERRIDE_DIR` entry in [`docker-compose.yml`](docker-compose.yml).
+5.   Restart the application to pick up the changes.
 
 ## Backend (Quarkus)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,12 +59,11 @@ services:
     # Override application.yaml
     #  - ./application.yaml:/deployments/config/application.yaml
 
-    # Export templates for PDF generation
-    #  - ./export-template:/export-template:ro
-
-    # Override email templates at runtime (mirror the bundled layout, e.g.
-    # ./email-templates/email/password-changed.html or email/fragments/card-layout-styles.html)
-    #  - ./email-templates:/deployments/email-templates:ro
+    # Override bundled templates at runtime without rebuilding the image (mirror the bundled
+    # layout: email templates under email/, e.g. email/password-changed.html or
+    # email/fragments/card-layout-styles.html; PDF export templates under export/, e.g.
+    # export/reserved.pdf, export/blocked.pdf)
+    #  - ./template-overrides:/deployments/template-overrides:ro
 
     environment:
       # Application configuration
@@ -73,8 +72,8 @@ services:
       # If you use only HTTP, set this to false
       # - SSL_ENABLED=false
 
-      # Point to the volume mounted above to enable email template overrides
-      # - EMAIL_TEMPLATE_OVERRIDE_DIR=/deployments/email-templates
+      # Point to the volume mounted above to enable template overrides (email + PDF export)
+      # - TEMPLATE_OVERRIDE_DIR=/deployments/template-overrides
 
       # Email configuration
       - MAIL_FROM=${MAIL_FROM}

--- a/src/main/java/de/felixhertweck/seatreservation/email/template/ExternalEmailTemplateLocator.java
+++ b/src/main/java/de/felixhertweck/seatreservation/email/template/ExternalEmailTemplateLocator.java
@@ -40,10 +40,13 @@ import org.jboss.logging.Logger;
  * Lets operators override the bundled email templates at runtime without rebuilding the
  * application.
  *
- * <p>When {@code email.template.override-dir} points to a directory, this locator is consulted
- * before the default classpath locator for any {@code email/*} template. If a matching {@code
- * .html} file exists in that directory it is used instead of the version shipped inside the
- * artifact; otherwise the locator returns empty and Qute falls back to the bundled template.
+ * <p>When {@code template.override-dir} points to a directory, this locator is consulted before the
+ * default classpath locator for any {@code email/*} template (the same directory's {@code export/}
+ * subfolder is used for PDF export template overrides, see {@link
+ * de.felixhertweck.seatreservation.utils.ReservationExporter}). If a matching {@code .html} file
+ * exists under the directory's {@code email/} subfolder it is used instead of the version shipped
+ * inside the artifact; otherwise the locator returns empty and Qute falls back to the bundled
+ * template.
  *
  * <p>The override files are still ordinary Qute templates (same {@code {#for}}/{@code {#if}} syntax
  * and HTML escaping) — only their source is read from the filesystem. Because they are not visible
@@ -69,7 +72,7 @@ public class ExternalEmailTemplateLocator implements TemplateLocator {
 
     @Inject
     public ExternalEmailTemplateLocator(
-            @ConfigProperty(name = "email.template.override-dir") Optional<String> overrideDir) {
+            @ConfigProperty(name = "template.override-dir") Optional<String> overrideDir) {
         this(
                 overrideDir
                         .map(String::trim)

--- a/src/main/java/de/felixhertweck/seatreservation/utils/ReservationExporter.java
+++ b/src/main/java/de/felixhertweck/seatreservation/utils/ReservationExporter.java
@@ -48,8 +48,18 @@ import com.lowagie.text.pdf.PdfWriter;
 import de.felixhertweck.seatreservation.model.entity.Reservation;
 import de.felixhertweck.seatreservation.model.entity.ReservationStatus;
 import de.felixhertweck.seatreservation.model.entity.User;
+import org.eclipse.microprofile.config.ConfigProvider;
 
 public class ReservationExporter {
+
+    /**
+     * Same property as {@link
+     * de.felixhertweck.seatreservation.email.template.ExternalEmailTemplateLocator}; this class
+     * uses its {@code export/} subfolder instead of {@code email/}.
+     */
+    private static final String TEMPLATE_OVERRIDE_DIR_PROPERTY = "template.override-dir";
+
+    private static final String EXPORT_OVERRIDE_SUBDIR = "export";
 
     private static final String TEMPLATE_PATH_RESERVED = "/export-template/reserved.pdf";
 
@@ -174,7 +184,8 @@ public class ReservationExporter {
                 } else {
                     for (Reservation reservation : reservations) {
                         if (reservation.getStatus() == ReservationStatus.BLOCKED) {
-                            byte[] templateBytes = loadTemplatePdf(TEMPLATE_PATH_BLOCKED);
+                            byte[] templateBytes =
+                                    loadTemplatePdf(TEMPLATE_PATH_BLOCKED, "blocked.pdf");
                             if (templateBytes != null) {
                                 addPageFromTemplate(
                                         writer, document, reservation, null, templateBytes);
@@ -182,7 +193,8 @@ public class ReservationExporter {
                                 addStandardBlockedPage(writer, document, reservation);
                             }
                         } else { // RESERVED or other statuses
-                            byte[] templateBytes = loadTemplatePdf(TEMPLATE_PATH_RESERVED);
+                            byte[] templateBytes =
+                                    loadTemplatePdf(TEMPLATE_PATH_RESERVED, "reserved.pdf");
                             if (templateBytes != null) {
                                 addPageFromTemplate(
                                         writer,
@@ -204,18 +216,43 @@ public class ReservationExporter {
         }
     }
 
-    private static byte[] loadTemplatePdf(String path) throws IOException {
-        if (path == null || path.trim().isEmpty()) {
-            return null;
+    /**
+     * Resolves a PDF export template, preferring an operator-supplied override over the bundled
+     * classpath version.
+     *
+     * @param classpathPath the bundled template's classpath location (e.g. {@code
+     *     /export-template/reserved.pdf})
+     * @param overrideFileName the file name looked up under {@code <template.override-dir>/export/}
+     *     (e.g. {@code reserved.pdf})
+     * @return the template bytes, or {@code null} if neither source has it
+     */
+    private static byte[] loadTemplatePdf(String classpathPath, String overrideFileName)
+            throws IOException {
+        byte[] overrideBytes = loadOverrideTemplatePdf(overrideFileName);
+        if (overrideBytes != null) {
+            return overrideBytes;
         }
-        InputStream resourceStream = ReservationExporter.class.getResourceAsStream(path);
+        InputStream resourceStream = ReservationExporter.class.getResourceAsStream(classpathPath);
         if (resourceStream != null) {
             try (InputStream is = resourceStream) {
                 return is.readAllBytes();
             }
         }
-        File templateFile = new File(path);
-        if (templateFile.exists() && templateFile.canRead()) {
+        return null;
+    }
+
+    private static byte[] loadOverrideTemplatePdf(String fileName) throws IOException {
+        String overrideDir =
+                ConfigProvider.getConfig()
+                        .getOptionalValue(TEMPLATE_OVERRIDE_DIR_PROPERTY, String.class)
+                        .map(String::trim)
+                        .filter(dir -> !dir.isEmpty())
+                        .orElse(null);
+        if (overrideDir == null) {
+            return null;
+        }
+        File templateFile = new File(new File(overrideDir, EXPORT_OVERRIDE_SUBDIR), fileName);
+        if (templateFile.isFile() && templateFile.canRead()) {
             return Files.readAllBytes(templateFile.toPath());
         }
         return null;

--- a/src/main/resources/application-docker.yaml
+++ b/src/main/resources/application-docker.yaml
@@ -46,10 +46,13 @@ smallrye:
   jwt:
     new-token:
       issuer: ${APP_URL}
+      signature-algorithm: ES256
     sign:
       key:
         location: /deployments/keys/privateKey.pem
 mp:
   jwt:
-    publickey:
-      location: /deployments/keys/publicKey.pem
+    verify:
+      publickey:
+        location: /deployments/keys/publicKey.pem
+        algorithm: ES256

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -33,6 +33,7 @@ smallrye:
     always-check-authorization: true
     new-token:
       issuer: http://localhost:8080
+      signature-algorithm: ES256
     sign:
       key:
         location: keys/privateKey.pem
@@ -44,12 +45,21 @@ mp:
     verify:
         publickey:
             location: keys/publicKey.pem
+            algorithm: ES256
+
+# Optional external directory used to override bundled templates at runtime without rebuilding
+# the image. Mirrors the bundled layout via two subfolders: email templates under
+# <dir>/email/ (e.g. reservation-confirmation.html) and PDF export templates under
+# <dir>/export/ (e.g. reserved.pdf, blocked.pdf). Leave empty to use only the bundled/classpath
+# templates. Picked up on application start.
+template:
+  override-dir: ""
 
 exporter:
     pdf:
         minutesBeforeEventStart: 10
 
-email:  
+email:
   resend-cooldown-seconds: 60
   frontend-base-url: http://localhost:8080
   verification:
@@ -79,12 +89,6 @@ email:
  
   # Template for entrance information text
   entrance-info-template: "Please use entrance {entrance} for seats {seats}"
-
-  # Optional external directory holding email template overrides (leave empty to use the
-  # bundled templates). Files there mirror the bundled layout, e.g.
-  # <dir>/email/reservation-confirmation.html, and are picked up on application start.
-  template:
-    override-dir: ""
 
   header:
     confirmation: "Please Confirm Your Email Address"

--- a/src/test/java/de/felixhertweck/seatreservation/email/template/ExternalTemplateOverrideTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/email/template/ExternalTemplateOverrideTest.java
@@ -57,7 +57,7 @@ class ExternalTemplateOverrideTest {
             Objects.requireNonNull(url, "email-template-overrides test resource not found");
             try {
                 Path dir = Path.of(url.toURI());
-                return Map.of("email.template.override-dir", dir.toString());
+                return Map.of("template.override-dir", dir.toString());
             } catch (URISyntaxException e) {
                 throw new IllegalStateException(e);
             }

--- a/src/test/java/de/felixhertweck/seatreservation/utils/ReservationExporterTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/utils/ReservationExporterTest.java
@@ -21,7 +21,10 @@ package de.felixhertweck.seatreservation.utils;
 
 import static de.felixhertweck.seatreservation.testutil.TestIds.id;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
@@ -31,13 +34,27 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.lowagie.text.Document;
+import com.lowagie.text.Element;
+import com.lowagie.text.Phrase;
+import com.lowagie.text.Rectangle;
+import com.lowagie.text.pdf.ColumnText;
+import com.lowagie.text.pdf.PdfContentByte;
+import com.lowagie.text.pdf.PdfReader;
+import com.lowagie.text.pdf.PdfWriter;
+import com.lowagie.text.pdf.TextField;
+import com.lowagie.text.pdf.parser.PdfTextExtractor;
 import de.felixhertweck.seatreservation.model.entity.Reservation;
 import de.felixhertweck.seatreservation.model.entity.ReservationStatus;
 import de.felixhertweck.seatreservation.model.entity.Seat;
 import de.felixhertweck.seatreservation.model.entity.User;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 class ReservationExporterTest {
+
+    @TempDir Path tempDir;
 
     private Reservation createReservation(
             UUID id,
@@ -229,6 +246,44 @@ class ReservationExporterTest {
         assertNotNull(pdfBytes);
         assertTrue(pdfBytes.length > 100, "PDF should not be empty");
         assertEquals("%PDF-", new String(pdfBytes, 0, 5));
+    }
+
+    @AfterEach
+    void clearOverrideDirProperty() {
+        System.clearProperty("template.override-dir");
+    }
+
+    private byte[] buildOverrideBlockedTemplate() throws Exception {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (Document document = new Document()) {
+            PdfWriter writer = PdfWriter.getInstance(document, baos);
+            document.open();
+            PdfContentByte canvas = writer.getDirectContent();
+            ColumnText.showTextAligned(
+                    canvas, Element.ALIGN_LEFT, new Phrase("OVERRIDE MARKER"), 50, 700, 0);
+            TextField seatInfoField =
+                    new TextField(writer, new Rectangle(50, 600, 250, 620), "seatInfo");
+            writer.addAnnotation(seatInfoField.getTextField());
+        }
+        return baos.toByteArray();
+    }
+
+    @Test
+    void exportReservationsToPdf_withOverrideDirTemplate_usesExternalTemplate() throws Exception {
+        Path exportDir = tempDir.resolve("export");
+        Files.createDirectories(exportDir);
+        Files.write(exportDir.resolve("blocked.pdf"), buildOverrideBlockedTemplate());
+        System.setProperty("template.override-dir", tempDir.toString());
+
+        Reservation reservation =
+                createReservation(id(1), "C1", "3", null, null, ReservationStatus.BLOCKED);
+        byte[] pdfBytes =
+                ReservationExporter.exportReservationsToPdf(List.of(reservation), null)
+                        .toByteArray();
+
+        String text = new PdfTextExtractor(new PdfReader(pdfBytes)).getTextFromPage(1);
+        assertTrue(text.contains("OVERRIDE MARKER"), text);
+        assertTrue(text.contains("C1 (3)"), text);
     }
 
     @Test


### PR DESCRIPTION
Auth JWT signing/verification moves from RSA-2048 to EC P-256 (ES256), and email + PDF export template overrides now share a single template.override-dir config with email/ and export/ subfolders.