### PR TITLE
fix(deps): exclude conflicting xml-apis from batik-transcoder

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -266,6 +266,16 @@
       <groupId>org.apache.xmlgraphics</groupId>
       <artifactId>batik-transcoder</artifactId>
       <version>1.19</version>
+      <exclusions>
+        <!-- Ships a bundled pre-JAXP-1.3 javax.xml.parsers with a hardcoded fallback to the
+             external org.apache.xerces.jaxp.SAXParserFactoryImpl provider, which isn't on the
+             classpath and breaks SAXParserFactory.newInstance() at runtime. The JDK's built-in
+             java.xml module already provides everything Batik needs. -->
+        <exclusion>
+          <groupId>xml-apis</groupId>
+          <artifactId>xml-apis</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.xmlgraphics</groupId>


### PR DESCRIPTION
### Summary

Excludes transitive dependency `xml-apis:xml-apis` from `org.apache.xmlgraphics:batik-transcoder`.

### Problem

When `batik-transcoder` runs on Java 21 / Quarkus runtime (e.g. converting dynamic SVG seatmaps to PNG for reservation confirmation emails), `SAXSVGDocumentFactory` / `SAXDocumentFactory` fails with:

```
java.lang.NoClassDefFoundError: Could not initialize class org.apache.batik.anim.dom.SAXSVGDocumentFactory
Caused by: java.lang.ExceptionInInitializerError: Exception javax.xml.parsers.FactoryConfigurationError: Provider org.apache.xerces.jaxp.SAXParserFactoryImpl not found
```

This occurs because `xml-apis:xml-apis:1.4.01` shades `javax.xml.parsers` and hardcodes a fallback lookup to `org.apache.xerces.jaxp.SAXParserFactoryImpl`, which is not on the classpath.

### Fix

Exclude `xml-apis:xml-apis` so that Batik uses the standard JAXP parser built into the JDK (`java.xml` module).