### PR TITLE
⚡ Bolt: Use HQL aggregations for OverviewService metrics

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-02-28 - N+1 query and memory issues with Streams
+**Learning:** Found multiple places in `OverviewService` where `allReservations.stream().filter(r -> r.getStatus() == ...).count()` is used after loading potentially all reservations. This is an N+1 and O(N) memory anti-pattern. E.g., `reservationRepository.listAll()` reads everything into memory for managers.
+**Action:** Always push counting and grouping queries to the database instead of loading everything into memory and grouping.

--- a/src/main/java/de/felixhertweck/seatreservation/management/service/OverviewService.java
+++ b/src/main/java/de/felixhertweck/seatreservation/management/service/OverviewService.java
@@ -36,7 +36,6 @@ import de.felixhertweck.seatreservation.management.dto.ManagementOverviewStatsDT
 import de.felixhertweck.seatreservation.management.dto.UpcomingEventDTO;
 import de.felixhertweck.seatreservation.model.entity.Event;
 import de.felixhertweck.seatreservation.model.entity.EventUserAllowance;
-import de.felixhertweck.seatreservation.model.entity.Reservation;
 import de.felixhertweck.seatreservation.model.entity.ReservationStatus;
 import de.felixhertweck.seatreservation.model.entity.User;
 import de.felixhertweck.seatreservation.model.repository.EventLocationRepository;
@@ -77,11 +76,6 @@ public class OverviewService {
                         ? eventRepository.listAll()
                         : eventRepository.findByManager(currentUser);
 
-        List<Reservation> allReservations =
-                manager.isAdmin()
-                        ? reservationRepository.listAll()
-                        : reservationRepository.findByManager(currentUser);
-
         List<EventUserAllowance> allAllowances =
                 manager.isAdmin()
                         ? eventUserAllowanceRepository.listAll()
@@ -108,18 +102,13 @@ public class OverviewService {
                                                 && !now.isAfter(e.getBookingDeadline()))
                         .count();
 
-        long reservationsReserved =
-                allReservations.stream()
-                        .filter(r -> r.getStatus() == ReservationStatus.RESERVED)
-                        .count();
-        long reservationsBlocked =
-                allReservations.stream()
-                        .filter(r -> r.getStatus() == ReservationStatus.BLOCKED)
-                        .count();
-        long reservationsPending =
-                allReservations.stream()
-                        .filter(r -> r.getStatus() == ReservationStatus.PENDING)
-                        .count();
+        Map<ReservationStatus, Long> reservationCounts =
+                reservationRepository.getReservationCounts(currentUser, manager.isAdmin());
+
+        long reservationsReserved = reservationCounts.getOrDefault(ReservationStatus.RESERVED, 0L);
+        long reservationsBlocked = reservationCounts.getOrDefault(ReservationStatus.BLOCKED, 0L);
+        long reservationsPending = reservationCounts.getOrDefault(ReservationStatus.PENDING, 0L);
+
         long reservationsCount = reservationsReserved + reservationsBlocked + reservationsPending;
 
         Set<UUID> locationIds =
@@ -137,20 +126,14 @@ public class OverviewService {
                         ? Map.of()
                         : eventLocationRepository.getSeatCountsByLocationIds(locationIds);
 
-        Map<UUID, Long> reservedCountByEventId =
-                allReservations.stream()
-                        .filter(
-                                r ->
-                                        r.getStatus() == ReservationStatus.RESERVED
-                                                && r.getEvent() != null)
-                        .collect(
-                                Collectors.groupingBy(
-                                        r -> r.getEvent().getId(), Collectors.counting()));
+        Map<UUID, Integer> reservedCountByEventId =
+                reservationRepository.getReservedSeatCountsByEventIds(
+                        allEvents.stream().map(Event::getId).toList());
 
         long occupancyReserved = 0;
         long occupancyCapacity = 0;
         for (Event e : futureEvents) {
-            occupancyReserved += reservedCountByEventId.getOrDefault(e.getId(), 0L);
+            occupancyReserved += reservedCountByEventId.getOrDefault(e.getId(), 0);
             if (e.getEventLocation() != null) {
                 occupancyCapacity += seatCounts.getOrDefault(e.getEventLocation().getId(), 0);
             }
@@ -161,16 +144,8 @@ public class OverviewService {
                         : 0;
 
         Map<String, Long> reservedCountByPair =
-                allReservations.stream()
-                        .filter(
-                                r ->
-                                        r.getStatus() == ReservationStatus.RESERVED
-                                                && r.getEvent() != null
-                                                && r.getUser() != null)
-                        .collect(
-                                Collectors.groupingBy(
-                                        r -> r.getEvent().getId() + ":" + r.getUser().getId(),
-                                        Collectors.counting()));
+                reservationRepository.getReservedSeatCountsByEventAndUser(
+                        currentUser, manager.isAdmin());
 
         long contingentUsed = 0;
         long contingentGranted = 0;
@@ -278,14 +253,14 @@ public class OverviewService {
     }
 
     private UpcomingEventDTO toUpcomingEventDto(
-            Event event, Map<UUID, Integer> seatCounts, Map<UUID, Long> reservedCountByEventId) {
+            Event event, Map<UUID, Integer> seatCounts, Map<UUID, Integer> reservedCountByEventId) {
         String locationName =
                 event.getEventLocation() != null ? event.getEventLocation().getName() : null;
         int capacity =
                 event.getEventLocation() != null
                         ? seatCounts.getOrDefault(event.getEventLocation().getId(), 0)
                         : 0;
-        int reservedCount = Math.toIntExact(reservedCountByEventId.getOrDefault(event.getId(), 0L));
+        int reservedCount = reservedCountByEventId.getOrDefault(event.getId(), 0);
         return new UpcomingEventDTO(
                 event.getId(),
                 event.getName(),

--- a/src/main/java/de/felixhertweck/seatreservation/model/repository/ReservationRepository.java
+++ b/src/main/java/de/felixhertweck/seatreservation/model/repository/ReservationRepository.java
@@ -129,6 +129,59 @@ public class ReservationRepository implements PanacheRepositoryBase<Reservation,
     }
 
     /**
+     * Retrieves seat counts by reservation status.
+     *
+     * @param manager user
+     * @param isAdmin isAdmin
+     * @return map of status to count
+     */
+    public Map<ReservationStatus, Long> getReservationCounts(User manager, boolean isAdmin) {
+        String hql;
+        if (isAdmin) {
+            hql = "SELECT r.status, COUNT(r) FROM Reservation r GROUP BY r.status";
+        } else {
+            hql =
+                    "SELECT r.status, COUNT(r) FROM Reservation r JOIN r.event e JOIN e.managers m"
+                            + " WHERE m = ?1 GROUP BY r.status";
+        }
+        var query = getEntityManager().createQuery(hql, Object[].class);
+        if (!isAdmin) {
+            query.setParameter(1, manager);
+        }
+        List<Object[]> results = query.getResultList();
+        return results.stream()
+                .collect(Collectors.toMap(row -> (ReservationStatus) row[0], row -> (Long) row[1]));
+    }
+
+    /**
+     * Retrieves seat counts by event and user.
+     *
+     * @param manager user
+     * @param isAdmin isAdmin
+     * @return map of string to count
+     */
+    public Map<String, Long> getReservedSeatCountsByEventAndUser(User manager, boolean isAdmin) {
+        String hql;
+        if (isAdmin) {
+            hql =
+                    "SELECT r.event.id, r.user.id, COUNT(r) FROM Reservation r WHERE r.status ="
+                            + " 'RESERVED' AND r.event IS NOT NULL AND r.user IS NOT NULL GROUP BY"
+                            + " r.event.id, r.user.id";
+        } else {
+            hql =
+                    "SELECT r.event.id, r.user.id, COUNT(r) FROM Reservation r JOIN r.event e JOIN"
+                        + " e.managers m WHERE m = ?1 AND r.status = 'RESERVED' AND r.user IS NOT"
+                        + " NULL GROUP BY r.event.id, r.user.id";
+        }
+        var query = getEntityManager().createQuery(hql, Object[].class);
+        if (!isAdmin) {
+            query.setParameter(1, manager);
+        }
+        return query.getResultList().stream()
+                .collect(Collectors.toMap(row -> row[0] + ":" + row[1], row -> (Long) row[2]));
+    }
+
+    /**
      * Finds all reservations for a given user that are not blocked.
      *
      * @param user the user to search for

--- a/src/test/java/de/felixhertweck/seatreservation/management/service/OverviewServiceTest.java
+++ b/src/test/java/de/felixhertweck/seatreservation/management/service/OverviewServiceTest.java
@@ -200,8 +200,13 @@ public class OverviewServiceTest {
     void getOverview_AsManager_Success() {
         when(eventRepository.findByManager(managerUser))
                 .thenReturn(List.of(upcomingEvent, pastEvent));
-        when(reservationRepository.findByManager(managerUser))
-                .thenReturn(List.of(reservation, blockedReservation));
+        when(reservationRepository.getReservationCounts(managerUser, false))
+                .thenReturn(Map.of(ReservationStatus.RESERVED, 1L, ReservationStatus.BLOCKED, 1L));
+        when(reservationRepository.getReservedSeatCountsByEventIds(
+                        org.mockito.ArgumentMatchers.any()))
+                .thenReturn(Map.of(upcomingEvent.id, 1, pastEvent.id, 0));
+        when(reservationRepository.getReservedSeatCountsByEventAndUser(managerUser, false))
+                .thenReturn(Map.of(upcomingEvent.id + ":" + regularUser.id, 1L));
         when(eventUserAllowanceRepository.findByEventManager(managerUser))
                 .thenReturn(List.of(allowance));
         when(eventLocationRepository.getSeatCountsByLocationIds(Set.of(location.id)))
@@ -219,6 +224,7 @@ public class OverviewServiceTest {
         assertEquals(0, overview.stats().reservationsPending());
         assertEquals(10, overview.stats().occupancyPercent());
         assertEquals(1, overview.stats().occupancyReserved());
+        assertEquals(4, overview.contingentEvents().getFirst().total());
         assertEquals(10, overview.stats().occupancyCapacity());
         assertEquals(
                 25,
@@ -241,7 +247,13 @@ public class OverviewServiceTest {
     @Test
     void getOverview_AsAdmin_Success() {
         when(eventRepository.listAll()).thenReturn(List.of(upcomingEvent));
-        when(reservationRepository.listAll()).thenReturn(List.of(reservation));
+        when(reservationRepository.getReservationCounts(adminUser, true))
+                .thenReturn(Map.of(ReservationStatus.RESERVED, 1L));
+        when(reservationRepository.getReservedSeatCountsByEventIds(
+                        org.mockito.ArgumentMatchers.any()))
+                .thenReturn(Map.of(upcomingEvent.id, 1));
+        when(reservationRepository.getReservedSeatCountsByEventAndUser(adminUser, true))
+                .thenReturn(Map.of(upcomingEvent.getId() + ":" + regularUser.getId(), 1L));
         when(eventUserAllowanceRepository.listAll()).thenReturn(List.of(allowance));
         when(eventLocationRepository.getSeatCountsByLocationIds(Set.of(location.id)))
                 .thenReturn(Map.of(location.id, 10));


### PR DESCRIPTION
💡 What: Replaced in-memory streaming and filtering of all reservations with targeted HQL aggregation queries in `OverviewService.java`.
🎯 Why: The previous implementation loaded all reservations into memory (e.g. `reservationRepository.listAll()`) just to count them by status, event ID, and user ID. This caused an O(N) memory overhead and N+1 query patterns that could crash the application as the database grew.
📊 Impact: Eliminates massive in-memory collections, substantially reducing memory consumption and CPU usage when generating the manager overview dashboard. 
🔬 Measurement: Check the manager dashboard loading time and memory allocation under heavy load. Verify that the correct seat count statistics are displayed.

---
*PR created automatically by Jules for task [14704664565197983758](https://jules.google.com/task/14704664565197983758) started by @FelixHertweck*